### PR TITLE
Sidebar restructure + Learnings + local-only cloud fixes

### DIFF
--- a/apps/app/public/eigenweltlabs-logo.svg
+++ b/apps/app/public/eigenweltlabs-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect x="14" y="14" width="32" height="32" fill="#2352DE"/>
+  <rect x="50" y="50" width="32" height="32" fill="#8669B9"/>
+  <rect x="50" y="14" width="32" height="32" fill="#FEFEFE"/>
+</svg>

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1653,7 +1653,14 @@ async function requestJsonRaw<T>(
   options: DenRequestOptions = {},
 ): Promise<RawJsonResponse<T>> {
   const baseUrls = typeof input === "string" ? resolveDenBaseUrls(input) : input;
-  const url = `${resolveRequestBaseUrl(baseUrls, path)}${path}`;
+  const requestBase = resolveRequestBaseUrl(baseUrls, path);
+  // Cloud is optional. When disabled (no Den base URL configured) a relative
+  // `/v1/...` path would build an invalid URL and throw a raw TypeError in the
+  // main process. Fail with a clean, catchable error instead.
+  if (!CLOUD_ENABLED || !/^https?:\/\//i.test(requestBase)) {
+    throw new DenApiError(0, "cloud_disabled", "LegalWork Cloud is not available in this build.");
+  }
+  const url = `${requestBase}${path}`;
   const headers: Record<string, string> = { Accept: "application/json" };
   const token = options.token?.trim() ?? "";
   if (token) {

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -417,7 +417,7 @@ const UserMessage = React.memo(
                 {message.parts.some((part) => part.type === "text" && part.text) ? (
                   <MessageContent
                     layoutId={message.id}
-                    className="border border-[rgba(35,82,222,0.22)] bg-[rgba(35,82,222,0.10)] text-foreground max-w-[85%] rounded-3xl rounded-br-lg px-5 py-2.5 whitespace-pre-wrap shadow-[0_6px_18px_-8px_rgba(35,82,222,0.35),inset_0_1px_0_rgba(255,255,255,0.25)] backdrop-blur-sm sm:max-w-[75%]"
+                    className="bg-foreground/[0.06] text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
                   >
                     {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
                   </MessageContent>

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import {
+  CLOUD_ENABLED,
   clearDenSession,
   createDenClient,
   DenApiError,
@@ -64,6 +65,13 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
 
   const refresh = useCallback(async () => {
     const currentRun = ++refreshTokenRef.current;
+    // Local-only build: no Den backend, so skip all /v1/* auth calls.
+    if (!CLOUD_ENABLED) {
+      setUser(null);
+      setError(null);
+      setStatus("signed_out");
+      return;
+    }
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -181,6 +181,8 @@ export type SessionPageProps = {
   onAccessibleTargetsChange?: (targets: OpenTarget[]) => void;
   /** Settings content rendered inside the right pane when the settings rail icon is active. */
   settingsSlot?: React.ReactNode;
+  /** When set, replaces the session main pane (keeps the sidebar). Used for the Learnings screen. */
+  mainView?: React.ReactNode;
   terminalOpen?: boolean;
   onTerminalOpenChange?: (open: boolean) => void;
   onSessionTabsChange?: (tabs: OpenSessionTab[]) => void;
@@ -855,9 +857,13 @@ export function SessionPage(props: SessionPageProps) {
           onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+          onShowLearnings={props.sidebar.onShowLearnings}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />
+        {props.mainView ? (
+          <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80">{props.mainView}</SidebarInset>
+        ) : (
         <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
           <div className="flex min-h-0 flex-1">
           <ResizablePanelGroup
@@ -1342,6 +1348,7 @@ export function SessionPage(props: SessionPageProps) {
           </aside>
           </div>
         </SidebarInset>
+        )}
         {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
       </SidebarProvider>
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -94,6 +94,7 @@ export type SessionPageHistoryControls = {
 };
 
 export type SessionPageSidebarProps = {
+  onShowLearnings?: () => void;
   workspaceSessionGroups: WorkspaceSessionGroup[];
   selectedWorkspaceId: string;
   selectedSessionId: string | null;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -106,6 +106,7 @@ import {
 import { cn } from "@/lib/utils";
 import { WorkspaceIcon } from "../../../design-system/workspace-icon";
 import { getSessionActivityStatusLabel, type SessionActivityStatus } from "../status/session-activity-store";
+import { DEFAULT_SHELL_CONFIG, useShellConfig } from "../../../shell/shell-config";
 
 interface SessionStatusIndicatorProps {
   className?: string;
@@ -606,6 +607,7 @@ function isSessionActivityStatus(status: string | undefined): status is SessionA
 }
 
 export function AppSidebar(props: AppSidebarProps) {
+  const { config: shellConfig } = useShellConfig();
   const navigate = useNavigate();
   const goSettings = React.useCallback(
     (tab: string) => {
@@ -706,6 +708,15 @@ export function AppSidebar(props: AppSidebarProps) {
     props.workspaceSessionGroups,
   ]);
 
+  const customSidebarBrandName = shellConfig.sidebarBrandName.trim();
+  const customSidebarBrandLogo = shellConfig.sidebarBrandLogoDataUrl.trim();
+  const sidebarBrandLogoSrc = customSidebarBrandLogo || "/eigenweltlabs-logo.svg";
+  const showSidebarBrandName = customSidebarBrandName.length > 0 || !customSidebarBrandLogo;
+  const sidebarBrandName = showSidebarBrandName
+    ? (customSidebarBrandName || DEFAULT_SHELL_CONFIG.sidebarBrandName)
+    : "";
+  const sidebarBrandAlt = sidebarBrandName || DEFAULT_SHELL_CONFIG.sidebarBrandName;
+
   const contextValue: SidebarContextValue = {
     selectedWorkspaceId: props.selectedWorkspaceId,
     selectedSessionId: props.selectedSessionId,
@@ -743,10 +754,29 @@ export function AppSidebar(props: AppSidebarProps) {
         collapsible="offcanvas"
         className="mac:**:data-[sidebar=sidebar]:bg-transparent"
       >
-        <div className="hidden h-14 mac:block mac:titlebar-drag"/>
+        <div className="hidden h-12 mac:block mac:titlebar-drag"/>
         {/* Top nav — fixed top 40% */}
         <div className="flex flex-[2] min-h-0 flex-col">
-        <SidebarMenu className="gap-0.5 px-2 pt-1 mac:titlebar-no-drag">
+        <div className="px-2 pb-1 mac:titlebar-no-drag">
+          <div className={cn("flex gap-2 px-3", showSidebarBrandName ? "items-center py-1" : "items-center py-0") }>
+            <img
+              src={sidebarBrandLogoSrc}
+              alt={`${sidebarBrandAlt} logo`}
+              className={cn(
+                "shrink-0 object-contain",
+                showSidebarBrandName
+                  ? "h-8 w-8 rounded-md"
+                  : "h-16 w-[13rem] max-w-[13rem] rounded-sm object-left object-cover",
+              )}
+            />
+            {showSidebarBrandName ? (
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium leading-tight">{sidebarBrandName}</div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <SidebarMenu className={cn("gap-0.5 px-2 mac:titlebar-no-drag", showSidebarBrandName ? "pt-1" : "pt-0")}>
           <SidebarMenuItem>
             <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
               <SquarePen className="size-4" />

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -6,7 +6,11 @@ import {
   ArchiveRestore,
   ChevronRight,
   FolderPlus,
+  GraduationCap,
   Loader2,
+  Puzzle,
+  Sparkles,
+  SquarePen,
   MoreHorizontal,
   Pencil,
   Pin,
@@ -21,6 +25,7 @@ import {
   Tag,
 } from "lucide-react";
 import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
+import { useNavigate } from "react-router-dom";
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -581,6 +586,7 @@ export type AppSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  onShowLearnings?: () => void;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
@@ -600,6 +606,14 @@ function isSessionActivityStatus(status: string | undefined): status is SessionA
 }
 
 export function AppSidebar(props: AppSidebarProps) {
+  const navigate = useNavigate();
+  const goSettings = React.useCallback(
+    (tab: string) => {
+      const ws = props.selectedWorkspaceId.trim();
+      navigate(ws ? `/workspace/${encodeURIComponent(ws)}/settings/${tab}` : `/settings/${tab}`);
+    },
+    [navigate, props.selectedWorkspaceId],
+  );
   const [expandedWorkspaceIds, setExpandedWorkspaceIds] = React.useState<Set<string>>(
     () => new Set(),
   );
@@ -730,48 +744,79 @@ export function AppSidebar(props: AppSidebarProps) {
         className="mac:**:data-[sidebar=sidebar]:bg-transparent"
       >
         <div className="hidden h-14 mac:block mac:titlebar-drag"/>
-        <div className="flex items-baseline gap-2 px-3.5 pt-2.5 pb-1 mac:titlebar-no-drag">
-          <span className="lw-section-eyebrow">Workspaces</span>
-          <span className="text-[10.5px] font-medium tracking-tight text-muted-foreground/70">local folders</span>
+        {/* Top nav — fixed top 40% */}
+        <div className="flex flex-[2] min-h-0 flex-col">
+        <SidebarMenu className="gap-0.5 px-2 pt-1 mac:titlebar-no-drag">
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
+              <SquarePen className="size-4" />
+              <span>New Task</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={() => props.onShowLearnings?.()}>
+              <GraduationCap className="size-4" />
+              <span>Learnings</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={() => goSettings("skills")}>
+              <Sparkles className="size-4" />
+              <span>Skills</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={() => goSettings("extensions/mcp")}>
+              <Puzzle className="size-4" />
+              <span>Integrations</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
         </div>
-        <LazyMotion features={domMax}>
-          <m.div
-            layoutScroll
-            data-slot="sidebar-content"
-            data-sidebar="content"
-            className="no-scrollbar flex min-h-0 flex-1 flex-col gap-px overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
-          >
-            <Reorder.Group
-              as="div"
-              axis="y"
-              values={props.workspaceSessionGroups.map((group) => group.workspace.id)}
-              onReorder={(workspaceIds) => props.onReorderWorkspaces?.(workspaceIds)}
-              className="flex flex-col gap-px"
-            >
-              {props.workspaceSessionGroups.map((group, index) => (
-                <WorkspaceReorderItem
-                  key={group.workspace.id}
-                  group={group}
-                  className={cn(index === 0 && "mac:pt-0")}
-                  showInitialLoading={props.showInitialLoading}
-                  previewCount={previewCount(group.workspace.id)}
-                  showMoreSessions={showMoreSessions}
-                />
-              ))}
-            </Reorder.Group>
-          </m.div>
-        </LazyMotion>
 
-        <SidebarFooter>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
-                <Plus className="size-4" />
-                {t("workspace_list.add_workspace")}
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarFooter>
+        {/* Folders — fixed bottom 60% (top edge at 40% from top). */}
+        <div className="flex flex-[3] min-h-0 flex-col border-t border-[color:var(--glass-border)] pt-1">
+          <div className="flex items-baseline gap-2 px-3.5 pt-2 pb-1 mac:titlebar-no-drag">
+            <span className="lw-section-eyebrow">Folders</span>
+          </div>
+          <LazyMotion features={domMax}>
+            <m.div
+              layoutScroll
+              data-slot="sidebar-content"
+              data-sidebar="content"
+              className="no-scrollbar flex min-h-0 flex-1 flex-col gap-px overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
+            >
+              <Reorder.Group
+                as="div"
+                axis="y"
+                values={props.workspaceSessionGroups.map((group) => group.workspace.id)}
+                onReorder={(workspaceIds) => props.onReorderWorkspaces?.(workspaceIds)}
+                className="flex flex-col gap-px"
+              >
+                {props.workspaceSessionGroups.map((group, index) => (
+                  <WorkspaceReorderItem
+                    key={group.workspace.id}
+                    group={group}
+                    className={cn(index === 0 && "mac:pt-0")}
+                    showInitialLoading={props.showInitialLoading}
+                    previewCount={previewCount(group.workspace.id)}
+                    showMoreSessions={showMoreSessions}
+                  />
+                ))}
+              </Reorder.Group>
+            </m.div>
+          </LazyMotion>
+          <SidebarFooter>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
+                  <FolderPlus className="size-4" />
+                  Add folder
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarFooter>
+        </div>
         <SidebarRail
           aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           title={props.onStartResize ? t("session.resize_workspace_column") : undefined}

--- a/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource react */
+import { useId, useRef, useState, type ChangeEvent } from "react";
 import { AlertTriangle, Info, Lock, RotateCcw } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,23 @@ import {
 } from "../settings-layout";
 import { useShellConfig, DEFAULT_SHELL_CONFIG, type ShellConfig } from "../../../shell/shell-config";
 import { useUiStateStore } from "../../../shell/ui-state-store";
+
+const SIDEBAR_BRAND_LOGO_MAX_BYTES = 512 * 1024;
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("Could not read file."));
+    reader.onload = () => {
+      if (typeof reader.result !== "string" || !reader.result.trim()) {
+        reject(new Error("Could not read file."));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
 
 /* ------------------------------------------------------------------ */
 /*  Interactive wireframe preview                                      */
@@ -223,6 +241,9 @@ export function ShellCustomizationView() {
   const { config, update, reset } = useShellConfig();
   const applicationMenuVisible = useUiStateStore((state) => state.applicationMenuVisible);
   const setApplicationMenuVisible = useUiStateStore((state) => state.setApplicationMenuVisible);
+  const [brandLogoError, setBrandLogoError] = useState<string | null>(null);
+  const logoInputId = useId();
+  const logoInputRef = useRef<HTMLInputElement | null>(null);
 
   const isDefault = (Object.keys(DEFAULT_SHELL_CONFIG) as (keyof ShellConfig)[]).every(
     (key) => config[key] === DEFAULT_SHELL_CONFIG[key],
@@ -230,8 +251,42 @@ export function ShellCustomizationView() {
 
   const resetAll = () => {
     reset();
+    setBrandLogoError(null);
     setApplicationMenuVisible(false);
   };
+
+  const handleSidebarBrandLogoChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0] ?? null;
+    event.currentTarget.value = "";
+    if (!file) return;
+    const mime = file.type.trim().toLowerCase();
+    if (!mime.startsWith("image/")) {
+      setBrandLogoError("Please choose an image file.");
+      return;
+    }
+    if (file.size > SIDEBAR_BRAND_LOGO_MAX_BYTES) {
+      setBrandLogoError("Logo is too large. Please use an image up to 512 KB.");
+      return;
+    }
+    setBrandLogoError(null);
+    void (async () => {
+      try {
+        const dataUrl = await readFileAsDataUrl(file);
+        update({ sidebarBrandLogoDataUrl: dataUrl });
+      } catch (error) {
+        setBrandLogoError(error instanceof Error ? error.message : "Could not load logo.");
+      }
+    })();
+  };
+
+  const customSidebarBrandName = config.sidebarBrandName.trim();
+  const customSidebarBrandLogo = config.sidebarBrandLogoDataUrl.trim();
+  const sidebarBrandLogoSrc = customSidebarBrandLogo || "/eigenweltlabs-logo.svg";
+  const showSidebarBrandName = customSidebarBrandName.length > 0 || !customSidebarBrandLogo;
+  const sidebarBrandName = showSidebarBrandName
+    ? (customSidebarBrandName || DEFAULT_SHELL_CONFIG.sidebarBrandName)
+    : "";
+  const sidebarBrandAlt = sidebarBrandName || DEFAULT_SHELL_CONFIG.sidebarBrandName;
 
   return (
     <LayoutStack>
@@ -246,30 +301,96 @@ export function ShellCustomizationView() {
 
         <LayoutSectionItem>
           <LayoutSectionItemHeader>
-            <LayoutSectionItemTitle>Change application name</LayoutSectionItemTitle>
+            <LayoutSectionItemTitle>Sidebar name</LayoutSectionItemTitle>
             <LayoutSectionItemDescription>
-              Appears in the title bar, sidebar, and welcome screen.
+              Shown above New task in the left sidebar. Leave blank to show logo only.
             </LayoutSectionItemDescription>
             <LayoutSectionItemHeaderActions>
               <Field className="w-64 max-w-full gap-0">
-               <FieldLabel className="sr-only" htmlFor="shell-app-name">
-                  App name
+                <FieldLabel className="sr-only" htmlFor="shell-sidebar-brand-name">
+                  Sidebar brand name
                 </FieldLabel>
                 <Input
-                  id="shell-app-name"
+                  id="shell-sidebar-brand-name"
                   className="h-8 text-xs"
-                  value={config.appName}
-                  placeholder="LegalWork"
-                  disabled
-                  onChange={(event) => update({ appName: event.currentTarget.value || DEFAULT_SHELL_CONFIG.appName })}
+                  value={config.sidebarBrandName}
+                  placeholder={DEFAULT_SHELL_CONFIG.sidebarBrandName}
+                  onChange={(event) => update({ sidebarBrandName: event.currentTarget.value })}
                 />
               </Field>
             </LayoutSectionItemHeaderActions>
           </LayoutSectionItemHeader>
-          <Alert>
-            <Info />
-            <AlertDescription>Changing the application name is not available yet.</AlertDescription>
-          </Alert>
+        </LayoutSectionItem>
+
+        <LayoutSectionItem>
+          <LayoutSectionItemHeader>
+            <LayoutSectionItemTitle>Sidebar logo</LayoutSectionItemTitle>
+            <LayoutSectionItemDescription>
+              Upload an image to show above New task. If no logo is set, the default logo is used.
+            </LayoutSectionItemDescription>
+            <LayoutSectionItemHeaderActions>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => logoInputRef.current?.click()}
+                >
+                  <span>Upload logo</span>
+                </Button>
+                {config.sidebarBrandLogoDataUrl.trim() ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      update({ sidebarBrandLogoDataUrl: "" });
+                      setBrandLogoError(null);
+                    }}
+                  >
+                    Use default
+                  </Button>
+                ) : null}
+                <input
+                  ref={logoInputRef}
+                  id={logoInputId}
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={handleSidebarBrandLogoChange}
+                />
+              </div>
+            </LayoutSectionItemHeaderActions>
+          </LayoutSectionItemHeader>
+          <div className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-hover/40 p-3">
+            <img
+              src={sidebarBrandLogoSrc}
+              alt={`${sidebarBrandAlt} logo`}
+              className={cn(
+                "shrink-0 border border-dls-border object-contain p-1",
+                showSidebarBrandName
+                  ? "h-10 w-10 rounded-lg"
+                  : "h-16 w-[13rem] max-w-[13rem] rounded-md object-left object-cover",
+              )}
+            />
+            {showSidebarBrandName ? (
+              <div className="min-w-0">
+                <div className="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">Preview</div>
+                <div className="truncate text-sm font-medium text-foreground">{sidebarBrandName}</div>
+              </div>
+            ) : (
+              <div className="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">Logo only</div>
+            )}
+          </div>
+          {brandLogoError ? (
+            <Alert variant="warning">
+              <AlertTriangle />
+              <AlertDescription>{brandLogoError}</AlertDescription>
+            </Alert>
+          ) : (
+            <Alert>
+              <Info />
+              <AlertDescription>Use a square PNG/SVG for best results. Max size: 512 KB.</AlertDescription>
+            </Alert>
+          )}
         </LayoutSectionItem>
       </LayoutSection>
 

--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal-state.ts
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal-state.ts
@@ -21,7 +21,8 @@ type CreateWorkspaceLocalAction<K extends keyof CreateWorkspaceLocalState = keyo
 
 export function createInitialWorkspaceLocalState(): CreateWorkspaceLocalState {
   return {
-    screen: "chooser",
+    // Local-only build: open straight to the local folder picker (no local/remote chooser).
+    screen: "local",
     selectedFolder: null,
     pickingFolder: false,
     showProgressDetails: false,

--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
@@ -184,7 +184,8 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
         className="flex max-h-[90vh] min-h-0 w-full max-w-xl flex-col overflow-hidden sm:max-w-xl"
       >
         <DialogHeader className="flex-row">
-          {screen !== "chooser" ? (
+          {/* Local-only: the chooser/remote screens are no longer reachable, so no back button. */}
+          {screen === "remote" ? (
             <Button
               onClick={() => setScreen("chooser")}
               disabled={submitting || remoteSubmitting}

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -170,6 +170,22 @@ export function AppRoot() {
                 }
               />
               <Route
+                path="/learnings"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
+                path="/workspace/:workspaceId/learnings"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
                 path="/session"
                 element={
                   <DevProfiler id="SessionRoute">

--- a/apps/app/src/react-app/shell/learnings-route.tsx
+++ b/apps/app/src/react-app/shell/learnings-route.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource react */
+
+/**
+ * Learnings main pane. Rendered inside the session shell's `SidebarInset`
+ * (via SessionPage's `mainView`), so the main app sidebar stays in place.
+ * Intentionally empty for now — just the title centered.
+ */
+export function LearningsPane() {
+  return (
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-[12%] -top-[20%] h-[60%] w-[60%] rounded-full bg-[radial-gradient(ellipse,rgba(35,82,222,0.07),transparent_70%)] blur-3xl" />
+        <div className="absolute -bottom-[18%] -right-[8%] h-[50%] w-[50%] rounded-full bg-[radial-gradient(ellipse,rgba(134,105,185,0.06),transparent_70%)] blur-3xl" />
+      </div>
+      <div className="relative z-10 flex flex-col items-center gap-2 text-center">
+        <span className="lw-section-eyebrow">Learnings</span>
+        <h1 className="text-4xl font-medium tracking-[-0.04em] text-foreground">Learnings</h1>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -6,7 +6,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { LearningsPane } from "./learnings-route";
 import { toast } from "@/components/ui/sonner";
 import type {
   AgentPartInput,
@@ -306,6 +307,7 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
 export function SessionRoute() {
   const navigate = useNavigate();
+  const [showLearnings, setShowLearnings] = useState(false);
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
@@ -1588,6 +1590,11 @@ export function SessionRoute() {
     }
   }, [client, local, refreshRouteState]);
 
+  // Leaving Learnings: any session/workspace navigation drops back to the session view.
+  useEffect(() => {
+    setShowLearnings(false);
+  }, [selectedSessionId, selectedWorkspaceId]);
+
   return (
     <WorkspaceProvider
       client={opencodeClient}
@@ -1672,6 +1679,7 @@ export function SessionRoute() {
         onRefreshProviders: sessionProviderAuthStore.refreshProviders,
         onClose: () => sessionProviderAuthStore.closeProviderAuthModal(),
       } : null}
+      mainView={showLearnings ? <LearningsPane /> : undefined}
       settingsSlot={
         <SettingsSurface
           embedded
@@ -1692,6 +1700,7 @@ export function SessionRoute() {
         sessionTabNavRef.current = { ...sessionTabNavRef.current, options: tabs };
       }}
       sidebar={{
+        onShowLearnings: () => setShowLearnings(true),
         workspaceSessionGroups,
         selectedWorkspaceId,
         selectedSessionId,

--- a/apps/app/src/react-app/shell/shell-config.tsx
+++ b/apps/app/src/react-app/shell/shell-config.tsx
@@ -8,6 +8,10 @@ import { createContext, useCallback, use, useMemo, useState, type ReactNode } fr
 export type ShellConfig = {
   /** Display name shown in the title bar, sidebar, and welcome page. */
   appName: string;
+  /** Brand name shown at the top of the left sidebar. */
+  sidebarBrandName: string;
+  /** Optional user-uploaded brand logo (data URL) for the left sidebar. */
+  sidebarBrandLogoDataUrl: string;
   /** Show the bottom status bar (connection status, docs, feedback). */
   statusBar: boolean;
   /** Show the left sidebar with workspace/session list. */
@@ -34,6 +38,8 @@ export type ShellConfig = {
 
 export const DEFAULT_SHELL_CONFIG: ShellConfig = {
   appName: "LegalWork",
+  sidebarBrandName: "LegalWork",
+  sidebarBrandLogoDataUrl: "",
   statusBar: true,
   sidebar: true,
   cloudSignin: true,
@@ -57,7 +63,12 @@ function readShellConfig(): ShellConfig {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_SHELL_CONFIG;
     const parsed = JSON.parse(raw);
-    return { ...DEFAULT_SHELL_CONFIG, ...parsed };
+    const next = { ...DEFAULT_SHELL_CONFIG, ...parsed };
+    return {
+      ...next,
+      sidebarBrandName: String(next.sidebarBrandName ?? DEFAULT_SHELL_CONFIG.sidebarBrandName).trim() || DEFAULT_SHELL_CONFIG.sidebarBrandName,
+      sidebarBrandLogoDataUrl: String(next.sidebarBrandLogoDataUrl ?? "").trim(),
+    };
   } catch {
     return DEFAULT_SHELL_CONFIG;
   }

--- a/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { OpenWorkAnthropicAdaptiveThinking } from "./openwork-anthropic-adaptive-thinking.js";
+import { LegalWorkAnthropicAdaptiveThinking } from "./openwork-anthropic-adaptive-thinking.js";
 
 async function runHook(apiId: string, options: Record<string, unknown>) {
-  const hooks = await OpenWorkAnthropicAdaptiveThinking();
+  const hooks = await LegalWorkAnthropicAdaptiveThinking();
   const output: { options: Record<string, unknown> } = { options };
   await hooks["chat.params"]({ model: { id: apiId, api: { id: apiId } } }, output);
   return output.options;
 }
 
-describe("OpenWorkAnthropicAdaptiveThinking chat.params", () => {
+describe("LegalWorkAnthropicAdaptiveThinking chat.params", () => {
   test("rewrites legacy enabled thinking to adaptive for Claude 5-family ids", async () => {
     expect(await runHook("claude-fable-5", { thinking: { type: "enabled", budgetTokens: 16000 } })).toEqual({
       thinking: { type: "adaptive" },
@@ -50,6 +50,6 @@ describe("OpenWorkAnthropicAdaptiveThinking chat.params", () => {
 
   test("module exposes only the plugin factory", async () => {
     const mod = await import("./openwork-anthropic-adaptive-thinking.js");
-    expect(Object.keys(mod)).toEqual(["OpenWorkAnthropicAdaptiveThinking"]);
+    expect(Object.keys(mod)).toEqual(["LegalWorkAnthropicAdaptiveThinking"]);
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts
@@ -1,5 +1,5 @@
 /**
- * OpenWork Anthropic Adaptive Thinking Plugin
+ * LegalWork Anthropic Adaptive Thinking Plugin
  *
  * Newer Anthropic models (Claude 5 family, e.g. "claude-fable-5") reject the
  * legacy extended-thinking payload `thinking: { type: "enabled", budgetTokens }`
@@ -49,7 +49,7 @@ function rewriteLegacyThinkingOptions(apiId: string, options: Record<string, unk
 
 // Single export: the OpenCode plugin loader treats every export of a plugin
 // module as a plugin factory, so helpers must stay module-private.
-export const OpenWorkAnthropicAdaptiveThinking = async () => ({
+export const LegalWorkAnthropicAdaptiveThinking = async () => ({
   "chat.params": async (
     input: { model: { id: string; api?: { id?: string } } },
     output: { options: Record<string, unknown> },

--- a/apps/server/src/opencode-plugins/openwork-anthropic-tool-schema.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-tool-schema.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { OpenWorkAnthropicToolSchema } from "./openwork-anthropic-tool-schema.js";
+import { LegalWorkAnthropicToolSchema } from "./openwork-anthropic-tool-schema.js";
 
 const calls: { input: Parameters<typeof fetch>[0]; init?: RequestInit }[] = [];
 const fakeBase = Object.assign(
@@ -15,7 +15,7 @@ let patchedFetch: typeof fetch;
 
 beforeAll(async () => {
   globalThis.fetch = fakeBase;
-  await OpenWorkAnthropicToolSchema();
+  await LegalWorkAnthropicToolSchema();
   patchedFetch = globalThis.fetch;
   globalThis.fetch = originalFetch;
 });
@@ -57,7 +57,7 @@ async function send(body: unknown, headers: Record<string, string> = ANTHROPIC_H
   return JSON.parse(sent);
 }
 
-describe("OpenWorkAnthropicToolSchema fetch patch", () => {
+describe("LegalWorkAnthropicToolSchema fetch patch", () => {
   test("flattens a top-level anyOf into a plain object schema", async () => {
     const body = await send({
       model: "claude-fable-5",
@@ -120,6 +120,6 @@ describe("OpenWorkAnthropicToolSchema fetch patch", () => {
 
   test("module exposes only the plugin factory", async () => {
     const mod = await import("./openwork-anthropic-tool-schema.js");
-    expect(Object.keys(mod)).toEqual(["OpenWorkAnthropicToolSchema"]);
+    expect(Object.keys(mod)).toEqual(["LegalWorkAnthropicToolSchema"]);
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-anthropic-tool-schema.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-tool-schema.ts
@@ -1,5 +1,5 @@
 /**
- * OpenWork Anthropic Tool Schema Plugin
+ * LegalWork Anthropic Tool Schema Plugin
  *
  * The Anthropic Messages API rejects tool input schemas that use `anyOf`,
  * `oneOf`, or `allOf` at the top level:
@@ -121,7 +121,7 @@ function installAnthropicFetchPatch(): void {
 
 // Single export: the OpenCode plugin loader treats every export of a plugin
 // module as a plugin factory, so helpers must stay module-private.
-export const OpenWorkAnthropicToolSchema = async () => {
+export const LegalWorkAnthropicToolSchema = async () => {
   installAnthropicFetchPatch();
   return {};
 };

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
-import { OpenWorkCapabilitiesKnowledge } from "./openwork-capabilities-knowledge.js";
+import { LegalWorkCapabilitiesKnowledge } from "./openwork-capabilities-knowledge.js";
 
-describe("OpenWork capabilities knowledge plugin", () => {
+describe("LegalWork capabilities knowledge plugin", () => {
   test("retrieves Slack connection guidance from bundled docs", async () => {
     process.env.OPENWORK_DOCS_DIR = resolve(import.meta.dir, "../../../../packages/docs");
 
-    const plugin = await OpenWorkCapabilitiesKnowledge();
+    const plugin = await LegalWorkCapabilitiesKnowledge();
     const search = await plugin.tool.openwork_docs_search.execute({ query: "how can i connect slack", limit: 3 });
 
     expect(search).toContain("start-here/connect-your-stack/connect-slack-mcp.mdx");

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -4,24 +4,24 @@ import { fileURLToPath } from "node:url";
 import { z } from "zod";
 
 /**
- * OpenWork Capabilities Knowledge Plugin
+ * LegalWork Capabilities Knowledge Plugin
  *
- * Injects knowledge about OpenWork's capabilities into the agent's system
+ * Injects knowledge about LegalWork's capabilities into the agent's system
  * prompt so it can proactively help users with:
  * - Adding AI providers (including local models via Ollama)
  * - Fixing authorized folders
  * - Enabling computer use
- * - Connecting MCP extensions, including OpenWork Cloud MCP
- * - Using OpenWork Cloud
- * - Finding OpenWork docs before falling back to code
+ * - Connecting MCP extensions, including LegalWork Cloud MCP
+ * - Using LegalWork Cloud
+ * - Finding LegalWork docs before falling back to code
  * - Voice mode, browser, skills, automations
  */
 
-const OPENWORK_CAPABILITIES_KNOWLEDGE = `You are running inside OpenWork, a desktop app for agentic work.
+const OPENWORK_CAPABILITIES_KNOWLEDGE = `You are running inside LegalWork, a desktop app for agentic work.
 
-CRITICAL: To navigate or control the OpenWork app (open settings, add providers, etc.), use the openwork_ui_execute_action tool, NOT browser tools. For example, to open settings: openwork_ui_execute_action({actionId:"settings.panel.open", args:{panel:"general"}}).
+CRITICAL: To navigate or control the LegalWork app (open settings, add providers, etc.), use the openwork_ui_execute_action tool, NOT browser tools. For example, to open settings: openwork_ui_execute_action({actionId:"settings.panel.open", args:{panel:"general"}}).
 
-For OpenWork product questions, use openwork_docs_search and openwork_docs_read as the first source of truth. Read and summarize relevant docs before answering. Cite the docs path when it helps the user verify or continue. If the docs are missing, ambiguous, or appear stale, inspect the implementation code as a last resort and say that you are inferring from code.
+For LegalWork product questions, use openwork_docs_search and openwork_docs_read as the first source of truth. Read and summarize relevant docs before answering. Cite the docs path when it helps the user verify or continue. If the docs are missing, ambiguous, or appear stale, inspect the implementation code as a last resort and say that you are inferring from code.
 
 Important docs to know:
 - General docs navigation: packages/docs/docs.json
@@ -37,7 +37,7 @@ Here is what you can help users with:
 
 ## Adding AI Providers
 - **Cloud providers**: Go to Settings > AI Providers to add Anthropic, OpenAI, Google, OpenRouter, or other providers with an API key.
-- **OpenWork Cloud models**: Users can sign up for OpenWork Cloud at the Den sign-in page for managed AI models without needing their own API keys.
+- **LegalWork Cloud models**: Users can sign up for LegalWork Cloud at the Den sign-in page for managed AI models without needing their own API keys.
 - **Local models (Ollama)**: Tell the user to:
   1. Install Ollama from https://ollama.com (or \`brew install ollama\` on macOS)
   2. Run \`ollama pull <model>\` in their terminal (e.g. \`ollama pull llama3\`)
@@ -46,7 +46,7 @@ Here is what you can help users with:
 - **Custom provider scripts**: Users can add custom OpenAI-compatible endpoints in Settings > AI Providers by adding a provider with a custom base URL.
 
 ## Fixing Authorized Folders
-- Go to Settings > Permissions to manage which folders OpenWork can access.
+- Go to Settings > Permissions to manage which folders LegalWork can access.
 - When the agent gets a "permission denied" or "not authorized" error for a file path, the user needs to add that folder (or a parent folder) to the authorized folders list.
 - The agent can navigate there: use the UI control action \`settings.panel.open\` with \`{panel: "permissions"}\`.
 
@@ -59,10 +59,10 @@ Here is what you can help users with:
 - Go to Settings > Extensions to add MCP servers.
 - Popular integrations: Google Workspace, GitHub, Slack, databases, file systems.
 - Users can browse the marketplace for pre-built extensions, or add custom MCPs by providing a command (e.g. \`npx -y @some/mcp-server\`) or URL.
-- OpenWork Cloud exposes a hosted remote MCP server at \`https://api.openworklabs.com/mcp\`. It uses OAuth, lets users choose an OpenWork Cloud organization, and exposes Cloud resources such as config objects, connectors, plugins, marketplaces, skills, workers, members, roles, teams, and LLM providers. For setup details, read packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx.
+- LegalWork Cloud exposes a hosted remote MCP server at \`https://api.openworklabs.com/mcp\`. It uses OAuth, lets users choose an LegalWork Cloud organization, and exposes Cloud resources such as config objects, connectors, plugins, marketplaces, skills, workers, members, roles, teams, and LLM providers. For setup details, read packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx.
 
 ## Voice Mode
-- Available as a side panel in sessions when the OpenWork Voice extension is enabled.
+- Available as a side panel in sessions when the LegalWork Voice extension is enabled.
 - Uses OpenAI Realtime for real-time voice interaction.
 - The voice model can control the UI on the user's behalf (same actions the agent has access to).
 
@@ -72,14 +72,14 @@ Here is what you can help users with:
 - The browser panel is visible on the right side of the session view.
 
 ## Cross-chat Session Memory
-- Cross-chat memory currently comes from saved OpenWork session history exposed through OpenWork UI actions, not a separate hidden long-term memory store.
-- If the user asks what they said, what happened, or what was decided in another OpenWork session, use the UI control actions: list sessions, open the matching session, then read the transcript.
+- Cross-chat memory currently comes from saved LegalWork session history exposed through LegalWork UI actions, not a separate hidden long-term memory store.
+- If the user asks what they said, what happened, or what was decided in another LegalWork session, use the UI control actions: list sessions, open the matching session, then read the transcript.
 - Match sessions by ID, title, workspace, or topic words. Ask a short clarifying question if multiple sessions match.
 - Answer only from the returned transcript. If the returned transcript is limited or missing older context, say that directly instead of guessing.
 
-## OpenWork Cloud
+## LegalWork Cloud
 - Users sign up at the Den portal (accessible from the status bar "Sign in" button).
-- Cloud features: managed AI models, team workspaces, shared skills, marketplace extensions, org provisioning, and the hosted OpenWork Cloud MCP server.
+- Cloud features: managed AI models, team workspaces, shared skills, marketplace extensions, org provisioning, and the hosted LegalWork Cloud MCP server.
 - Organization owners and admins can use desktop policies to control desktop app capabilities for the whole org, specific members, or teams. For setup details, read packages/docs/cloud/share-with-your-team/desktop-policies.mdx.
 - After signing in, cloud-provisioned providers and extensions appear automatically.
 
@@ -89,15 +89,15 @@ Here is what you can help users with:
 - Users can install skill templates or create custom skills in \`.opencode/skills/\`.
 
 ## Creating Plugins
-- Plugins extend OpenWork/OpenCode with custom tools.
+- Plugins extend LegalWork/OpenCode with custom tools.
 - Create a file in \`.opencode/plugins/my-plugin.ts\` and add it to the \`plugin\` array in \`opencode.json\`.
 - Plugins are async factory functions returning a hooks object with \`tool\` definitions.
 - See the \`create-plugin\` skill for the full API reference.
 
-When users ask "what can I do?" or "what can OpenWork do?", summarize these capabilities. When they ask how to do something specific, read the relevant docs first with openwork_docs_search/openwork_docs_read, then give direct steps. If docs do not answer it, inspect code as a last resort and clearly label that as code-derived guidance.`;
+When users ask "what can I do?" or "what can LegalWork do?", summarize these capabilities. When they ask how to do something specific, read the relevant docs first with openwork_docs_search/openwork_docs_read, then give direct steps. If docs do not answer it, inspect code as a last resort and clearly label that as code-derived guidance.`;
 
 const docsSearchArgsSchema = z.object({
-  query: z.string().min(1).describe("OpenWork docs search query, for example 'connect slack mcp'."),
+  query: z.string().min(1).describe("LegalWork docs search query, for example 'connect slack mcp'."),
   limit: z.number().int().min(1).max(10).optional().describe("Maximum number of matching docs to return."),
 });
 
@@ -211,13 +211,13 @@ function excerpt(content: string, query: string): string {
   return content.slice(from, from + 500).replace(/\s+/g, " ").trim();
 }
 
-export const OpenWorkCapabilitiesKnowledge = async () => ({
+export const LegalWorkCapabilitiesKnowledge = async () => ({
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
     output.system.push(OPENWORK_CAPABILITIES_KNOWLEDGE);
   },
   tool: {
     openwork_docs_search: {
-      description: "Search the bundled OpenWork documentation. Use this first for OpenWork product questions before inspecting implementation code.",
+      description: "Search the bundled LegalWork documentation. Use this first for LegalWork product questions before inspecting implementation code.",
       args: docsSearchArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const args = docsSearchArgsSchema.parse(rawArgs);
@@ -237,7 +237,7 @@ export const OpenWorkCapabilitiesKnowledge = async () => ({
       },
     },
     openwork_docs_read: {
-      description: "Read a bundled OpenWork documentation page by docs-relative path returned from openwork_docs_search.",
+      description: "Read a bundled LegalWork documentation page by docs-relative path returned from openwork_docs_search.",
       args: docsReadArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const args = docsReadArgsSchema.parse(rawArgs);
@@ -245,7 +245,7 @@ export const OpenWorkCapabilitiesKnowledge = async () => ({
         if (normalized.split("/").includes("..")) throw new Error("Invalid docs path");
         const docs = await loadDocs();
         const entry = docs.find((doc) => doc.path === normalized);
-        if (!entry) throw new Error(`OpenWork docs page not found: ${normalized}`);
+        if (!entry) throw new Error(`LegalWork docs page not found: ${normalized}`);
         return JSON.stringify(entry, null, 2);
       },
     },

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -34,7 +34,7 @@ const uiExecuteArgsSchema = z.object({
 });
 
 const browserOpenUrlArgsSchema = z.object({
-  url: z.string().describe("The website URL to open in the OpenWork built-in browser."),
+  url: z.string().describe("The website URL to open in the LegalWork built-in browser."),
   provider: z.enum(["auto", "builtin", "external"]).optional().describe("Browser provider. Use builtin or auto; external is reserved for future support."),
 });
 
@@ -43,28 +43,28 @@ const browserSetProxyArgsSchema = z.object({
 });
 
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
-  "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+  "If the user asks for something you cannot do with obvious built-in tools, check LegalWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
 
 const OPENWORK_UI_CONTROL_INSTRUCTION =
-  `IMPORTANT: You are running inside the OpenWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the OpenWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
+  `IMPORTANT: You are running inside the LegalWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the LegalWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
 
 To open settings: openwork_ui_execute_action with actionId "settings.panel.open" and args {panel:"general"} (or "ai", "extensions", "permissions", "skills", "appearance", etc.)
 To add a provider: openwork_ui_execute_action with actionId "settings.provider.add" and optional args {providerId:"anthropic"}
 To see what the user sees: openwork_ui_snapshot
 To list all available actions: openwork_ui_list_actions
-To ask what OpenWork can do: openwork_ui_execute_action with actionId "help.capabilities"
+To ask what LegalWork can do: openwork_ui_execute_action with actionId "help.capabilities"
 
 ## Cross-session memory
-When the user asks what they said, what happened, or what was decided in another OpenWork chat/session, treat it as a session-history lookup through the OpenWork UI, not hidden model memory.
+When the user asks what they said, what happened, or what was decided in another LegalWork chat/session, treat it as a session-history lookup through the LegalWork UI, not hidden model memory.
 Use openwork_ui_execute_action with actionId "session.list_sessions" to find matching sessions by title, workspace, topic, or session ID.
 If there is one clear match, use actionId "session.open" with args {sessionId:"..."}, then use actionId "session.read_transcript" with args {count:30} to read recent messages.
 Answer only from the returned transcript. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.
 
-Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
+Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the LegalWork app itself. Those are for browsing external websites.
 
 ## Built-in Browser (external websites)
-For web browsing tasks, ALWAYS start with openwork_browser_open_url. It creates/selects a built-in OpenWork browser tab and returns browser_url plus target_id. Use that exact browser_url and target_id for every later browser_snapshot, browser_click, browser_fill, browser_eval, and browser_screenshot call.
-Do not call browser_navigate without a target_id returned by openwork_browser_open_url. Do not use browser_* tools on the OpenWork app target (avoid targets with title "OpenWork" or URLs containing ":5173/#/").`;
+For web browsing tasks, ALWAYS start with openwork_browser_open_url. It creates/selects a built-in LegalWork browser tab and returns browser_url plus target_id. Use that exact browser_url and target_id for every later browser_snapshot, browser_click, browser_fill, browser_eval, and browser_screenshot call.
+Do not call browser_navigate without a target_id returned by openwork_browser_open_url. Do not use browser_* tools on the LegalWork app target (avoid targets with title "LegalWork" or URLs containing ":5173/#/").`;
 
 // ── UI control bridge discovery ──
 
@@ -108,7 +108,7 @@ async function discoverUiBridge(): Promise<UiBridge | null> {
 
 async function uiBridgeRequest(path: string, options: { method?: string; body?: unknown } = {}): Promise<unknown> {
   const bridge = await discoverUiBridge();
-  if (!bridge) return { ok: false, error: "OpenWork UI bridge not available. The desktop app may not be running." };
+  if (!bridge) return { ok: false, error: "LegalWork UI bridge not available. The desktop app may not be running." };
   try {
     const response = await fetch(`${bridge.baseUrl}${path}`, {
       method: options.method || "GET",
@@ -136,11 +136,11 @@ function serverToken(): string {
   return String(process.env.OPENWORK_SERVER_TOKEN || "");
 }
 
-function requireOpenWorkServer(): { url: string; token: string } {
+function requireLegalWorkServer(): { url: string; token: string } {
   const url = serverUrl();
   const token = serverToken();
   if (!url || !token) {
-    throw new Error("OpenWork extension tools are only available when OpenCode is launched by OpenWork.");
+    throw new Error("LegalWork extension tools are only available when OpenCode is launched by LegalWork.");
   }
   return { url, token };
 }
@@ -174,7 +174,7 @@ function errorMessage(payload: unknown, fallback: string): string {
 }
 
 async function postJson(path: string, body: ExtensionActionPayload): Promise<unknown> {
-  const { url, token } = requireOpenWorkServer();
+  const { url, token } = requireLegalWorkServer();
   const response = await fetch(url + path, {
     method: "POST",
     headers: {
@@ -185,7 +185,7 @@ async function postJson(path: string, body: ExtensionActionPayload): Promise<unk
   });
   const payload = await parseResponse(response);
   if (!response.ok) {
-    throw new Error(errorMessage(payload, "OpenWork extension call failed"));
+    throw new Error(errorMessage(payload, "LegalWork extension call failed"));
   }
   return payload;
 }
@@ -200,29 +200,29 @@ function contextPayload(context: OpenCodeContext) {
   };
 }
 
-export const OpenWorkExtensionsPreview = async () => ({
+export const LegalWorkExtensionsPreview = async () => ({
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
     output.system.push(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
     output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);
   },
   tool: {
     openwork_extension_list_actions: {
-      description: `List extension actions currently exposed by OpenWork. ${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION}`,
+      description: `List extension actions currently exposed by LegalWork. ${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION}`,
       args: listActionsArgsSchema.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = listActionsArgsSchema.parse(rawArgs);
         const query = args.extensionId ? `?extensionId=${encodeURIComponent(args.extensionId)}` : "";
-        const { url, token } = requireOpenWorkServer();
+        const { url, token } = requireLegalWorkServer();
         const response = await fetch(`${url}/experimental/extensions/actions${query}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         const payload = await parseResponse(response);
-        if (!response.ok) throw new Error(errorMessage(payload, "OpenWork extension action listing failed"));
+        if (!response.ok) throw new Error(errorMessage(payload, "LegalWork extension action listing failed"));
         return JSON.stringify(addContext(payload, context), null, 2);
       },
     },
     openwork_extension_call: {
-      description: `Call an OpenWork extension action. Use openwork_extension_list_actions first to inspect available actions and schemas. ${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION}`,
+      description: `Call an LegalWork extension action. Use openwork_extension_list_actions first to inspect available actions and schemas. ${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION}`,
       args: callArgsSchema.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = callArgsSchema.parse(rawArgs);
@@ -236,7 +236,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_ui_snapshot: {
-      description: "Get a snapshot of the current OpenWork UI state: active route, narration, visible actions, and status. Use this to understand what the user sees before taking action.",
+      description: "Get a snapshot of the current LegalWork UI state: active route, narration, visible actions, and status. Use this to understand what the user sees before taking action.",
       args: {},
       async execute() {
         const result = await uiBridgeRequest("/snapshot");
@@ -244,7 +244,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_ui_list_actions: {
-      description: `List all UI control actions currently available in OpenWork. Each action has an id you can pass to openwork_ui_execute_action. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
+      description: `List all UI control actions currently available in LegalWork. Each action has an id you can pass to openwork_ui_execute_action. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
       args: {},
       async execute() {
         const result = await uiBridgeRequest("/actions");
@@ -252,7 +252,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_ui_execute_action: {
-      description: `Execute an OpenWork UI action by its id. Use openwork_ui_list_actions first to see available actions. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
+      description: `Execute an LegalWork UI action by its id. Use openwork_ui_list_actions first to see available actions. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
       args: uiExecuteArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const { actionId, args } = uiExecuteArgsSchema.parse(rawArgs);
@@ -264,7 +264,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_browser_open_url: {
-      description: "Open a URL in the OpenWork built-in browser and return the exact CDP browser_url and target_id to use for browser_* automation tools. Always use this before browser_snapshot/click/fill/eval for web browsing tasks.",
+      description: "Open a URL in the LegalWork built-in browser and return the exact CDP browser_url and target_id to use for browser_* automation tools. Always use this before browser_snapshot/click/fill/eval for web browsing tasks.",
       args: browserOpenUrlArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const args = browserOpenUrlArgsSchema.parse(rawArgs);
@@ -279,7 +279,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_browser_set_proxy: {
-      description: "Route all OpenWork built-in browser traffic through an HTTP/SOCKS proxy — for example to fetch search results or pages as seen from another location. Applies to every built-in browser tab (including browser_* automation) until cleared with openwork_browser_clear_proxy. If the user has named proxies configured as OPENWORK_BROWSER_PROXY_<NAME> environment variables, pass env:NAME instead of a raw URL.",
+      description: "Route all LegalWork built-in browser traffic through an HTTP/SOCKS proxy — for example to fetch search results or pages as seen from another location. Applies to every built-in browser tab (including browser_* automation) until cleared with openwork_browser_clear_proxy. If the user has named proxies configured as OPENWORK_BROWSER_PROXY_<NAME> environment variables, pass env:NAME instead of a raw URL.",
       args: browserSetProxyArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const args = browserSetProxyArgsSchema.parse(rawArgs);
@@ -291,7 +291,7 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
     openwork_browser_clear_proxy: {
-      description: "Clear the OpenWork built-in browser proxy and restore the system network settings.",
+      description: "Clear the LegalWork built-in browser proxy and restore the system network settings.",
       args: {},
       async execute() {
         const result = await uiBridgeRequest("/execute", {


### PR DESCRIPTION
## What
- **Sidebar restructure**: top nav — **New Task** (opens the local-folder modal), **Learnings**, **Skills** & **Integrations** (deep-link to settings) — over a fixed **bottom-60% Folders** section (renamed from Workspaces).
- **Learnings**: a state-driven main-pane view rendered *inside the session shell* (keeps the app sidebar). Empty placeholder for now.
- **Add-folder** opens the local folder picker directly — local/remote chooser removed (we're local-only).
- **Fixes the local-only regression from #1**: `requestJsonRaw` (den.ts) and `DenAuthProvider` now guard on `CLOUD_ENABLED`, so the dangling `/v1/me` and `/v1/llm-providers` calls no longer throw "Invalid URL".
- **Misc**: user messages are grey/borderless; markdown artifacts already render by default; renamed remaining agent-facing "OpenWork" → "LegalWork" in the opencode system-prompt plugins (the lowercase `openwork_*` tool ids are intentionally preserved).

## Follow-up (not in this PR)
- **Shell unification**: Skills/Integrations still render the **Settings** shell (its own sidebar). Lifting those panels (MCP view has ~29 props) into the main shell is a separate refactor.

## Test
`pnpm dev` (local-only). Verified: no `/v1` errors, sidebar 40/60 layout, grey bubbles, add-folder = local picker. Learnings is wired via `onShowLearnings` state — clicking it swaps the main pane while keeping the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)