### PR TITLE
fix(desktop): build word add-in pane bundle into packaged app

### DIFF
--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, cpSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -40,6 +40,17 @@ run(pnpmCmd, ["--filter", "legalwork-server", "build"], repoRoot);
 run(pnpmCmd, ["--filter", "@legalwork/app", "build"], repoRoot, {
   LEGALWORK_ELECTRON_BUILD: "1",
 });
+// Office task pane bundle — electron-builder.yml ships apps/app/dist-word-addin
+// as Resources/word-addin-dist. The dir is gitignored, and electron-builder
+// silently skips a missing extraResources source, so build it here and fail
+// loudly if the entry point is absent (the packaged add-in would otherwise
+// 503 with word_addin_bundle_missing).
+run(pnpmCmd, ["--filter", "@legalwork/app", "build:word-addin"], repoRoot);
+const wordAddinDistDir = resolve(repoRoot, "apps", "app", "dist-word-addin");
+if (!existsSync(resolve(wordAddinDistDir, "taskpane.html"))) {
+  console.error(`Word add-in bundle missing after build: ${wordAddinDistDir}/taskpane.html`);
+  process.exit(1);
+}
 // Copy constants.json next to server dist so the packaged asar can resolve it.
 // Also patch the compiled import path so it works from both dev and packaged layouts.
 const serverDistDir = resolve(repoRoot, "apps", "server", "dist");
@@ -67,6 +78,7 @@ process.stdout.write(
     {
       ok: true,
       renderer: "apps/app/dist",
+      wordAddin: "apps/app/dist-word-addin",
       electronMain: "apps/desktop/electron/main.mjs",
       electronPreload: "apps/desktop/electron/preload.mjs",
     },

--- a/apps/server/src/word-addin.ts
+++ b/apps/server/src/word-addin.ts
@@ -468,7 +468,7 @@ export async function handleWordAddinRequest(input: {
       {
         code: "word_addin_bundle_missing",
         message:
-          "Word add-in bundle not found. Build it with `pnpm --filter legalwork-app build:word-addin` or set --word-addin-dist.",
+          "Word add-in bundle not found. Build it with `pnpm --filter @legalwork/app build:word-addin` or set --word-addin-dist.",
       },
       503,
     );


### PR DESCRIPTION
## Problem

The macOS alpha shipped without the Word add-in task pane bundle. Opening the pane in Word fails with:

```
{"code":"word_addin_bundle_missing","message":"Word add-in bundle not found. ..."}
```

Root cause chain:

- `apps/app/dist-word-addin` is gitignored, so it never exists on a fresh CI checkout.
- `apps/desktop/scripts/electron-build.mjs` builds the server and the renderer app but never ran `build:word-addin`.
- `electron-builder.yml` declares `extraResources: ../app/dist-word-addin → word-addin-dist`, and electron-builder **silently skips** a missing source directory — so the release packaged and published cleanly, minus the pane bundle.
- At runtime the embedded server finds no `taskpane.html` and 503s every pane load.

It worked in dev only because the dist folder existed locally from dev builds.

## Fix

- `electron-build.mjs` now runs `pnpm --filter @legalwork/app build:word-addin` after the renderer build, and **exits non-zero** if `dist-word-addin/taskpane.html` is absent afterwards — a missing pane can never ship silently again. Covers both the alpha and stable workflows (both go through `build:electron`).
- Corrected the package filter in the 503 message (`legalwork-app` → `@legalwork/app`).

## Testing

- Reproduced the CI state locally (`rm -rf apps/app/dist-word-addin`), ran `package:electron:dir`: the packaged app now contains `Resources/word-addin-dist/taskpane.html` + assets. Before the fix, this exact sequence produces the broken alpha.
- Serve-path test against the built artifact: imported the packaged server module (`server/dist/word-addin.js`, the copy packed into app.asar) pointed at the packaged `Resources/word-addin-dist`, and verified `/word-addin/app.html` returns the vite pane HTML (200), its entry script and ribbon icons serve, and the control case (missing dist) still returns the `word_addin_bundle_missing` 503 — proving the test would have caught the shipped alpha.
- Remaining verification after the next alpha is dispatched: inspect the release zip (`Resources/word-addin-dist/` present) and reopen the pane in Word on an updated install (`/word-addin/clear-cache` first if Word cached the error page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)