### PR TITLE
Local model runtimes + working provider disconnect

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/local-templates.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/local-templates.ts
@@ -1,0 +1,105 @@
+import type { CustomProviderApiType } from "./store";
+
+/**
+ * A one-click starting point for a local model server. Picking a template
+ * pre-fills the custom provider form (Base URL, name, API type) for that
+ * runtime; the user then fetches models and connects. All local runtimes speak
+ * the OpenAI /v1/chat/completions spec, so they route through
+ * `@ai-sdk/openai-compatible` with no API key.
+ */
+export type LocalRuntimeTemplate = {
+  /** Stable template key (also the suggested provider id / name slug). */
+  id: string;
+  label: string;
+  /** Display name prefilled into the form. */
+  name: string;
+  /** Base URL prefilled into the form. */
+  baseURL: string;
+  /** Base URL placeholder shown when the field is blank. */
+  placeholder: string;
+  apiType: CustomProviderApiType;
+  /** Shown under the picker when this template is active. */
+  note: string;
+  /**
+   * True when the opencode engine already auto-detects this runtime on the
+   * default host (its built-in `loadLocal` probes the endpoint and lists
+   * installed models live). Adding it manually is optional and, on the default
+   * host, replaces that live list — the picker shows a heads-up.
+   */
+  autoDetected?: boolean;
+};
+
+export const LOCAL_RUNTIME_TEMPLATES: LocalRuntimeTemplate[] = [
+  {
+    id: "llamacpp",
+    label: "llama.cpp",
+    name: "llama.cpp",
+    baseURL: "http://localhost:8080/v1",
+    placeholder: "http://localhost:8080/v1",
+    apiType: "chat",
+    note: "Run `llama-server -m model.gguf`, then fetch the served model. No API key needed.",
+  },
+  {
+    id: "vllm",
+    label: "vLLM",
+    name: "vLLM",
+    baseURL: "http://localhost:8000/v1",
+    placeholder: "http://localhost:8000/v1",
+    apiType: "chat",
+    note: "Point at your vLLM server (local or self-hosted), then fetch its served models.",
+  },
+  {
+    id: "localai",
+    label: "LocalAI",
+    name: "LocalAI",
+    baseURL: "http://localhost:8080/v1",
+    placeholder: "http://localhost:8080/v1",
+    apiType: "chat",
+    note: "Point at your LocalAI endpoint, then fetch its configured models. No API key needed.",
+  },
+  {
+    id: "ollama",
+    label: "Ollama",
+    name: "Ollama",
+    baseURL: "http://localhost:11434/v1",
+    placeholder: "http://localhost:11434/v1",
+    apiType: "chat",
+    autoDetected: true,
+    note: "Heads up: a local Ollama is already detected automatically and its models show up live — adding it here isn't required. Change the URL to point at a remote or non-default host.",
+  },
+  {
+    id: "lmstudio",
+    label: "LM Studio",
+    name: "LM Studio",
+    baseURL: "http://localhost:1234/v1",
+    placeholder: "http://localhost:1234/v1",
+    apiType: "chat",
+    autoDetected: true,
+    note: "Heads up: a local LM Studio is already detected automatically and its models show up live — adding it here isn't required. Change the URL to point at a remote or non-default host.",
+  },
+];
+
+/** Turn a free-text provider name into a stable lowercase provider id. */
+export function slugifyProviderId(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "custom-provider";
+}
+
+/**
+ * The display name to use after picking a template. We replace the current
+ * value only when it's blank or still a template default, so a name the user
+ * typed themselves is preserved when switching between templates.
+ */
+export function resolveTemplateName(
+  currentName: string,
+  template: LocalRuntimeTemplate,
+  templates: LocalRuntimeTemplate[] = LOCAL_RUNTIME_TEMPLATES,
+): string {
+  const trimmed = currentName.trim();
+  const isTemplateName = templates.some((candidate) => candidate.name === trimmed);
+  return !trimmed || isTemplateName ? template.name : currentName;
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -50,6 +50,12 @@ import type {
   ProviderAuthProvider,
   ProviderOAuthStartResult,
 } from "./store";
+import {
+  LOCAL_RUNTIME_TEMPLATES,
+  resolveTemplateName,
+  slugifyProviderId,
+  type LocalRuntimeTemplate,
+} from "./local-templates";
 
 /** Base URLs that default to the Responses API (`@ai-sdk/openai`). */
 function inferCustomApiType(baseURL: string): CustomProviderApiType {
@@ -103,6 +109,12 @@ type BrandedCustomProvider = {
   name: string;
   apiType: CustomProviderApiType;
   baseUrlPlaceholder: string;
+  /**
+   * Fixed-endpoint runtimes (local model servers) listen on a well-known URL,
+   * so we pre-fill the Base URL field instead of only hinting at it — the user
+   * just fetches their models and connects. Omit for per-deployment gateways.
+   */
+  baseUrlDefault?: string;
   description: string;
 };
 
@@ -119,15 +131,8 @@ const BRANDED_CUSTOM_PROVIDERS: BrandedCustomProvider[] = [
 /** Synthetic list entry id for the user-defined OpenAI-compatible provider. */
 const CUSTOM_PROVIDER_ENTRY_ID = "__custom_openai_compatible__";
 
-/** Turn a free-text provider name into a stable lowercase provider id. */
-function slugifyProviderId(name: string) {
-  const slug = name
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return slug || "custom-provider";
-}
+/** Synthetic list entry id for the templated "Local model" provider. */
+const LOCAL_PROVIDER_ENTRY_ID = "__local_model__";
 
 type ProviderAuthEntry = {
   id: string;
@@ -151,7 +156,14 @@ const PROVIDER_LABELS: Record<string, string> = {
   openrouter: "OpenRouter",
   apertus: "Apertus AI",
   "apertus-ai": "Apertus AI",
+  ollama: "Ollama (local)",
+  lmstudio: "LM Studio (local)",
+  llamacpp: "llama.cpp (local)",
+  vllm: "vLLM (local)",
+  localai: "LocalAI (local)",
 };
+// Note: `ollama` / `lmstudio` labels are kept so opencode's auto-detected
+// local providers still render with a friendly name in the provider list.
 
 export type ProviderAuthModalProps = {
   open: boolean;
@@ -210,6 +222,10 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [customEditMode, setCustomEditMode] = useState(false);
   // Display name of a branded provider being added (e.g. "Apertus AI"), else null.
   const [customBrandName, setCustomBrandName] = useState<string | null>(null);
+  // True when the form is in "Local model" mode — shows the runtime template
+  // picker. `customTemplateId` is the currently-selected template, if any.
+  const [customShowLocalTemplates, setCustomShowLocalTemplates] = useState(false);
+  const [customTemplateId, setCustomTemplateId] = useState<string | null>(null);
   const [customModelInput, setCustomModelInput] = useState("");
   const [customModels, setCustomModels] = useState<CustomModelDraft[]>([]);
   const [customFetchedModels, setCustomFetchedModels] = useState<string[]>([]);
@@ -228,6 +244,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     !customEditMode && customBrandName
       ? BRANDED_CUSTOM_PROVIDERS.find((provider) => provider.id === customFixedProviderId) ?? null
       : null;
+  const activeLocalTemplate = customShowLocalTemplates
+    ? LOCAL_RUNTIME_TEMPLATES.find((template) => template.id === customTemplateId) ?? null
+    : null;
 
   const formatProviderName = (id: string, fallback?: string) => {
     const named = fallback?.trim();
@@ -332,6 +351,17 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
         });
       }
 
+      // One consolidated "Local model" entry with per-runtime templates
+      // (llama.cpp, vLLM, LocalAI, …). Ollama / LM Studio on the default host
+      // are auto-detected by the engine and appear via auth methods above.
+      nextEntries.push({
+        id: LOCAL_PROVIDER_ENTRY_ID,
+        name: "Local model",
+        methods: [{ type: "api", label: "Ollama · LM Studio · llama.cpp · vLLM" }],
+        connected: false,
+        env: [],
+      });
+
       // Generic user-defined option, pinned at the very bottom.
       nextEntries.push({
         id: CUSTOM_PROVIDER_ENTRY_ID,
@@ -417,6 +447,8 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setCustomFixedProviderId(null);
     setCustomEditMode(false);
     setCustomBrandName(null);
+    setCustomShowLocalTemplates(false);
+    setCustomTemplateId(null);
     setCustomModelInput("");
     setCustomModels([]);
     setCustomFetchedModels([]);
@@ -710,6 +742,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       return;
     }
 
+    if (entry.id === LOCAL_PROVIDER_ENTRY_ID) {
+      startLocalProvider();
+      return;
+    }
+
     const branded = BRANDED_CUSTOM_PROVIDERS.find((provider) => provider.id === entry.id);
     if (branded) {
       startCustomProvider(branded);
@@ -822,17 +859,56 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setCustomFixedProviderId(branded?.id ?? null);
     setCustomBrandName(branded?.name ?? null);
     setCustomName(branded?.name ?? "");
-    setCustomBaseURL("");
+    // Fixed-endpoint runtimes (Ollama, LM Studio, …) pre-fill their Base URL so
+    // the user can fetch models immediately; per-deployment gateways stay blank.
+    setCustomBaseURL(branded?.baseUrlDefault ?? "");
     setCustomApiKey("");
     setCustomApiType(branded?.apiType ?? "chat");
     setCustomApiTypeTouched(Boolean(branded));
     setCustomBaseUrlPlaceholder(branded?.baseUrlPlaceholder ?? DEFAULT_BASE_URL_PLACEHOLDER);
+    setCustomShowLocalTemplates(false);
+    setCustomTemplateId(null);
     setCustomModelInput("");
     setCustomModels([]);
     setCustomFetchedModels([]);
     setLocalError(null);
     setSelectedProviderId(branded?.id ?? CUSTOM_PROVIDER_ENTRY_ID);
     setView("custom");
+  };
+
+  // Open the custom form in "Local model" mode: a runtime template picker on
+  // top of an otherwise-blank custom form. Provider id derives from the name
+  // (not fixed), so several local providers can coexist.
+  const startLocalProvider = () => {
+    setCustomEditMode(false);
+    setCustomFixedProviderId(null);
+    setCustomBrandName("Local model");
+    setCustomShowLocalTemplates(true);
+    setCustomTemplateId(null);
+    setCustomName("");
+    setCustomBaseURL("");
+    setCustomApiKey("");
+    setCustomApiType("chat");
+    setCustomApiTypeTouched(false);
+    setCustomBaseUrlPlaceholder(DEFAULT_BASE_URL_PLACEHOLDER);
+    setCustomModelInput("");
+    setCustomModels([]);
+    setCustomFetchedModels([]);
+    setLocalError(null);
+    setSelectedProviderId(LOCAL_PROVIDER_ENTRY_ID);
+    setView("custom");
+  };
+
+  // Apply a runtime template: prefill Base URL, API type, and (when the name is
+  // still blank or matches another template's name) the display name.
+  const applyLocalTemplate = (template: LocalRuntimeTemplate) => {
+    setCustomTemplateId(template.id);
+    setCustomBaseURL(template.baseURL);
+    setCustomBaseUrlPlaceholder(template.placeholder);
+    setCustomApiType(template.apiType);
+    setCustomApiTypeTouched(true);
+    setCustomName((current) => resolveTemplateName(current, template));
+    if (localError) setLocalError(null);
   };
 
   const handleCustomSubmit = async () => {
@@ -1334,13 +1410,52 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       <div className="mt-1 text-xs text-dls-secondary">
                         {isEditingCustomProvider
                           ? "Update this OpenAI-compatible provider."
-                          : activeBrandedProvider?.description ?? "Connect any endpoint that speaks the OpenAI API spec."}
+                          : customShowLocalTemplates
+                            ? "Pick a runtime to prefill its endpoint, then fetch its models."
+                            : activeBrandedProvider?.description ?? "Connect any endpoint that speaks the OpenAI API spec."}
                       </div>
                     </div>
                     <Button variant="outline" onClick={handleBack} disabled={actionDisabled || customBusy}>
                       Back
                     </Button>
                   </div>
+
+                  {customShowLocalTemplates ? (
+                    <div className="space-y-1.5">
+                      <div className="text-xs font-medium text-dls-secondary">Runtime</div>
+                      <div className="flex flex-wrap gap-1.5">
+                        {LOCAL_RUNTIME_TEMPLATES.map((template) => {
+                          const active = customTemplateId === template.id;
+                          return (
+                            <button
+                              key={template.id}
+                              type="button"
+                              onClick={() => applyLocalTemplate(template)}
+                              disabled={actionDisabled || customBusy}
+                              className={`rounded-lg border px-3 py-1.5 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                                active
+                                  ? "border-[rgba(var(--dls-accent-rgb),0.4)] bg-[rgba(var(--dls-accent-rgb),0.08)] text-dls-text"
+                                  : "border-dls-border bg-dls-hover text-dls-secondary hover:bg-dls-active hover:text-dls-text"
+                              }`}
+                            >
+                              {template.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      {activeLocalTemplate ? (
+                        <div
+                          className={`rounded-lg border px-3 py-2 text-[11px] leading-relaxed ${
+                            activeLocalTemplate.autoDetected
+                              ? "border-amber-7/30 bg-amber-3/30 text-amber-11"
+                              : "border-dls-border bg-dls-hover text-dls-secondary"
+                          }`}
+                        >
+                          {activeLocalTemplate.note}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
 
                   <TextInput
                     label="Name"

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -922,6 +922,71 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     );
   };
 
+  /**
+   * Remove a config/runtime-defined provider so it fully disconnects (mirrors
+   * {@link writeCustomProviderConfig}). Custom providers are stored in the
+   * LegalWork runtime config store or the project opencode.jsonc, so deleting
+   * the auth credential alone leaves them connected — this deletes the
+   * `provider.<id>` block itself. No-op when the provider isn't in config.
+   */
+  const removeCustomProviderFromConfig = async (providerId: string): Promise<void> => {
+    const resolved = providerId.trim();
+    if (!resolved) return;
+
+    const { legalworkClient, legalworkWorkspaceId, hasLegalworkTarget, canUseLegalworkServer } =
+      await resolveLegalworkConfigTarget("write");
+
+    if (canUseLegalworkServer && legalworkClient && legalworkWorkspaceId) {
+      // A `null` value tells the server to delete this key from the runtime
+      // provider map (patch payloads can't carry `undefined` over JSON).
+      await legalworkClient.patchConfig(legalworkWorkspaceId, {
+        opencode: { provider: { [resolved]: null } },
+      });
+      return;
+    }
+
+    if (hasLegalworkTarget) {
+      // Connected to a LegalWork server we can't write config to — nothing to
+      // remove there; credential removal above is the best we can do.
+      return;
+    }
+
+    // Desktop-local: delete the provider block from opencode.jsonc.
+    await updateProjectConfigFile(
+      (raw) => {
+        const base = raw.trim()
+          ? raw
+          : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+        const edits = modify(base, ["provider", resolved], undefined, {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+        });
+        const updated = applyEdits(base, edits);
+        return updated.endsWith("\n") ? updated : `${updated}\n`;
+      },
+      (config) => {
+        if (!config.provider || typeof config.provider !== "object") return config;
+        const nextProviders = { ...(config.provider as Record<string, unknown>) };
+        delete nextProviders[resolved];
+        return { ...config, provider: nextProviders };
+      },
+    );
+  };
+
+  /** True when the provider is defined in config (custom / has a base URL), so
+   *  removing it requires deleting its config block, not just its credential. */
+  const providerIsConfigDefined = (providerId: string): boolean => {
+    const entry = options.providers().find((provider) => provider.id === providerId);
+    if (!entry) return false;
+    const source = (entry as { source?: unknown }).source;
+    if (source === "custom" || source === "config") return true;
+    const entryOptions = (entry as { options?: unknown }).options;
+    const baseURL =
+      entryOptions && typeof entryOptions === "object"
+        ? (entryOptions as Record<string, unknown>).baseURL
+        : undefined;
+    return typeof baseURL === "string" && baseURL.trim().length > 0;
+  };
+
   async function readCustomProviderForEdit(
     providerId: string,
   ): Promise<CustomProviderEditData | null> {
@@ -1040,12 +1105,30 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       throw new Error(t("providers.provider_id_required"));
     }
 
+    const configDefined = providerIsConfigDefined(resolved);
+
     try {
-      await removeProviderAuthCredentials(resolved);
+      // Remove the stored API credential. Best-effort: config-defined providers
+      // may have none, and the engine can reject removal of a key that isn't
+      // there — that shouldn't abort the config removal below.
+      try {
+        await removeProviderAuthCredentials(resolved);
+      } catch (credentialError) {
+        if (!configDefined) throw credentialError;
+      }
+
+      // Custom / config-defined providers live in the runtime config store or
+      // opencode.jsonc, so removing the credential alone leaves them connected.
+      // Delete the provider's config block too.
+      if (configDefined) {
+        await removeCustomProviderFromConfig(resolved);
+        options.markOpencodeConfigReloadRequired();
+      }
+
       const updated = await refreshProviders({ dispose: true });
       if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
-        // Provider is still connected (e.g. via env var). Just remove
-        // stored credentials; do NOT add to disabled_providers.
+        // Still connected (e.g. via an env var we can't unset). Report what we
+        // did rather than silently doing nothing.
         return `Removed stored credentials for ${resolved}${t("providers.still_connected_suffix")}`;
       }
       removeProviderFromState(resolved);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -372,6 +372,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [localProviderBusy, setLocalProviderBusy] = useState(false);
   const [localProviderStatus, setLocalProviderStatus] = useState<string | null>(null);
   const [localProviderError, setLocalProviderError] = useState<string | null>(null);
+  const [disconnectingProviderId, setDisconnectingProviderId] = useState<string | null>(null);
+  const [providerDisconnectStatus, setProviderDisconnectStatus] = useState<string | null>(null);
+  const [providerDisconnectError, setProviderDisconnectError] = useState<string | null>(null);
   const [googleWorkspaceConnected, setGoogleWorkspaceConnected] = useState(false);
   const [imageExtensionBusy, setImageExtensionBusy] = useState(false);
   const [imageExtensionStatus, setImageExtensionStatus] = useState<string | null>(null);
@@ -987,6 +990,22 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       setLocalProviderBusy(false);
     }
   }, [local, legalworkClient, reloadCoordinator, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
+
+  const handleDisconnectProvider = useCallback(async (providerId: string) => {
+    const resolved = providerId.trim();
+    if (!resolved || disconnectingProviderId) return;
+    setProviderDisconnectStatus(null);
+    setProviderDisconnectError(null);
+    setDisconnectingProviderId(resolved);
+    try {
+      const message = await providerAuthStore.disconnectProvider(resolved);
+      setProviderDisconnectStatus(typeof message === "string" && message ? message : `Disconnected ${resolved}.`);
+    } catch (error) {
+      setProviderDisconnectError(describeRouteError(error));
+    } finally {
+      setDisconnectingProviderId(null);
+    }
+  }, [disconnectingProviderId, providerAuthStore]);
 
   useEffect(() => {
     local.setUi((previous) => ({ ...previous, view: "settings", tab: route.tab }));
@@ -1757,14 +1776,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             providerStatusStyle={providerStatusStyle}
             providerSummary={providerSummary}
             connectedProviders={connectedProviders}
-            disconnectingProviderId={null}
+            disconnectingProviderId={disconnectingProviderId}
             providerConnectError={customProviderEditError ?? providerAuthSnapshot.providerAuthError}
-            providerDisconnectStatus={configActionStatus}
-            providerDisconnectError={null}
+            providerDisconnectStatus={providerDisconnectStatus ?? configActionStatus}
+            providerDisconnectError={providerDisconnectError}
             onOpenProviderAuth={handleOpenProviderAuth}
-            onDisconnectProvider={async (providerId) => {
-              await providerAuthStore.disconnectProvider(providerId);
-            }}
+            onDisconnectProvider={handleDisconnectProvider}
             onEditProvider={handleEditCustomProvider}
             canDisconnectProvider={(source) => source !== "env"}
           />

--- a/apps/app/tests/provider-local-templates.test.ts
+++ b/apps/app/tests/provider-local-templates.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LOCAL_RUNTIME_TEMPLATES,
+  resolveTemplateName,
+  slugifyProviderId,
+} from "../src/react-app/domains/connections/provider-auth/local-templates";
+
+describe("local runtime templates", () => {
+  test("has the expected runtimes with unique ids", () => {
+    const ids = LOCAL_RUNTIME_TEMPLATES.map((template) => template.id);
+    expect(ids).toEqual(["llamacpp", "vllm", "localai", "ollama", "lmstudio"]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every template autofills a base URL (regression: Ollama/LM Studio must not be blank)", () => {
+    for (const template of LOCAL_RUNTIME_TEMPLATES) {
+      expect(template.baseURL).toMatch(/^https?:\/\/.+\/v1$/);
+      expect(template.placeholder).toMatch(/^https?:\/\/.+\/v1$/);
+    }
+    const byId = Object.fromEntries(LOCAL_RUNTIME_TEMPLATES.map((t) => [t.id, t]));
+    expect(byId.ollama.baseURL).toBe("http://localhost:11434/v1");
+    expect(byId.lmstudio.baseURL).toBe("http://localhost:1234/v1");
+  });
+
+  test("all templates route through the chat-completions SDK", () => {
+    for (const template of LOCAL_RUNTIME_TEMPLATES) {
+      expect(template.apiType).toBe("chat");
+    }
+  });
+
+  test("only the engine auto-detected runtimes are flagged", () => {
+    const autoDetected = LOCAL_RUNTIME_TEMPLATES.filter((t) => t.autoDetected).map((t) => t.id);
+    expect(autoDetected.sort()).toEqual(["lmstudio", "ollama"]);
+  });
+});
+
+describe("slugifyProviderId", () => {
+  test.each([
+    ["Ollama", "ollama"],
+    ["llama.cpp", "llama-cpp"],
+    ["LM Studio", "lm-studio"],
+    ["vLLM", "vllm"],
+    ["  My  Provider  ", "my-provider"],
+    ["", "custom-provider"],
+    ["   ", "custom-provider"],
+    ["***", "custom-provider"],
+  ])("slugifies %p -> %p", (input, expected) => {
+    expect(slugifyProviderId(input)).toBe(expected);
+  });
+});
+
+describe("resolveTemplateName", () => {
+  const ollama = LOCAL_RUNTIME_TEMPLATES.find((t) => t.id === "ollama")!;
+  const vllm = LOCAL_RUNTIME_TEMPLATES.find((t) => t.id === "vllm")!;
+
+  test("fills a blank name with the template name", () => {
+    expect(resolveTemplateName("", ollama)).toBe("Ollama");
+    expect(resolveTemplateName("   ", ollama)).toBe("Ollama");
+  });
+
+  test("replaces a name that is still another template's default", () => {
+    // User picked vLLM (name -> "vLLM"), then switches to Ollama.
+    expect(resolveTemplateName("vLLM", ollama)).toBe("Ollama");
+    expect(resolveTemplateName(vllm.name, ollama)).toBe("Ollama");
+  });
+
+  test("preserves a name the user typed themselves", () => {
+    expect(resolveTemplateName("My Remote Box", ollama)).toBe("My Remote Box");
+  });
+});

--- a/apps/server/src/runtime-opencode-config-store.provider-patch.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.provider-patch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { mergeRuntimeProviderPatch } from "./runtime-opencode-config-store.js";
+
+const ollama = { npm: "@ai-sdk/openai-compatible", name: "Ollama", options: { baseURL: "http://localhost:11434/v1" } };
+const vllm = { npm: "@ai-sdk/openai-compatible", name: "vLLM", options: { baseURL: "http://localhost:8000/v1" } };
+
+describe("mergeRuntimeProviderPatch", () => {
+  test("adds a new provider onto an empty map", () => {
+    expect(mergeRuntimeProviderPatch(undefined, { ollama })).toEqual({ ollama });
+  });
+
+  test("keeps existing providers when adding another", () => {
+    expect(mergeRuntimeProviderPatch({ ollama }, { vllm })).toEqual({ ollama, vllm });
+  });
+
+  test("overrides an existing provider with the same id", () => {
+    const updated = { ...ollama, name: "Ollama Remote" };
+    expect(mergeRuntimeProviderPatch({ ollama }, { ollama: updated })).toEqual({ ollama: updated });
+  });
+
+  test("a null value removes that provider (disconnect)", () => {
+    expect(mergeRuntimeProviderPatch({ ollama, vllm }, { ollama: null })).toEqual({ vllm });
+  });
+
+  test("removing the only provider yields an empty map", () => {
+    expect(mergeRuntimeProviderPatch({ ollama }, { ollama: null })).toEqual({});
+  });
+
+  test("deleting a provider that isn't present is a no-op", () => {
+    expect(mergeRuntimeProviderPatch({ ollama }, { vllm: null })).toEqual({ ollama });
+  });
+
+  test("does not mutate the current map", () => {
+    const current = { ollama, vllm };
+    mergeRuntimeProviderPatch(current, { ollama: null });
+    expect(current).toEqual({ ollama, vllm });
+  });
+
+  test("add and delete can be mixed in one patch", () => {
+    expect(mergeRuntimeProviderPatch({ ollama }, { ollama: null, vllm })).toEqual({ vllm });
+  });
+});

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -178,6 +178,26 @@ export async function writeRuntimeOpencodeConfig(
   return next;
 }
 
+/**
+ * Merge a provider patch into the current runtime provider map. A `null` value
+ * in the patch removes that provider — patch payloads can't carry `undefined`
+ * over JSON, so callers signal deletion with `null`. This is what lets a client
+ * fully disconnect a custom/runtime provider (not just drop its credential).
+ */
+export function mergeRuntimeProviderPatch(
+  current: Record<string, unknown> | undefined,
+  update: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {
+    ...(isRecord(current) ? current : {}),
+    ...update,
+  };
+  for (const [key, value] of Object.entries(update)) {
+    if (value === null) delete merged[key];
+  }
+  return merged;
+}
+
 export function mergeOpencodeConfigs(
   persisted: Record<string, unknown>,
   runtime: RuntimeOpencodeConfig,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -58,6 +58,7 @@ import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import {
   mergeOpencodeConfigs,
+  mergeRuntimeProviderPatch,
   readRuntimeOpencodeConfig,
   runtimeMcpMap,
   type RuntimeOpencodeConfig,
@@ -1769,10 +1770,12 @@ function createRoutes(
       const providerUpdate = ensurePlainObject(provider);
       if (Object.keys(providerUpdate).length) {
         const currentRuntime = await readRuntimeOpencodeConfig(config, workspace.id);
-        logicalUpdates.provider = {
-          ...(ensurePlainObject(currentRuntime.provider)),
-          ...providerUpdate,
-        };
+        // A `null` value in the patch removes that provider (see
+        // mergeRuntimeProviderPatch) so a client can fully disconnect it.
+        logicalUpdates.provider = mergeRuntimeProviderPatch(
+          ensurePlainObject(currentRuntime.provider),
+          providerUpdate,
+        );
       }
 
       const permissionUpdate = ensurePlainObject(permission);


### PR DESCRIPTION
## Summary

Two related provider improvements:

1. **Local model runtimes** — a single **"Local model"** entry in the provider modal opens a per-runtime template picker (llama.cpp, vLLM, LocalAI, Ollama, LM Studio). Each template prefills Base URL, name, and API type; models come from **Fetch from endpoint** or manual entry. All route through `@ai-sdk/openai-compatible` with no API key.
   - Ollama and LM Studio are flagged **auto-detected** — the opencode engine's built-in `loadLocal` already lists them live — with a heads-up note, but still autofill their localhost URL so the picker behaves consistently.

2. **Working provider disconnect** — disconnect previously did nothing for custom/local providers. They're added via `patchConfig` into the per-workspace **runtime config store**, so removing only the API credential left them defined and connected. Now:
   - `patchConfig` treats a `null` provider value as **delete** (`mergeRuntimeProviderPatch`).
   - The store deletes the provider's config block (in addition to its credential) for config-defined providers.
   - The AI settings view gets real disconnect UI state (in-progress id, success/error notices) — these were hardcoded to `null`.

## Why

Local runtimes all speak the OpenAI `/v1` spec, so they fit the existing custom-provider flow — the template picker just makes the common ones one click. And the disconnect gap became visible now that adding local/custom providers is easy.

## Tests

- `apps/app/tests/provider-local-templates.test.ts` — template invariants (incl. regression: Ollama/LM Studio autofill their Base URL), `slugifyProviderId`, name resolution. **15 pass**
- `apps/server/src/runtime-opencode-config-store.provider-patch.test.ts` — merge / override / null-delete / no-mutation. **8 pass**
- Full `apps/app` unit suite green (73 pass). Both packages typecheck clean.

> Note: one pre-existing server test (`runtime-opencode-config-store.test.ts` › "malformed user opencode config…") fails on this machine because a global `~/.config/opencode` MCP (`notion`) leaks into the un-isolated assertion — confirmed failing on a clean checkout without these changes.

## Notes for reviewers

- Server change requires a `pnpm dev` restart to take effect (electron-dev rebuilds `legalwork-server` via `tsc` at startup; renderer is HMR only).
- Not click-tested end-to-end in the running app; logic verified by unit tests + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)