### PR TITLE
chore(release): stop appending SignPath note to release bodies

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -132,9 +132,6 @@ jobs:
               "- Electron builds use the attached latest-mac.yml updater feed."
           fi
 
-          SIGNPATH_RELEASE_NOTE='*Windows Build free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org)*'
-          printf -v RELEASE_BODY '%s\n\n%s' "$RELEASE_BODY" "$SIGNPATH_RELEASE_NOTE"
-
           draft="${INPUT_DRAFT:-}"
           if [ -z "$draft" ]; then
             if [ "${GITHUB_EVENT_NAME}" = "push" ]; then


### PR DESCRIPTION
## What

Removes the two lines in the `resolve-release` job of `.github/workflows/release-macos-aarch64.yml` that unconditionally appended the SignPath attribution footer (`*Windows Build free code signing provided by SignPath.io...*`) to every release body. Release descriptions are now published exactly as passed in via `workflow_dispatch` (or the generated default for tag pushes).

## Why

We currently don't sign the Windows build through SignPath, so the attribution note in the release notes was inaccurate. If we start signing via SignPath Foundation's OSS program again, the attribution requirement comes back — re-add the footer (or a README mention) at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)