### PR TITLE
chore: bump version to 0.0.12

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/app",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "scripts": {
     "test": "bun test tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/desktop",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "LegalWork desktop shell",
   "author": {
     "name": "LegalWork",
@@ -41,5 +41,5 @@
     "electron-devtools-installer": "^4.0.0"
   },
   "packageManager": "pnpm@10.27.0",
-  "opencodeRouterVersion": "0.0.11"
+  "opencodeRouterVersion": "0.0.12"
 }

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-router",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "opencode-router: Slack + Telegram bridge + directory routing for a running opencode server",
   "private": false,
   "type": "module",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-orchestrator",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "LegalWork host orchestrator for opencode + LegalWork server + opencode-router",
   "private": true,
   "type": "module",
@@ -47,8 +47,8 @@
     "@opencode-ai/sdk": "^1.17.3",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "opencode-router": "0.0.11",
-    "legalwork-server": "0.0.11",
+    "opencode-router": "0.0.12",
+    "legalwork-server": "0.0.12",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-server",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Filesystem-backed API for LegalWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,10 +326,10 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       legalwork-server:
-        specifier: 0.0.11
+        specifier: 0.0.12
         version: link:../server
       opencode-router:
-        specifier: 0.0.11
+        specifier: 0.0.12
         version: link:../opencode-router
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
Version bump commit for the v0.0.12 release (created by `pnpm release:prepare`). The `v0.0.12` tag points at this commit and the release build is already running off it; merging with a **merge commit** (not squash/rebase) keeps the tagged commit in dev's history.

Direct push to dev was rejected by the repository ruleset (changes must go through a PR), hence this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)