### PR TITLE
feat(files): workspace file browser in the right side panel

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -420,6 +420,20 @@ export type LegalworkWorkspaceFileStat = {
   updatedAt?: number;
 };
 
+export type LegalworkWorkspaceDirectoryEntry = {
+  name: string;
+  path: string;
+  kind: "file" | "dir";
+  size?: number;
+  updatedAt?: number;
+};
+
+export type LegalworkWorkspaceDirectoryList = {
+  path: string;
+  entries: LegalworkWorkspaceDirectoryEntry[];
+  truncated: boolean;
+};
+
 export type LegalworkInboxItem = {
   id: string;
   name?: string;
@@ -1601,6 +1615,13 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
       requestJson<LegalworkWorkspaceFileContent>(
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/files/content?path=${encodeURIComponent(path)}`,
+        { token, hostToken },
+      ),
+
+    listWorkspaceDirectory: (workspaceId: string, path: string) =>
+      requestJson<LegalworkWorkspaceDirectoryList>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/list?path=${encodeURIComponent(path)}`,
         { token, hostToken },
       ),
 

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -66,7 +66,20 @@ function isTextContent(target: OpenTarget): boolean {
 export function ArtifactPanel({ sessionId, tab, client, workspaceId, workspaceRoot, isRemoteWorkspace = false, onClose }: ArtifactPanelProps) {
   const transcriptTargets = usePanelTabStore((state) => state.transcriptArtifactTargets[sessionId] ?? EMPTY_TRANSCRIPT_TARGETS);
   const artifactTargets = useMemo(() => transcriptTargets.filter(isCollectibleArtifactTarget), [transcriptTargets]);
-  const target = artifactTargets.find((item) => item.id === tab.id) ?? null;
+  // Tabs opened from the workspace file browser carry their own path, so they
+  // stay viewable even when the transcript never mentioned the file.
+  const target = artifactTargets.find((item) => item.id === tab.id) ?? (tab.value ? {
+    id: tab.id,
+    kind: "file",
+    value: tab.value,
+    name: tab.label,
+    preview: tab.preview,
+    confidence: 100,
+    reason: "workspace file",
+    exists: true,
+    size: tab.size,
+    updatedAt: tab.updatedAt,
+  } satisfies OpenTarget : null);
 
   if (!target || !client || !workspaceId) {
     return null;

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -78,7 +78,7 @@ function extname(value: string) {
   return index >= 0 ? name.slice(index) : "";
 }
 
-function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPreview {
+export function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPreview {
   if (kind === "url") return "browser";
   const ext = extname(value);
   if ([".md", ".markdown", ".mdx"].includes(ext)) return "markdown";

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,11 +2,15 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Columns2, FileText, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
+import { Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { LEGALWORK_EXTENSION_CATALOG } from "../../../../app/constants";
-import { type LegalworkServerClient, type LegalworkServerStatus } from "../../../../app/lib/legalwork-server";
+import {
+  type LegalworkServerClient,
+  type LegalworkServerStatus,
+  type LegalworkWorkspaceDirectoryEntry,
+} from "../../../../app/lib/legalwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
 import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -52,10 +56,11 @@ import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
-import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
+import { classifyOpenTarget, isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
 import type { OpenTargetOptions } from "@/lib/target-provider";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
+import { WorkspaceFilesPanel } from "../panel/workspace-files-panel";
 import { TerminalDock } from "../terminal/terminal-dock";
 import { useActivePanelTab, usePanelTabStore, useSessionPanelState } from "../panel/panel-tab-store";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
@@ -310,6 +315,7 @@ export function SessionPage(props: SessionPageProps) {
   const activeSidePanel = voiceSidePanelOpen ? "voice" : sessionSidePanel;
   const sidePanelOpen = activeSidePanel !== null;
   const panelRailActive = activeSidePanel === "panel";
+  const filesRailActive = activeSidePanel === "files";
   const extensionsRailActive = activeSidePanel === "extensions";
   const voiceRailActive = activeSidePanel === "voice";
   const voiceExtension = useMemo(
@@ -557,6 +563,43 @@ export function SessionPage(props: SessionPageProps) {
       toggleCurrentSidePanel("panel");
     }
   }, [artifactFileTargets, hasArtifactTargets, openTab, panelRailActive, props.selectedSessionId, selectTab, sessionPanelState, toggleCurrentSidePanel]);
+  const openFilesRailPane = useCallback(() => {
+    toggleCurrentSidePanel("files");
+  }, [toggleCurrentSidePanel]);
+  const openWorkspaceFileEntry = useCallback((entry: LegalworkWorkspaceDirectoryEntry) => {
+    const preview = classifyOpenTarget(entry.name, "file");
+    if (preview === "external" || preview === "browser") {
+      if (props.selectedWorkspaceDisplay.workspaceType !== "remote" && isElectronRuntime()) {
+        void openDesktopPath(absoluteWorkspacePath(props.selectedWorkspaceRoot, entry.path)).catch(() => undefined);
+      } else {
+        void downloadOpenTarget({
+          id: `file:${entry.path.toLowerCase()}`,
+          kind: "file",
+          value: entry.path,
+          name: entry.name,
+          preview,
+          confidence: 100,
+          reason: "workspace file",
+          exists: true,
+          size: entry.size,
+          updatedAt: entry.updatedAt,
+        }).catch(() => undefined);
+      }
+      return;
+    }
+    if (!props.selectedSessionId) return;
+    openTab(props.selectedSessionId, {
+      id: `file:${entry.path.toLowerCase()}`,
+      type: "artifact",
+      label: entry.name,
+      preview,
+      value: entry.path,
+      size: entry.size,
+      updatedAt: entry.updatedAt,
+    });
+    preserveSidePanelOnPanelOpenRef.current = true;
+    setCurrentSidePanel("panel");
+  }, [downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   const openExtensionsRailPane = useCallback(() => {
     toggleCurrentSidePanel("extensions");
   }, [toggleCurrentSidePanel]);
@@ -1281,6 +1324,15 @@ export function SessionPage(props: SessionPageProps) {
                       sessionId={props.selectedSessionId}
                       onClose={closeRightPane}
                     />
+                  ) : activeSidePanel === "files" ? (
+                    <WorkspaceFilesPanel
+                      key={props.runtimeWorkspaceId ?? "__no_workspace__"}
+                      client={props.legalworkServerClient}
+                      workspaceId={props.runtimeWorkspaceId}
+                      workspaceRoot={props.selectedWorkspaceRoot}
+                      onOpenFile={openWorkspaceFileEntry}
+                      onClose={closeRightPane}
+                    />
                   ) : activeSidePanel === "panel" && props.selectedSessionId ? (
                     <SidePanel
                       sessionId={props.selectedSessionId}
@@ -1347,6 +1399,21 @@ export function SessionPage(props: SessionPageProps) {
                   {artifactTargetCount > 9 ? "9+" : artifactTargetCount}
                 </span>
               ) : null}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={cn(
+                "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
+                filesRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+              )}
+              onClick={openFilesRailPane}
+              title="Workspace files"
+              aria-label="Workspace files"
+              aria-pressed={filesRailActive}
+              disabled={!props.selectedSessionId || !props.legalworkServerClient || !props.runtimeWorkspaceId}
+            >
+              <Folder size={17} />
             </Button>
             <Button
               variant="ghost"

--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -15,6 +15,11 @@ export type ArtifactPanelTab = {
   type: "artifact";
   label: string;
   preview: OpenTargetPreview;
+  // Workspace-relative path for tabs opened directly from the workspace file
+  // browser. Tabs without it resolve through the session's transcript targets.
+  value?: string;
+  size?: number;
+  updatedAt?: number;
 }
 
 export type PanelTab = BrowserPanelTab | ArtifactPanelTab;
@@ -91,7 +96,10 @@ function reconcileOpenArtifactTabs(
       const target = targetMap.get(tab.id);
 
       if (!target) {
-        return null;
+        // Tabs opened from the workspace file browser carry their own path and
+        // are not derived from the transcript — reconciling against transcript
+        // targets must not close them.
+        return tab.value ? tab : null;
       }
 
       return {
@@ -134,7 +142,8 @@ function isSameTab(left: PanelTab, right: PanelTab) {
   if (left.type === "artifact" && right.type === "artifact") {
     return (
       left.label === right.label &&
-      left.preview === right.preview
+      left.preview === right.preview &&
+      left.value === right.value
     );
   }
 

--- a/apps/app/src/react-app/domains/session/panel/workspace-files-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/workspace-files-panel.tsx
@@ -1,0 +1,258 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, ChevronRight, Eye, EyeOff, Folder, FolderOpen, RotateCw, X } from "lucide-react";
+
+import type {
+  LegalworkServerClient,
+  LegalworkWorkspaceDirectoryEntry,
+  LegalworkWorkspaceDirectoryList,
+} from "@/app/lib/legalwork-server";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn, formatFileSize } from "@/lib/utils";
+
+import { ArtifactIcon } from "../artifacts/artifact-icon";
+import { classifyOpenTarget } from "../artifacts/open-target";
+
+type WorkspaceFilesPanelProps = {
+  client: LegalworkServerClient | null;
+  workspaceId: string | null;
+  workspaceRoot: string;
+  onOpenFile: (entry: LegalworkWorkspaceDirectoryEntry) => void;
+  onClose: () => void;
+};
+
+const SKELETON_ROW_WIDTHS = ["56%", "72%", "44%", "64%", "38%", "52%"];
+
+// The panel unmounts whenever the user switches to the preview or another rail
+// pane; remember the folder per workspace so reopening lands where they left off.
+const lastPathByWorkspace = new Map<string, string>();
+
+function workspaceDisplayName(workspaceRoot: string): string {
+  const cleaned = workspaceRoot.trim().replace(/[/\\]+$/, "");
+  const name = cleaned.split(/[/\\]/).filter(Boolean).pop();
+  return name || "Workspace";
+}
+
+export function WorkspaceFilesPanel({
+  client,
+  workspaceId,
+  workspaceRoot,
+  onOpenFile,
+  onClose,
+}: WorkspaceFilesPanelProps) {
+  const [path, setPath] = React.useState(() => (workspaceId ? lastPathByWorkspace.get(workspaceId) ?? "" : ""));
+  const [showHidden, setShowHidden] = React.useState(false);
+
+  React.useEffect(() => {
+    if (workspaceId) {
+      lastPathByWorkspace.set(workspaceId, path);
+    }
+  }, [path, workspaceId]);
+  const breadcrumbsRef = React.useRef<HTMLElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  const { data, error, isError, isLoading, isFetching, refetch } = useQuery<LegalworkWorkspaceDirectoryList>({
+    queryKey: ["workspace-files", workspaceId, path] as const,
+    queryFn: async () => {
+      if (!client || !workspaceId) {
+        throw new Error("Workspace is not connected.");
+      }
+      return client.listWorkspaceDirectory(workspaceId, path);
+    },
+    enabled: Boolean(client && workspaceId),
+    staleTime: 15_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const crumbs = React.useMemo(() => {
+    const segments = path.split("/").filter(Boolean);
+    return [
+      { label: workspaceDisplayName(workspaceRoot), path: "" },
+      ...segments.map((segment, index) => ({
+        label: segment,
+        path: segments.slice(0, index + 1).join("/"),
+      })),
+    ];
+  }, [path, workspaceRoot]);
+
+  const visibleEntries = React.useMemo(() => {
+    const entries = data?.entries ?? [];
+    return showHidden ? entries : entries.filter((entry) => !entry.name.startsWith("."));
+  }, [data?.entries, showHidden]);
+
+  const hiddenCount = (data?.entries.length ?? 0) - visibleEntries.length;
+
+  // Deep paths overflow the breadcrumb bar; keep the current folder in view.
+  React.useEffect(() => {
+    breadcrumbsRef.current?.scrollTo({ left: breadcrumbsRef.current.scrollWidth });
+  }, [path]);
+
+  const navigateTo = React.useCallback((nextPath: string) => {
+    setPath(nextPath);
+    listRef.current?.scrollTo({ top: 0 });
+  }, []);
+
+  return (
+    <TooltipProvider delay={1000}>
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background pe-2 ps-4 mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+            <h3 className="truncate text-sm font-medium text-foreground">Files</h3>
+          </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={(
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setShowHidden((value) => !value)}
+                  aria-label={showHidden ? "Hide hidden files" : "Show hidden files"}
+                  aria-pressed={showHidden}
+                >
+                  {showHidden ? <EyeOff /> : <Eye />}
+                </Button>
+              )}
+            />
+            <TooltipContent>{showHidden ? "Hide hidden files" : "Show hidden files"}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={(
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => void refetch()}
+                  disabled={isFetching}
+                  aria-label="Refresh folder"
+                >
+                  <RotateCw className={cn(isFetching && "animate-spin")} />
+                </Button>
+              )}
+            />
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={(
+                <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close files panel">
+                  <X />
+                </Button>
+              )}
+            />
+            <TooltipContent>Close</TooltipContent>
+          </Tooltip>
+        </div>
+
+        <nav
+          ref={breadcrumbsRef}
+          aria-label="Current folder"
+          className="no-scrollbar flex h-9 shrink-0 items-center gap-0.5 overflow-x-auto whitespace-nowrap border-b border-border/60 bg-background px-2.5"
+        >
+          {crumbs.map((crumb, index) => {
+            const current = index === crumbs.length - 1;
+            return (
+              <React.Fragment key={crumb.path || "__workspace_root__"}>
+                {index > 0 ? <ChevronRight className="size-3 shrink-0 text-muted-foreground/50" /> : null}
+                <button
+                  type="button"
+                  onClick={() => navigateTo(crumb.path)}
+                  disabled={current}
+                  aria-current={current ? "location" : undefined}
+                  className={cn(
+                    "shrink-0 rounded-md px-1.5 py-0.5 text-xs transition-colors",
+                    current
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {crumb.label}
+                </button>
+              </React.Fragment>
+            );
+          })}
+        </nav>
+
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto p-1.5">
+          {isLoading ? (
+            <div className="space-y-0.5">
+              {SKELETON_ROW_WIDTHS.map((width, index) => (
+                <div key={index} className="flex items-center gap-2.5 px-2.5 py-2">
+                  <Skeleton className="size-4 shrink-0 rounded" />
+                  <Skeleton className="h-3.5 rounded" style={{ width }} />
+                </div>
+              ))}
+            </div>
+          ) : isError ? (
+            <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+              <AlertCircle className="size-7 text-muted-foreground/50" strokeWidth={1.5} />
+              <p className="text-sm text-muted-foreground">
+                {error instanceof Error ? error.message : "Failed to load this folder."}
+              </p>
+              <Button variant="outline" size="sm" onClick={() => void refetch()}>
+                Try again
+              </Button>
+            </div>
+          ) : visibleEntries.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+              <FolderOpen className="size-8 text-muted-foreground/40" strokeWidth={1.5} />
+              <p className="text-sm text-muted-foreground">This folder is empty</p>
+              {hiddenCount > 0 ? (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground/70 underline-offset-2 hover:underline"
+                  onClick={() => setShowHidden(true)}
+                >
+                  Show {hiddenCount} hidden {hiddenCount === 1 ? "item" : "items"}
+                </button>
+              ) : null}
+            </div>
+          ) : (
+            <>
+              {visibleEntries.map((entry) => (
+                <button
+                  key={entry.path}
+                  type="button"
+                  onClick={() => (entry.kind === "dir" ? navigateTo(entry.path) : onOpenFile(entry))}
+                  title={entry.name}
+                  className="group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  {entry.kind === "dir" ? (
+                    <Folder className="size-4 shrink-0 fill-sky-9/15 text-sky-9" />
+                  ) : (
+                    <ArtifactIcon type={classifyOpenTarget(entry.name, "file")} className="size-4" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">{entry.name}</span>
+                  {entry.kind === "dir" ? (
+                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100" />
+                  ) : entry.size !== undefined ? (
+                    <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                      {formatFileSize(entry.size)}
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+              {data?.truncated ? (
+                <p className="px-2.5 py-2 text-center text-[11px] text-muted-foreground/70">
+                  This folder has more entries than can be shown.
+                </p>
+              ) : null}
+              {!showHidden && hiddenCount > 0 ? (
+                <button
+                  type="button"
+                  className="w-full px-2.5 py-2 text-center text-[11px] text-muted-foreground/70 underline-offset-2 hover:underline"
+                  onClick={() => setShowHidden(true)}
+                >
+                  {hiddenCount} hidden {hiddenCount === 1 ? "item" : "items"}
+                </button>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -14,7 +14,7 @@ export const DEFAULT_WORKSPACE_RIGHT_SIDEBAR_EXPANDED_WIDTH = 520;
 export const MIN_WORKSPACE_RIGHT_SIDEBAR_WIDTH = 320;
 export const MAX_WORKSPACE_RIGHT_SIDEBAR_WIDTH = 960;
 
-export const SIDE_PANEL_ITEMS = ["panel", "extensions", "voice"] as const;
+export const SIDE_PANEL_ITEMS = ["panel", "files", "extensions", "voice"] as const;
 export type SidePanelItem = (typeof SIDE_PANEL_ITEMS)[number];
 export type SidePanelState = Record<string, SidePanelItem | null>;
 

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -109,4 +109,37 @@ describe("artifact file routes", () => {
     expect(xlsxDownload.status).toBe(200);
     expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
   });
+
+  test("lists workspace directories with dirs-first ordering and path safety", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startLegalworkServer(root);
+
+    const rootList = await fetch(`${base}/workspace/ws_1/files/list`, { headers: auth(token) });
+    expect(rootList.status).toBe(200);
+    const rootListing = await rootList.json() as { path: string; entries: Array<any>; truncated: boolean };
+    expect(rootListing.path).toBe("");
+    expect(rootListing.truncated).toBe(false);
+    expect(rootListing.entries.map((entry) => entry.name)).toContain("reports");
+    expect(rootListing.entries.find((entry) => entry.name === "reports")).toMatchObject({ kind: "dir", path: "reports" });
+
+    const reportsList = await fetch(`${base}/workspace/ws_1/files/list?path=${encodeURIComponent("reports")}`, { headers: auth(token) });
+    expect(reportsList.status).toBe(200);
+    const reportsListing = await reportsList.json() as { path: string; entries: Array<any> };
+    expect(reportsListing.path).toBe("reports");
+    const csvEntry = reportsListing.entries.find((entry) => entry.name === "artifact-eval.csv");
+    expect(csvEntry).toMatchObject({ kind: "file", path: "reports/artifact-eval.csv" });
+    expect(csvEntry.size).toBeGreaterThan(0);
+    expect(csvEntry.updatedAt).toBeGreaterThan(0);
+    const names = reportsListing.entries.map((entry) => entry.name);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base", numeric: true })));
+
+    const fileList = await fetch(`${base}/workspace/ws_1/files/list?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
+    expect(fileList.status).toBe(400);
+
+    const escapeList = await fetch(`${base}/workspace/ws_1/files/list?path=${encodeURIComponent("../..")}`, { headers: auth(token) });
+    expect(escapeList.status).toBe(400);
+
+    const missingList = await fetch(`${base}/workspace/ws_1/files/list?path=${encodeURIComponent("does-not-exist")}`, { headers: auth(token) });
+    expect(missingList.status).toBe(404);
+  });
 });

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -16,6 +16,7 @@ const FILE_SESSION_MAX_BATCH_ITEMS = 64;
 const FILE_SESSION_MAX_FILE_BYTES = 5_000_000;
 const FILE_SESSION_CATALOG_DEFAULT_LIMIT = 2000;
 const FILE_SESSION_CATALOG_MAX_LIMIT = 10000;
+const FILE_LIST_MAX_ENTRIES = 2000;
 
 type JsonResponse = (data: unknown, status?: number) => Response;
 type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
@@ -1066,6 +1067,56 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
       kind: info.isFile() ? "file" : info.isDirectory() ? "dir" : "other",
       size: info.size,
       updatedAt: info.mtimeMs,
+    });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/files/list", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    // An empty path lists the workspace root; normalizeWorkspaceRelativePath rejects it.
+    const relativePath = requested ? normalizeWorkspaceRelativePath(requested, { allowSubdirs: true }) : "";
+    const absPath = relativePath ? resolveSafeChildPath(workspace.path, relativePath) : resolve(workspace.path);
+    if (!(await exists(absPath))) {
+      throw new ApiError(404, "dir_not_found", "Directory not found");
+    }
+    const info = await stat(absPath);
+    if (!info.isDirectory()) {
+      throw new ApiError(400, "invalid_path", "Path must point to a directory");
+    }
+
+    const dirents = await readdir(absPath, { withFileTypes: true });
+    type DirectoryEntry = { name: string; path: string; kind: "file" | "dir"; size?: number; updatedAt?: number };
+    const entries = (
+      await Promise.all(
+        dirents.map(async (dirent): Promise<DirectoryEntry | null> => {
+          const entryPath = relativePath ? `${relativePath}/${dirent.name}` : dirent.name;
+          try {
+            const entryInfo = await stat(join(absPath, dirent.name));
+            if (entryInfo.isDirectory()) {
+              return { name: dirent.name, path: entryPath, kind: "dir" };
+            }
+            if (entryInfo.isFile()) {
+              return { name: dirent.name, path: entryPath, kind: "file", size: entryInfo.size, updatedAt: entryInfo.mtimeMs };
+            }
+          } catch {
+            // Broken symlinks and entries deleted mid-listing just drop out.
+          }
+          return null;
+        }),
+      )
+    ).filter((entry): entry is DirectoryEntry => entry !== null);
+
+    entries.sort((left, right) => (
+      left.kind === right.kind
+        ? left.name.localeCompare(right.name, undefined, { sensitivity: "base", numeric: true })
+        : left.kind === "dir" ? -1 : 1
+    ));
+
+    const truncated = entries.length > FILE_LIST_MAX_ENTRIES;
+    return jsonResponse({
+      path: relativePath,
+      entries: truncated ? entries.slice(0, FILE_LIST_MAX_ENTRIES) : entries,
+      truncated,
     });
   });
 


### PR DESCRIPTION
## What

Adds a workspace file browser to the right side panel:

- A **folder icon in the right rail** (below the Artifacts icon) toggles a new **Files** panel showing the current workspace's contents.
- **Folder navigation is flat (no tree)**: clicking a folder opens it, with **breadcrumbs** above tracking the path from the workspace root. Deep paths keep the current folder scrolled into view, and the panel remembers your folder per workspace when you switch panes.
- **Clicking a file opens it in the preview** (the existing artifact viewer): markdown, sheets, docx, images, PDFs, HTML, and plain text all render; unsupported types open externally (or download on remote/web).
- The viewer niceties: color-coded file-type icons, file sizes, dirs-first natural sort, a hidden-files toggle (dotfiles hidden by default with an *N hidden items* hint), and dedicated loading/empty/error states.

## How

- **Server**: new `GET /workspace/:id/files/list?path=` route in `apps/server/src/routes/files.ts` — empty path lists the workspace root, path traversal is rejected via the existing `normalizeWorkspaceRelativePath`/`resolveSafeChildPath` helpers, entries are sorted dirs-first, capped at 2000 with a `truncated` flag. Covered by a new e2e test.
- **Client**: `listWorkspaceDirectory()` on `LegalworkServerClient` + `LegalworkWorkspaceDirectoryEntry/List` types.
- **Panel**: new `WorkspaceFilesPanel` component; `"files"` added to `SIDE_PANEL_ITEMS`; rail button + pane branch in `session-page.tsx`.
- **Artifact tabs**: tabs opened from the file browser carry their own workspace-relative path (`ArtifactPanelTab.value`), so `ArtifactPanel` can render files never mentioned in the transcript and `reconcileOpenArtifactTabs` no longer closes them on transcript sync. Files that are also transcript targets share the same tab id, so no duplicates.

## Verification

Drove the built app end-to-end (legalwork-server binary + web UI in headless Chromium against a scratch workspace): root listing, folder navigation, breadcrumb jumps, markdown/text/image/CSV previews opening as artifact tabs, hidden-file toggle, empty-folder state, folder position remembered after switching to the preview and back. Server route probed directly for traversal (`../..` → 400), file-as-dir (400), and missing dir (404). `bun test src/artifact-files.e2e.test.ts` and both packages' typechecks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)