### PR TITLE
feat(office-addin): Windows support for the Office add-in installer

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/app",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "scripts": {
     "test": "bun test tests/",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/app",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "scripts": {
     "test": "bun test tests/",

--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -18,7 +18,7 @@ const de: Record<string, string> = {
   "office_addins.requires_desktop_title": "Desktop-App erforderlich",
   "office_addins.requires_desktop": "Office-Add-ins können nur aus der LegalWork-Desktop-App installiert werden.",
   "office_addins.unsupported_title": "Auf dieser Plattform noch nicht unterstützt",
-  "office_addins.unsupported_body": "Die Installation des Office-Add-ins wird derzeit unter macOS unterstützt. Windows folgt.",
+  "office_addins.unsupported_body": "Die Installation des Office-Add-ins wird unter macOS und Windows unterstützt.",
   "office_addins.status_title": "LegalWork-Add-in",
   "office_addins.status_enabled": "Installiert und aktiv.",
   "office_addins.status_disabled": "Nicht installiert.",
@@ -43,21 +43,27 @@ const de: Record<string, string> = {
   "office_addins.cert_prompt_title": "Sichere lokale Verbindung einrichten",
   "office_addins.cert_prompt_body":
     "LegalWork erstellt ein privates Zertifikat, damit Office auf deinem Mac über eine sichere Verbindung mit dieser App kommunizieren kann. macOS fragt einmalig nach deinem Passwort, um dieses Zertifikat als vertrauenswürdig einzustufen.",
+  "office_addins.cert_prompt_body_windows":
+    "LegalWork erstellt ein privates Zertifikat, damit Office über eine sichere Verbindung mit dieser App kommunizieren kann. Windows zeigt einmalig einen Sicherheitsdialog, in dem du die Aufnahme in die vertrauenswürdigen Zertifikate bestätigst.",
   "office_addins.restart_title": "Installation erfolgreich",
   "office_addins.restart_body":
     "Beende {app} vollständig (Cmd+Q) und öffne es erneut. LegalWork erscheint dann unter Start → Add-ins.",
+  "office_addins.restart_body_windows":
+    "Schließe {app} vollständig und öffne es erneut. LegalWork erscheint dann unter Start → Add-ins.",
   "office_addins.restart_note":
     "LegalWork muss geöffnet sein, damit das Add-in funktioniert. Lass die App daher beim Arbeiten laufen.",
   "office_addins.restart_ok": "Verstanden",
   "office_addins.uninstall_prompt_title": "Sichere lokale Verbindung entfernen",
   "office_addins.uninstall_prompt_body":
     "Dies ist das letzte installierte Office-Add-in. LegalWork entfernt daher auch sein privates Zertifikat von deinem Mac. macOS fragt dabei eventuell einmalig nach deinem Passwort.",
+  "office_addins.uninstall_prompt_body_windows":
+    "Dies ist das letzte installierte Office-Add-in. LegalWork entfernt daher auch sein privates Zertifikat aus Windows. Windows bittet dich dabei eventuell um eine Bestätigung.",
   "office_addins.install_success": "Office-Add-in installiert. Starte Word/Excel/PowerPoint neu, falls geöffnet.",
   "office_addins.install_failed": "Das Office-Add-in konnte nicht installiert werden.",
   "office_addins.uninstall_success": "Office-Add-in entfernt.",
   "office_addins.uninstall_failed": "Das Office-Add-in konnte nicht entfernt werden.",
   "office_addins.install_hint":
-    "Bei der Installation wird ein nur für localhost gültiges Zertifikat erzeugt und vom Betriebssystem als vertrauenswürdig eingestuft (eine Passwortabfrage); danach wird das Add-in zu deinen Office-Apps hinzugefügt.",
+    "Bei der Installation wird ein nur für localhost gültiges Zertifikat erzeugt und vom Betriebssystem als vertrauenswürdig eingestuft (eine einmalige Bestätigung); danach wird das Add-in zu deinen Office-Apps hinzugefügt.",
 
   /* ---- Common actions ---- */
   "common.add": "Hinzufügen",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -12,7 +12,7 @@ export default {
   "office_addins.requires_desktop_title": "Desktop app required",
   "office_addins.requires_desktop": "Office add-ins can only be installed from the LegalWork desktop app.",
   "office_addins.unsupported_title": "Not supported on this platform yet",
-  "office_addins.unsupported_body": "Installing the Office add-in is currently supported on macOS. Windows support is coming.",
+  "office_addins.unsupported_body": "Installing the Office add-in is supported on macOS and Windows.",
   "office_addins.status_title": "LegalWork add-in",
   "office_addins.status_enabled": "Installed and running.",
   "office_addins.status_disabled": "Not installed.",
@@ -37,21 +37,27 @@ export default {
   "office_addins.cert_prompt_title": "Set up the secure local connection",
   "office_addins.cert_prompt_body":
     "LegalWork will create a private certificate so Office can talk to this app over a secure connection on your Mac. macOS will ask for your password once to mark that certificate as trusted.",
+  "office_addins.cert_prompt_body_windows":
+    "LegalWork will create a private certificate so Office can talk to this app over a secure connection. Windows will show one security dialog asking you to confirm adding it to your trusted certificates.",
   "office_addins.restart_title": "Installation successful",
   "office_addins.restart_body":
     "Quit {app} completely (Cmd+Q) and reopen it. LegalWork will appear under Home → Add-ins.",
+  "office_addins.restart_body_windows":
+    "Close {app} completely and reopen it. LegalWork will appear under Home → Add-ins.",
   "office_addins.restart_note":
     "LegalWork has to be running for the add-in to work, so keep the app open while you use it.",
   "office_addins.restart_ok": "OK",
   "office_addins.uninstall_prompt_title": "Remove the secure local connection",
   "office_addins.uninstall_prompt_body":
     "This is the last installed Office add-in, so LegalWork will also remove its private certificate from your Mac. macOS may ask for your password once.",
+  "office_addins.uninstall_prompt_body_windows":
+    "This is the last installed Office add-in, so LegalWork will also remove its private certificate from Windows. Windows may ask you to confirm the removal.",
   "office_addins.install_success": "Office add-in installed. Restart Word/Excel/PowerPoint if they are open.",
   "office_addins.install_failed": "Could not install the Office add-in.",
   "office_addins.uninstall_success": "Office add-in removed.",
   "office_addins.uninstall_failed": "Could not remove the Office add-in.",
   "office_addins.install_hint":
-    "Installing generates a localhost-only certificate and asks your OS to trust it (one password prompt), then adds the add-in to your Office apps.",
+    "Installing generates a localhost-only certificate and asks your OS to trust it (a one-time confirmation), then adds the add-in to your Office apps.",
   "app.compact_command_desc": "Summarize this session to reduce context size.",
   "app.error_audit_load": "Failed to load audit log.",
   "app.error_auth_failed": "Authentication failed",

--- a/apps/app/src/react-app/domains/settings/pages/office-addins-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/office-addins-view.tsx
@@ -131,6 +131,8 @@ export function OfficeAddinsView() {
 
   const busy = installMutation.isPending || uninstallMutation.isPending;
   const status = statusQuery.data;
+  /** The trust-store prompts differ: keychain password on macOS, a security dialog on Windows. */
+  const isWindows = status?.platform === "win32";
 
   if (!desktop) {
     return (
@@ -245,7 +247,7 @@ export function OfficeAddinsView() {
             <DialogTitle>{t("office_addins.cert_prompt_title")}</DialogTitle>
           </DialogHeader>
           <p className="text-sm leading-relaxed text-dls-secondary">
-            {t("office_addins.cert_prompt_body")}
+            {t(isWindows ? "office_addins.cert_prompt_body_windows" : "office_addins.cert_prompt_body")}
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmApp(null)}>
@@ -275,7 +277,11 @@ export function OfficeAddinsView() {
             <DialogTitle>{t("office_addins.uninstall_prompt_title")}</DialogTitle>
           </DialogHeader>
           <p className="text-sm leading-relaxed text-dls-secondary">
-            {t("office_addins.uninstall_prompt_body")}
+            {t(
+              isWindows
+                ? "office_addins.uninstall_prompt_body_windows"
+                : "office_addins.uninstall_prompt_body",
+            )}
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmUninstallApp(null)}>
@@ -305,7 +311,9 @@ export function OfficeAddinsView() {
             <DialogTitle>{t("office_addins.restart_title", { app: restartApp ?? "" })}</DialogTitle>
           </DialogHeader>
           <p className="text-sm leading-relaxed text-dls-secondary">
-            {t("office_addins.restart_body", { app: restartApp ?? "" })}
+            {t(isWindows ? "office_addins.restart_body_windows" : "office_addins.restart_body", {
+              app: restartApp ?? "",
+            })}
           </p>
           <p className="flex items-start gap-2 text-sm leading-relaxed text-dls-secondary">
             <TriangleAlert size={16} className="mt-0.5 shrink-0 text-amber-11" />

--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -1,0 +1,32 @@
+; LegalWork NSIS customizations (electron-builder `nsis.include`).
+;
+; Uninstall cleanup for the Office add-in: the settings tab registers
+; per-app manifests under HKCU\...\WEF\Developer and trusts a localhost-
+; constrained CA in the CurrentUser Root store. Without this cleanup an
+; uninstalled LegalWork would leave Word/Excel/PowerPoint pointing at a
+; manifest that no longer resolves, plus a stray trusted CA.
+;
+; Everything is best-effort (the user may never have installed the add-in),
+; and skipped during in-place updates so auto-updates never touch the
+; registrations or prompt the user.
+;
+; Manifest ids: keep in sync with WORD_ADDIN_MANIFEST_IDS in
+; apps/server/src/word-addin.ts and apps/desktop/electron/office-addin-platform.mjs.
+
+!macro customUnInstall
+  ${ifNot} ${isUpdated}
+    DetailPrint "Removing LegalWork Office add-in registrations..."
+    ; Word
+    ExecWait 'reg delete "HKCU\Software\Microsoft\Office\16.0\WEF\Developer" /v "fdea378d-ff62-4a4f-af08-d1622c083957" /f'
+    ; Excel
+    ExecWait 'reg delete "HKCU\Software\Microsoft\Office\16.0\WEF\Developer" /v "65facd67-9deb-4356-8072-e2cc6e36d9fe" /f'
+    ; PowerPoint
+    ExecWait 'reg delete "HKCU\Software\Microsoft\Office\16.0\WEF\Developer" /v "db1cc438-a239-4b01-b732-2ff838ecca38" /f'
+    ; Remove the localhost-constrained CA from the user trust store. When the
+    ; CA is present Windows shows one confirmation dialog; denying it keeps
+    ; the CA (the user's call). When absent certutil fails fast and silently.
+    ; Two passes sweep a stale duplicate from older installs.
+    ExecWait 'certutil -user -delstore Root "LegalWork Local CA"'
+    ExecWait 'certutil -user -delstore Root "LegalWork Local CA"'
+  ${endIf}
+!macroend

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -101,4 +101,8 @@ win:
         - versions.json-x86_64-pc-windows-msvc.exe
   target:
     - nsis
+# Uninstall cleanup for the Office add-in (registry sideload entries and the
+# trusted local CA) — see build/installer.nsh.
+nsis:
+  include: build/installer.nsh
 artifactName: legalwork-${os}-${arch}-${version}.${ext}

--- a/apps/desktop/electron/office-addin-cert-web.mjs
+++ b/apps/desktop/electron/office-addin-cert-web.mjs
@@ -1,0 +1,196 @@
+/**
+ * Pure-JS certificate generation for the Office add-in — the Windows path.
+ *
+ * Windows has no system OpenSSL, so the localhost-constrained CA and leaf
+ * are generated with @peculiar/x509 on top of Node's native webcrypto (key
+ * generation and signing run in BoringSSL, not JS). macOS does NOT use this
+ * module — office-addin-cert.mjs keeps shelling out to the system LibreSSL
+ * there and only imports this file on win32.
+ *
+ * The output must stay semantically identical to the OpenSSL path in
+ * office-addin-cert.mjs (same file names, subjects, validity windows, and
+ * the critical localhost/loopback name constraint). The cross-generator
+ * guarantees live in office-addin-cert-web.test.mjs, which verifies these
+ * certificates — including the name-constraint rejection of a non-localhost
+ * leaf — with the system OpenSSL verifier.
+ */
+import { randomBytes, webcrypto } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Must precede @peculiar/x509: its DI container (tsyringe) needs the
+// Reflect.metadata polyfill at load time.
+import "reflect-metadata";
+
+import { AsnConvert } from "@peculiar/asn1-schema";
+import {
+  GeneralName,
+  GeneralSubtree,
+  GeneralSubtrees,
+  NameConstraints,
+  id_ce_nameConstraints,
+} from "@peculiar/asn1-x509";
+import * as x509 from "@peculiar/x509";
+
+// Node's webcrypto implements the WebCrypto API, but its TS type lags the
+// DOM lib's (Ed25519 overloads); the runtime object is compatible.
+x509.cryptoProvider.set(/** @type {Crypto} */ (/** @type {unknown} */ (webcrypto)));
+
+// Keep in sync with the OpenSSL constants in office-addin-cert.mjs.
+const CA_SUBJECT = "CN=LegalWork Local CA, O=LegalWork";
+const LEAF_SUBJECT = "CN=localhost, O=LegalWork";
+const CA_VALID_DAYS = 825;
+const LEAF_VALID_DAYS = 397;
+
+/** Tolerate clocks that are slightly ahead of this machine. */
+const CLOCK_SKEW_MS = 5 * 60_000;
+
+const RSA_ALG = {
+  name: "RSASSA-PKCS1-v1_5",
+  hash: "SHA-256",
+  publicExponent: new Uint8Array([1, 0, 1]),
+  modulusLength: 2048,
+};
+
+const LOCALHOST_ALT_NAMES = [
+  { type: "dns", value: "localhost" },
+  { type: "ip", value: "127.0.0.1" },
+  { type: "ip", value: "::1" },
+];
+
+function validityWindow(days) {
+  const now = Date.now();
+  return {
+    notBefore: new Date(now - CLOCK_SKEW_MS),
+    notAfter: new Date(now + days * 24 * 60 * 60 * 1000),
+  };
+}
+
+/** Random positive serial (DER INTEGER must not be negative or zero). */
+function randomSerialNumber() {
+  const bytes = randomBytes(16);
+  bytes[0] &= 0x7f;
+  bytes[0] |= 0x01;
+  return bytes.toString("hex");
+}
+
+/**
+ * The critical name constraint that bounds the CA to loopback names — the
+ * JS equivalent of the OpenSSL config in office-addin-cert.mjs
+ * (`permitted;DNS:localhost, permitted;IP:127.0.0.1/…, permitted;IP:::1/…`).
+ * CIDR strings serialize to the address+mask octets RFC 5280 requires.
+ */
+function localhostNameConstraintsExtension() {
+  const constraints = new NameConstraints({
+    permittedSubtrees: new GeneralSubtrees([
+      new GeneralSubtree({ base: new GeneralName({ dNSName: "localhost" }) }),
+      new GeneralSubtree({ base: new GeneralName({ iPAddress: "127.0.0.1/32" }) }),
+      new GeneralSubtree({ base: new GeneralName({ iPAddress: "::1/128" }) }),
+    ]),
+  });
+  return new x509.Extension(id_ce_nameConstraints, true, AsnConvert.serialize(constraints));
+}
+
+function generateRsaKeyPair() {
+  return webcrypto.subtle.generateKey(RSA_ALG, true, ["sign", "verify"]);
+}
+
+async function exportPrivateKeyPem(privateKey) {
+  const pkcs8 = await webcrypto.subtle.exportKey("pkcs8", privateKey);
+  return x509.PemConverter.encode(pkcs8, "PRIVATE KEY");
+}
+
+async function issueLeaf({ caCert, caPrivateKey, subject, altNames, validDays }) {
+  const keys = await generateRsaKeyPair();
+  const { notBefore, notAfter } = validityWindow(validDays);
+  const cert = await x509.X509CertificateGenerator.create({
+    serialNumber: randomSerialNumber(),
+    subject,
+    issuer: caCert.subject,
+    notBefore,
+    notAfter,
+    signingAlgorithm: RSA_ALG,
+    publicKey: keys.publicKey,
+    signingKey: caPrivateKey,
+    extensions: [
+      new x509.BasicConstraintsExtension(false, undefined, true),
+      new x509.KeyUsagesExtension(
+        x509.KeyUsageFlags.digitalSignature | x509.KeyUsageFlags.keyEncipherment,
+        true,
+      ),
+      new x509.ExtendedKeyUsageExtension([x509.ExtendedKeyUsage.serverAuth], false),
+      new x509.SubjectAlternativeNameExtension(altNames, false),
+      await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+    ],
+  });
+  return { cert, keys };
+}
+
+/**
+ * Generate the name-constrained CA plus the localhost leaf and write all
+ * four PEM files. Not idempotent by itself — office-addin-cert.mjs decides
+ * when regeneration is needed (same contract as the OpenSSL path).
+ */
+export async function generateLocalCertWeb({ caCertPath, caKeyPath, leafCertPath, leafKeyPath }) {
+  const caKeys = await generateRsaKeyPair();
+  const { notBefore, notAfter } = validityWindow(CA_VALID_DAYS);
+  const caCert = await x509.X509CertificateGenerator.create({
+    serialNumber: randomSerialNumber(),
+    subject: CA_SUBJECT,
+    issuer: CA_SUBJECT,
+    notBefore,
+    notAfter,
+    signingAlgorithm: RSA_ALG,
+    publicKey: caKeys.publicKey,
+    signingKey: caKeys.privateKey,
+    extensions: [
+      new x509.BasicConstraintsExtension(true, 0, true),
+      new x509.KeyUsagesExtension(
+        x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+        true,
+      ),
+      localhostNameConstraintsExtension(),
+      await x509.SubjectKeyIdentifierExtension.create(caKeys.publicKey),
+    ],
+  });
+
+  const leaf = await issueLeaf({
+    caCert,
+    caPrivateKey: caKeys.privateKey,
+    subject: LEAF_SUBJECT,
+    altNames: LOCALHOST_ALT_NAMES,
+    validDays: LEAF_VALID_DAYS,
+  });
+
+  writeFileSync(caCertPath, caCert.toString("pem"), "utf8");
+  writeFileSync(caKeyPath, await exportPrivateKeyPem(caKeys.privateKey), "utf8");
+  writeFileSync(leafCertPath, leaf.cert.toString("pem"), "utf8");
+  writeFileSync(leafKeyPath, await exportPrivateKeyPem(leaf.keys.privateKey), "utf8");
+
+  return { caCertPath, caKeyPath, leafCertPath, leafKeyPath };
+}
+
+/**
+ * Sign an arbitrary-SAN leaf with an existing JS-generated CA.
+ * Test/diagnostic helper mirroring signLeafForTest in office-addin-cert.mjs:
+ * proves the name constraint by attempting a non-localhost cert (which must
+ * fail chain verification even though the signature is valid).
+ */
+export async function signLeafForTestWeb(dir, altNames, subjectCommonName = "test") {
+  const caCertPem = readFileSync(join(dir, "legalwork-local-ca.crt"), "utf8");
+  const caKeyPem = readFileSync(join(dir, "legalwork-local-ca.key"), "utf8");
+  const caCert = new x509.X509Certificate(caCertPem);
+  const [caKeyDer] = x509.PemConverter.decode(caKeyPem);
+  const caPrivateKey = await webcrypto.subtle.importKey("pkcs8", caKeyDer, RSA_ALG, false, ["sign"]);
+
+  const leaf = await issueLeaf({
+    caCert,
+    caPrivateKey,
+    subject: `CN=${subjectCommonName}`,
+    altNames,
+    validDays: 30,
+  });
+  const certPath = join(dir, "test-leaf.crt");
+  writeFileSync(certPath, leaf.cert.toString("pem"), "utf8");
+  return certPath;
+}

--- a/apps/desktop/electron/office-addin-cert-web.test.mjs
+++ b/apps/desktop/electron/office-addin-cert-web.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * Cross-generator guarantees for the pure-JS (Windows) certificate path:
+ * everything the OpenSSL-generated certificates must satisfy is asserted
+ * here against the JS-generated ones, using the system OpenSSL as the
+ * independent verifier — including the localhost name-constraint proof.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSecureContext } from "node:tls";
+
+import { leafCertValidNode } from "./office-addin-cert.mjs";
+import { generateLocalCertWeb, signLeafForTestWeb } from "./office-addin-cert-web.mjs";
+
+const OPENSSL = process.env.LEGALWORK_OPENSSL_BIN?.trim() || "openssl";
+const opensslAvailable = (() => {
+  try {
+    return spawnSync(OPENSSL, ["version"], { encoding: "utf8", timeout: 10_000 }).status === 0;
+  } catch {
+    return false;
+  }
+})();
+
+function certPaths(dir) {
+  return {
+    caCertPath: join(dir, "legalwork-local-ca.crt"),
+    caKeyPath: join(dir, "legalwork-local-ca.key"),
+    leafCertPath: join(dir, "localhost.crt"),
+    leafKeyPath: join(dir, "localhost.key"),
+  };
+}
+
+function opensslVerify(caCertPath, leafCertPath) {
+  return (
+    spawnSync(OPENSSL, ["verify", "-CAfile", caCertPath, leafCertPath], {
+      encoding: "utf8",
+      timeout: 30_000,
+    }).status === 0
+  );
+}
+
+test("JS-generated localhost leaf chains to the CA (openssl cross-check)", { skip: !opensslAvailable }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "lw-certweb-ok-"));
+  try {
+    const paths = certPaths(dir);
+    await generateLocalCertWeb(paths);
+    assert.ok(
+      opensslVerify(paths.caCertPath, paths.leafCertPath),
+      "openssl must accept the JS-generated localhost chain",
+    );
+    // SAN must cover the names the manifest points Office at.
+    const text = spawnSync(OPENSSL, ["x509", "-in", paths.leafCertPath, "-noout", "-text"], {
+      encoding: "utf8",
+      timeout: 30_000,
+    }).stdout;
+    assert.match(text, /DNS:localhost/);
+    assert.match(text, /IP Address:127\.0\.0\.1/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JS CA name constraint rejects a non-localhost certificate (openssl)", { skip: !opensslAvailable }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "lw-certweb-evil-"));
+  try {
+    const paths = certPaths(dir);
+    await generateLocalCertWeb(paths);
+
+    // A well-formed, CA-signed cert for a real domain — the signature is
+    // valid, but the name constraint must make chain verification fail.
+    const evilCert = await signLeafForTestWeb(
+      dir,
+      [{ type: "dns", value: "evil.example.com" }],
+      "evil.example.com",
+    );
+    assert.equal(
+      opensslVerify(paths.caCertPath, evilCert),
+      false,
+      "a cert for evil.example.com must NOT validate against a localhost-constrained CA",
+    );
+
+    // Sanity: a second localhost cert from the same CA still validates.
+    const okCert = await signLeafForTestWeb(
+      dir,
+      [
+        { type: "dns", value: "localhost" },
+        { type: "ip", value: "127.0.0.1" },
+      ],
+      "localhost",
+    );
+    assert.ok(opensslVerify(paths.caCertPath, okCert), "a localhost cert must still validate");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("leafCertValidNode validates the JS pair and rejects a foreign CA", async () => {
+  const dirA = mkdtempSync(join(tmpdir(), "lw-certweb-node-a-"));
+  const dirB = mkdtempSync(join(tmpdir(), "lw-certweb-node-b-"));
+  try {
+    const a = certPaths(dirA);
+    const b = certPaths(dirB);
+    await generateLocalCertWeb(a);
+    await generateLocalCertWeb(b);
+    assert.ok(leafCertValidNode(a.leafCertPath, a.caCertPath), "own chain must validate");
+    assert.equal(
+      leafCertValidNode(a.leafCertPath, b.caCertPath),
+      false,
+      "a leaf must not validate against another install's CA",
+    );
+  } finally {
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  }
+});
+
+test("the HTTPS listener can consume the JS-generated key pair", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "lw-certweb-tls-"));
+  try {
+    const paths = certPaths(dir);
+    await generateLocalCertWeb(paths);
+    // Throws on a cert/key mismatch or unparsable PEM.
+    createSecureContext({
+      cert: readFileSync(paths.leafCertPath, "utf8"),
+      key: readFileSync(paths.leafKeyPath, "utf8"),
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/electron/office-addin-cert.mjs
+++ b/apps/desktop/electron/office-addin-cert.mjs
@@ -8,11 +8,17 @@
  * mint certificates for real domains — modern macOS/Windows enforce the
  * constraint — so trusting it in the OS store is a bounded decision.
  *
- * Generation shells out to OpenSSL (present on macOS; on Windows this needs
- * a bundled openssl or a JS fallback — see officeAddinCertToolAvailable).
+ * On macOS generation shells out to the system OpenSSL (LibreSSL). Windows
+ * has no system OpenSSL, so there — and only there — generation and
+ * validation run in pure JS (office-addin-cert-web.mjs, loaded lazily so
+ * macOS never touches it). Both generators produce the same certificate
+ * shape; office-addin-cert-web.test.mjs proves the JS output against the
+ * OpenSSL verifier.
  */
 import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { platform } from "node:os";
 import { join } from "node:path";
 
 const CA_SUBJECT = "/CN=LegalWork Local CA/O=LegalWork";
@@ -38,8 +44,12 @@ function runOpenssl(args, input) {
   return result;
 }
 
-/** True when the OpenSSL binary needed for generation is callable. */
+/**
+ * True when certificate generation can work here: always on Windows (pure
+ * JS), otherwise when the OpenSSL binary is callable.
+ */
 export function officeAddinCertToolAvailable() {
+  if (platform() === "win32") return true;
   try {
     const result = spawnSync(opensslBin(), ["version"], { encoding: "utf8", timeout: 10_000 });
     return result.status === 0;
@@ -86,7 +96,7 @@ const LOCALHOST_ALT_NAMES = "DNS:localhost, IP:127.0.0.1, IP:::1";
  * in `dir`. Idempotent: existing valid material is kept. Returns absolute
  * paths for the CA, leaf cert, and leaf key.
  */
-export function ensureLocalCert(dir, { force = false } = {}) {
+export async function ensureLocalCert(dir, { force = false } = {}) {
   mkdirSync(dir, { recursive: true });
   const caKeyPath = join(dir, "legalwork-local-ca.key");
   const caCertPath = join(dir, "legalwork-local-ca.crt");
@@ -98,6 +108,11 @@ export function ensureLocalCert(dir, { force = false } = {}) {
     existsSync(caKeyPath) && existsSync(caCertPath) && existsSync(leafKeyPath) && existsSync(leafCertPath);
   if (complete && !force && leafCertValid(leafCertPath, caCertPath)) {
     return { caCertPath, caKeyPath, leafCertPath, leafKeyPath };
+  }
+
+  if (platform() === "win32") {
+    const { generateLocalCertWeb } = await import("./office-addin-cert-web.mjs");
+    return generateLocalCertWeb({ caCertPath, caKeyPath, leafCertPath, leafKeyPath });
   }
 
   writeFileSync(extPath, `${REQ_SHIM}\n${CA_EXTENSIONS}\n${leafExtensions(LOCALHOST_ALT_NAMES)}\n`, "utf8");
@@ -132,9 +147,30 @@ export function ensureLocalCert(dir, { force = false } = {}) {
   return { caCertPath, caKeyPath, leafCertPath, leafKeyPath };
 }
 
+/**
+ * Signature/expiry validation of the local pair via node:crypto — used on
+ * Windows where OpenSSL is unavailable. This gates regeneration; the name
+ * constraint itself is enforced by the OS chain validator at connect time
+ * (and proven cross-generator in office-addin-cert-web.test.mjs).
+ */
+export function leafCertValidNode(leafCertPath, caCertPath) {
+  try {
+    const leaf = new X509Certificate(readFileSync(leafCertPath));
+    const ca = new X509Certificate(readFileSync(caCertPath));
+    const now = Date.now();
+    for (const cert of [leaf, ca]) {
+      if (now < Date.parse(cert.validFrom) || now > Date.parse(cert.validTo)) return false;
+    }
+    return leaf.checkIssued(ca) && leaf.verify(ca.publicKey);
+  } catch {
+    return false;
+  }
+}
+
 /** Verify a leaf certificate chains to the CA (enforces name constraints). */
 export function leafCertValid(leafCertPath, caCertPath) {
   if (!existsSync(leafCertPath) || !existsSync(caCertPath)) return false;
+  if (platform() === "win32") return leafCertValidNode(leafCertPath, caCertPath);
   const result = spawnSync(opensslBin(), ["verify", "-CAfile", caCertPath, leafCertPath], {
     encoding: "utf8",
     timeout: 30_000,
@@ -145,6 +181,13 @@ export function leafCertValid(leafCertPath, caCertPath) {
 /** SHA-256 fingerprint of the CA cert, for status display / dedup. */
 export function caFingerprint(caCertPath) {
   if (!existsSync(caCertPath)) return null;
+  if (platform() === "win32") {
+    try {
+      return new X509Certificate(readFileSync(caCertPath)).fingerprint256;
+    } catch {
+      return null;
+    }
+  }
   try {
     const out = runOpenssl(["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha256"]).stdout;
     return out.split("=")[1]?.trim() ?? null;

--- a/apps/desktop/electron/office-addin-cert.test.mjs
+++ b/apps/desktop/electron/office-addin-cert.test.mjs
@@ -14,10 +14,10 @@ import {
 
 const opensslAvailable = officeAddinCertToolAvailable();
 
-test("generates a localhost leaf that validates against the CA", { skip: !opensslAvailable }, () => {
+test("generates a localhost leaf that validates against the CA", { skip: !opensslAvailable }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "lw-cert-ok-"));
   try {
-    const { caCertPath, leafCertPath, leafKeyPath } = ensureLocalCert(dir);
+    const { caCertPath, leafCertPath, leafKeyPath } = await ensureLocalCert(dir);
     assert.ok(leafCertValid(leafCertPath, caCertPath), "localhost leaf should chain to the CA");
     assert.ok(caFingerprint(caCertPath), "CA fingerprint should be readable");
     assert.ok(leafKeyPath.endsWith("localhost.key"));
@@ -26,10 +26,10 @@ test("generates a localhost leaf that validates against the CA", { skip: !openss
   }
 });
 
-test("name constraint rejects a non-localhost certificate", { skip: !opensslAvailable }, () => {
+test("name constraint rejects a non-localhost certificate", { skip: !opensslAvailable }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "lw-cert-evil-"));
   try {
-    ensureLocalCert(dir);
+    await ensureLocalCert(dir);
 
     // A well-formed, CA-signed cert for a real domain — the signature is
     // valid, but the name constraint must make chain verification fail.
@@ -51,12 +51,12 @@ test("name constraint rejects a non-localhost certificate", { skip: !opensslAvai
   }
 });
 
-test("ensureLocalCert is idempotent (reuses valid material)", { skip: !opensslAvailable }, () => {
+test("ensureLocalCert is idempotent (reuses valid material)", { skip: !opensslAvailable }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "lw-cert-idem-"));
   try {
-    const first = ensureLocalCert(dir);
+    const first = await ensureLocalCert(dir);
     const firstFp = caFingerprint(first.caCertPath);
-    const second = ensureLocalCert(dir);
+    const second = await ensureLocalCert(dir);
     assert.equal(caFingerprint(second.caCertPath), firstFp, "CA should not be regenerated when valid");
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/desktop/electron/office-addin-manager.mjs
+++ b/apps/desktop/electron/office-addin-manager.mjs
@@ -8,50 +8,32 @@
  *  - a per-install, localhost-constrained CA + leaf certificate (shared by
  *    all apps; created on first install, removed with the last uninstall),
  *  - OS trust-store install/removal of that CA,
- *  - manifest install/removal into each Office app's sideload folder.
+ *  - manifest install/removal per Office app.
  *
- * HOME pitfall: in dev mode the Electron main process's HOME is redirected to
- * an app sandbox (see buildChildEnv in runtime.mjs), so every user-home path
- * here MUST use the real account home from the user database, never homedir().
+ * Everything OS-specific (trust store, manifest registration, app detection
+ * and launch) lives in office-addin-platform.mjs; this module owns state,
+ * certificates, manifest building, and orchestration. Supported platforms
+ * are macOS and Windows — elsewhere the backend is null and status reports
+ * `supported: false`.
  *
  * Privileged steps (trust store) shell out to platform tools and surface a
- * single OS auth prompt. Operations return structured results with per-step
+ * single OS prompt. Operations return structured results with per-step
  * outcomes and real error details; failures also log to the main console.
  */
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir, platform, userInfo } from "node:os";
+import { platform } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
-  CA_COMMON_NAME,
   caFingerprint,
   ensureLocalCert,
   leafCertValid,
   officeAddinCertToolAvailable,
 } from "./office-addin-cert.mjs";
+import { createOfficeAddinPlatformBackend } from "./office-addin-platform.mjs";
 
 const DEFAULT_PORT = 47443;
-const MANIFEST_FILENAME = "legalwork-office-addin.manifest.xml";
-
-/** @type {ReadonlyArray<{ id: "word" | "excel" | "powerpoint"; label: string; container: string }>} */
-const MAC_OFFICE_APPS = [
-  { id: "word", label: "Word", container: "com.microsoft.Word" },
-  { id: "excel", label: "Excel", container: "com.microsoft.Excel" },
-  { id: "powerpoint", label: "PowerPoint", container: "com.microsoft.Powerpoint" },
-];
-
-/** Real account home — homedir() lies when dev mode rewrites $HOME. */
-function realHomeDir() {
-  try {
-    const info = userInfo();
-    if (info?.homedir) return info.homedir;
-  } catch {
-    // Accounts without a passwd entry fall back to the env-derived home.
-  }
-  return homedir();
-}
 
 function logError(message) {
   console.error(`[office-addin] ${message}`);
@@ -68,6 +50,25 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
   const userDataDir = app.getPath("userData");
   const certDir = join(userDataDir, "office-addin-certs");
   const statePath = join(userDataDir, "office-addins.json");
+
+  function certPaths() {
+    return {
+      caCertPath: join(certDir, "legalwork-local-ca.crt"),
+      leafCertPath: join(certDir, "localhost.crt"),
+      leafKeyPath: join(certDir, "localhost.key"),
+    };
+  }
+
+  const backend = createOfficeAddinPlatformBackend({ userDataDir, certPaths: certPaths() });
+
+  function unsupportedResult(steps = []) {
+    return {
+      ok: false,
+      error: "The Office add-in installer supports macOS and Windows only.",
+      steps,
+      status: status(),
+    };
+  }
 
   function emptyApps() {
     return { word: false, excel: false, powerpoint: false };
@@ -105,14 +106,6 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
     return Object.values(state.apps).some(Boolean);
   }
 
-  function certPaths() {
-    return {
-      caCertPath: join(certDir, "legalwork-local-ca.crt"),
-      leafCertPath: join(certDir, "localhost.crt"),
-      leafKeyPath: join(certDir, "localhost.key"),
-    };
-  }
-
   /**
    * Server config the embedded server should launch with. Null when no app is
    * installed or the certificate is missing, so the listener stays off.
@@ -132,104 +125,25 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
     };
   }
 
-  // ── OS trust store (macOS) ────────────────────────────────────────────
-  function loginKeychain() {
-    return join(realHomeDir(), "Library", "Keychains", "login.keychain-db");
-  }
-
-  function caTrusted() {
-    if (platform() !== "darwin") return false;
-    const { caCertPath, leafCertPath } = certPaths();
-    if (!existsSync(caCertPath) || !existsSync(leafCertPath)) return false;
-    const result = spawnSync("security", ["verify-cert", "-c", leafCertPath], {
-      encoding: "utf8",
-      timeout: 20_000,
-    });
-    return result.status === 0;
-  }
-
-  function trustCa() {
-    if (platform() !== "darwin") {
-      return { ok: false, error: "Trust-store install is only implemented on macOS so far." };
-    }
-    const { caCertPath } = certPaths();
-    // Unscoped trust (like office-addin-dev-certs): scoping to `-p ssl` makes
-    // `verify-cert -p ssl` demand Certificate Transparency SCTs, which local
-    // CAs cannot have. The name constraint is the real risk bound here.
-    const result = spawnSync(
-      "security",
-      ["add-trusted-cert", "-r", "trustRoot", "-k", loginKeychain(), caCertPath],
-      { encoding: "utf8", timeout: 60_000 },
-    );
-    if (result.status !== 0) {
-      return { ok: false, error: (result.stderr || result.stdout || "add-trusted-cert failed").trim() };
-    }
-    return { ok: true };
-  }
-
-  function untrustCa() {
-    if (platform() !== "darwin") return { ok: true };
-    const { caCertPath } = certPaths();
-    if (existsSync(caCertPath)) {
-      const wasTrusted = caTrusted();
-      const result = spawnSync("security", ["remove-trusted-cert", caCertPath], {
-        encoding: "utf8",
-        timeout: 60_000,
-      });
-      // The exit code alone is ambiguous (it is also non-zero when no trust
-      // settings exist). The OS trust state is the truth: if the CA was
-      // trusted before and still is, the user denied the keychain prompt.
-      if (wasTrusted && caTrusted()) {
-        const detail =
-          (result.stderr || result.stdout || "").trim() || "the keychain change was not authorized";
-        return { ok: false, error: detail };
-      }
-    }
-    for (let i = 0; i < 8; i += 1) {
-      const result = spawnSync(
-        "security",
-        ["delete-certificate", "-c", CA_COMMON_NAME, loginKeychain()],
-        { encoding: "utf8", timeout: 30_000 },
-      );
-      if (result.status !== 0) break;
-    }
-    return { ok: true };
-  }
-
   // ── Manifests ─────────────────────────────────────────────────────────
-  async function buildManifest(port) {
+  async function buildManifest(port, host) {
     const dist = locateServerDist?.();
     if (!dist) return null;
     const modulePath = join(dist, "word-addin.js");
     if (!existsSync(modulePath)) return null;
     const { buildWordAddinManifest } = await import(pathToFileURL(modulePath).href);
     const version = typeof app.getVersion === "function" ? `${app.getVersion()}.0` : undefined;
-    return buildWordAddinManifest({ baseUrl: `https://localhost:${port}`, version });
-  }
-
-  function officeApps() {
-    if (platform() !== "darwin") return [];
-    const home = realHomeDir();
-    return MAC_OFFICE_APPS.map((entry) => {
-      const containerDir = join(home, "Library", "Containers", entry.container);
-      const wefDir = join(containerDir, "Data", "Documents", "wef");
-      return {
-        ...entry,
-        installed: existsSync(containerDir),
-        wefDir,
-        manifestPath: join(wefDir, MANIFEST_FILENAME),
-      };
+    return buildWordAddinManifest({
+      baseUrl: `https://localhost:${port}`,
+      version,
+      ...(host ? { host } : {}),
     });
-  }
-
-  function officeAppById(appId) {
-    return officeApps().find((entry) => entry.id === appId) ?? null;
   }
 
   // ── Shared install pieces ─────────────────────────────────────────────
   async function ensureCertAndTrust(steps) {
     try {
-      const { leafCertPath, caCertPath } = ensureLocalCert(certDir);
+      const { leafCertPath, caCertPath } = await ensureLocalCert(certDir);
       const valid = leafCertValid(leafCertPath, caCertPath);
       steps.push({ step: "certificate", ok: valid });
       if (!valid) return "The generated certificate did not validate against its CA.";
@@ -240,11 +154,11 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
       return `Certificate generation failed: ${detail}`;
     }
 
-    if (caTrusted()) {
+    if (backend.caTrusted()) {
       steps.push({ step: "trust", ok: true, skipped: true });
       return null;
     }
-    const trust = trustCa();
+    const trust = backend.trustCa();
     steps.push({ step: "trust", ok: trust.ok, ...(trust.error ? { error: trust.error } : {}) });
     if (!trust.ok) {
       logError(`trust step failed: ${trust.error}`);
@@ -268,22 +182,22 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
   function status() {
     const state = readState();
     const { caCertPath, leafCertPath } = certPaths();
-    const apps = officeApps().map((entry) => ({
+    const apps = (backend?.listApps() ?? []).map((entry) => ({
       id: entry.id,
       label: entry.label,
       installed: entry.installed,
       enabled: state.apps[entry.id] === true,
-      manifestInstalled: existsSync(entry.manifestPath),
+      manifestInstalled: entry.manifestInstalled,
     }));
     return {
-      supported: platform() === "darwin",
+      supported: backend != null,
       platform: platform(),
       toolAvailable: officeAddinCertToolAvailable(),
       enabled: anyEnabled(state),
       port: state.port,
       installedAt: state.installedAt,
       certPresent: existsSync(leafCertPath),
-      certTrusted: caTrusted(),
+      certTrusted: backend?.caTrusted() ?? false,
       caFingerprint: caFingerprint(caCertPath),
       paneBundlePresent: Boolean(locatePaneDist?.() && existsSync(join(locatePaneDist(), "taskpane.html"))),
       apps,
@@ -293,15 +207,18 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
   /** @param {"word" | "excel" | "powerpoint"} appId */
   async function install(appId) {
     const steps = [];
-    const target = officeAppById(appId);
-    if (platform() !== "darwin") {
-      return { ok: false, error: "The Office add-in installer currently supports macOS only.", steps, status: status() };
-    }
+    if (!backend) return unsupportedResult(steps);
+    const target = backend.listApps().find((entry) => entry.id === appId) ?? null;
     if (!target) {
       return { ok: false, error: `Unknown Office app: ${appId}`, steps, status: status() };
     }
     if (!target.installed) {
       return { ok: false, error: `${target.label} is not installed on this machine.`, steps, status: status() };
+    }
+    // Checked before any cert/trust work so unsupported Office variants
+    // (e.g. Microsoft Store installs) fail fast without OS prompts.
+    if (target.unsupportedReason) {
+      return { ok: false, error: target.unsupportedReason, steps, status: status() };
     }
     if (!officeAddinCertToolAvailable()) {
       return { ok: false, error: "OpenSSL is required to generate the certificate but was not found.", steps, status: status() };
@@ -314,23 +231,18 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
       return { ok: false, steps, status: status(), error: certError };
     }
 
-    const manifest = await buildManifest(state.port);
+    const manifest = await buildManifest(state.port, backend.manifestHost(appId));
     if (!manifest) {
       const detail = "Could not build the add-in manifest (server bundle missing).";
       steps.push({ step: "manifest", ok: false, error: detail });
       logError(detail);
       return { ok: false, steps, status: status(), error: detail };
     }
-    try {
-      mkdirSync(target.wefDir, { recursive: true });
-      const current = existsSync(target.manifestPath) ? readFileSync(target.manifestPath, "utf8") : null;
-      if (current !== manifest) writeFileSync(target.manifestPath, manifest, "utf8");
-      steps.push({ step: "manifest", ok: true });
-    } catch (error) {
-      const detail = `Could not write the ${target.label} manifest: ${String(error?.message ?? error)}`;
-      steps.push({ step: "manifest", ok: false, error: detail });
-      logError(detail);
-      return { ok: false, steps, status: status(), error: detail };
+    const written = backend.writeManifest(appId, manifest);
+    steps.push({ step: "manifest", ok: written.ok, ...(written.error ? { error: written.error } : {}) });
+    if (!written.ok) {
+      logError(written.error);
+      return { ok: false, steps, status: status(), error: written.error };
     }
 
     state.apps[appId] = true;
@@ -343,7 +255,8 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
   /** @param {"word" | "excel" | "powerpoint"} appId */
   async function uninstall(appId) {
     const steps = [];
-    const target = officeAppById(appId);
+    if (!backend) return unsupportedResult(steps);
+    const target = backend.listApps().find((entry) => entry.id === appId) ?? null;
     if (!target) {
       return { ok: false, error: `Unknown Office app: ${appId}`, steps, status: status() };
     }
@@ -354,9 +267,9 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
 
     if (lastOne) {
       // Last app: remove the trust-store entry FIRST, before touching any
-      // other state. If the user denies the keychain prompt, abort with
-      // everything intact instead of stranding a trusted CA in the keychain.
-      const untrust = untrustCa();
+      // other state. If the user denies the OS prompt, abort with
+      // everything intact instead of stranding a trusted CA in the store.
+      const untrust = backend.untrustCa();
       steps.push({ step: "trust", ok: untrust.ok, ...(untrust.error ? { error: untrust.error } : {}) });
       if (!untrust.ok) {
         logError(`untrust failed: ${untrust.error}`);
@@ -371,8 +284,12 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
       steps.push({ step: "certificate", ok: true });
     }
 
-    rmSync(target.manifestPath, { force: true });
-    steps.push({ step: "manifest", ok: true });
+    const removed = backend.removeManifest(appId);
+    steps.push({ step: "manifest", ok: removed.ok, ...(removed.error ? { error: removed.error } : {}) });
+    if (!removed.ok) {
+      logError(removed.error);
+      return { ok: false, steps, status: status(), error: removed.error };
+    }
 
     writeState({ apps: nextApps, port: state.port, installedAt: lastOne ? null : state.installedAt });
     await applyListenerState(steps);
@@ -382,22 +299,10 @@ export function createOfficeAddinManager({ app, locateServerDist, locatePaneDist
 
   /** @param {"word" | "excel" | "powerpoint"} appId */
   function openApp(appId) {
-    const target = officeAppById(appId);
-    if (!target) {
-      return { ok: false, error: `Unknown Office app: ${appId}` };
+    if (!backend) {
+      return { ok: false, error: "The Office add-in installer supports macOS and Windows only." };
     }
-    if (!target.installed) {
-      return { ok: false, error: `${target.label} is not installed on this machine.` };
-    }
-    // The sandbox container id doubles as the app's bundle id on macOS.
-    const result = spawnSync("open", ["-b", target.container], { encoding: "utf8", timeout: 30_000 });
-    if (result.status !== 0) {
-      const detail =
-        (result.stderr || result.stdout || "").trim() || `Could not open ${target.label}.`;
-      logError(`open app failed: ${detail}`);
-      return { ok: false, error: detail };
-    }
-    return { ok: true };
+    return backend.openApp(appId);
   }
 
   return { readState, serverConfig, status, install, uninstall, openApp };

--- a/apps/desktop/electron/office-addin-platform.mjs
+++ b/apps/desktop/electron/office-addin-platform.mjs
@@ -1,0 +1,483 @@
+/**
+ * Platform backends for the Office add-in manager (see
+ * office-addin-manager.mjs for the overall install/uninstall flow).
+ *
+ * A backend owns everything OS-specific:
+ *  - which Office apps exist on this machine,
+ *  - trusting/untrusting the per-install CA in the OS trust store,
+ *  - installing/removing the add-in manifest per app,
+ *  - launching an Office app.
+ *
+ * macOS: manifests are files in each app's sandboxed `wef` folder; trust is
+ * the login keychain via `security`.
+ *
+ * Windows: manifests are registered as REG_SZ values under
+ * HKCU\...\Office\16.0\WEF\Developer — the value name is the manifest's Id
+ * and the data is the manifest's path on disk (the same mechanism
+ * Microsoft's office-addin-dev-settings uses). Trust is the CurrentUser
+ * Root store via `certutil` (one native confirmation dialog, no admin).
+ * Office apps are detected through their App Paths registry entries, which
+ * cover both MSI and Click-to-Run installs.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, platform, userInfo } from "node:os";
+import { dirname, join } from "node:path";
+
+import { CA_COMMON_NAME } from "./office-addin-cert.mjs";
+
+const MANIFEST_FILENAME = "legalwork-office-addin.manifest.xml";
+
+/**
+ * @typedef {object} OfficeAppEntry
+ * @property {"word" | "excel" | "powerpoint"} id
+ * @property {string} label
+ * @property {boolean} installed          The Office app exists on this machine.
+ * @property {boolean} manifestInstalled  The LegalWork manifest is sideloaded for it.
+ * @property {string} [unsupportedReason] Install is blocked (e.g. Microsoft Store Office).
+ */
+
+function logError(message) {
+  console.error(`[office-addin] ${message}`);
+}
+
+// ── Shared pure helpers (exported for tests) ─────────────────────────────
+
+/**
+ * Extract the string data of the first REG_SZ/REG_EXPAND_SZ value in
+ * `reg.exe query` output; expands %VAR% environment references.
+ */
+export function parseRegSzValue(output, env = process.env) {
+  for (const line of String(output ?? "").split(/\r?\n/)) {
+    const match = line.match(/\bREG_(?:EXPAND_)?SZ\s+(.*\S)/);
+    if (match) {
+      return match[1].replace(/%([^%]+)%/g, (whole, name) => env[name] ?? whole);
+    }
+  }
+  return null;
+}
+
+/**
+ * Office installed from the Microsoft Store lives under WindowsApps and
+ * cannot load registry-sideloaded add-ins — installing would "succeed"
+ * silently and never show up. Detected so install can fail with a clear
+ * message instead.
+ */
+export function isStoreOfficeExecutable(exePath) {
+  return /[\\/]WindowsApps[\\/]/i.test(String(exePath ?? ""));
+}
+
+/**
+ * SHA-1 thumbprint (lowercase hex) of the first certificate in a PEM string
+ * — the identifier Windows cert stores use (`certutil -verifystore Root
+ * <thumbprint>`). Returns null when no certificate block is found.
+ */
+export function certSha1ThumbprintFromPem(pem) {
+  const match = String(pem ?? "").match(
+    /-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\r\n\s]+?)-----END CERTIFICATE-----/,
+  );
+  if (!match) return null;
+  try {
+    const der = Buffer.from(match[1].replace(/\s+/g, ""), "base64");
+    if (der.length === 0) return null;
+    return createHash("sha1").update(der).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+// ── macOS ────────────────────────────────────────────────────────────────
+
+/** @type {ReadonlyArray<{ id: "word" | "excel" | "powerpoint"; label: string; container: string }>} */
+const MAC_OFFICE_APPS = [
+  { id: "word", label: "Word", container: "com.microsoft.Word" },
+  { id: "excel", label: "Excel", container: "com.microsoft.Excel" },
+  { id: "powerpoint", label: "PowerPoint", container: "com.microsoft.Powerpoint" },
+];
+
+/**
+ * Real account home — homedir() lies when dev mode rewrites $HOME (see
+ * buildChildEnv in runtime.mjs), so every user-home path MUST use the real
+ * account home from the user database.
+ */
+function realHomeDir() {
+  try {
+    const info = userInfo();
+    if (info?.homedir) return info.homedir;
+  } catch {
+    // Accounts without a passwd entry fall back to the env-derived home.
+  }
+  return homedir();
+}
+
+function createDarwinBackend({ certPaths }) {
+  function loginKeychain() {
+    return join(realHomeDir(), "Library", "Keychains", "login.keychain-db");
+  }
+
+  function officeApps() {
+    const home = realHomeDir();
+    return MAC_OFFICE_APPS.map((entry) => {
+      const containerDir = join(home, "Library", "Containers", entry.container);
+      const wefDir = join(containerDir, "Data", "Documents", "wef");
+      return {
+        ...entry,
+        installed: existsSync(containerDir),
+        wefDir,
+        manifestPath: join(wefDir, MANIFEST_FILENAME),
+      };
+    });
+  }
+
+  function officeAppById(appId) {
+    return officeApps().find((entry) => entry.id === appId) ?? null;
+  }
+
+  function caTrusted() {
+    const { caCertPath, leafCertPath } = certPaths;
+    if (!existsSync(caCertPath) || !existsSync(leafCertPath)) return false;
+    const result = spawnSync("security", ["verify-cert", "-c", leafCertPath], {
+      encoding: "utf8",
+      timeout: 20_000,
+    });
+    return result.status === 0;
+  }
+
+  return {
+    platformId: "darwin",
+
+    /** @returns {OfficeAppEntry[]} */
+    listApps() {
+      return officeApps().map((entry) => ({
+        id: entry.id,
+        label: entry.label,
+        installed: entry.installed,
+        manifestInstalled: existsSync(entry.manifestPath),
+      }));
+    },
+
+    /** macOS keeps one multi-host manifest per app folder. */
+    manifestHost() {
+      return undefined;
+    },
+
+    caTrusted,
+
+    trustCa() {
+      const { caCertPath } = certPaths;
+      // Unscoped trust (like office-addin-dev-certs): scoping to `-p ssl` makes
+      // `verify-cert -p ssl` demand Certificate Transparency SCTs, which local
+      // CAs cannot have. The name constraint is the real risk bound here.
+      const result = spawnSync(
+        "security",
+        ["add-trusted-cert", "-r", "trustRoot", "-k", loginKeychain(), caCertPath],
+        { encoding: "utf8", timeout: 60_000 },
+      );
+      if (result.status !== 0) {
+        return { ok: false, error: (result.stderr || result.stdout || "add-trusted-cert failed").trim() };
+      }
+      return { ok: true };
+    },
+
+    untrustCa() {
+      const { caCertPath } = certPaths;
+      if (existsSync(caCertPath)) {
+        const wasTrusted = caTrusted();
+        const result = spawnSync("security", ["remove-trusted-cert", caCertPath], {
+          encoding: "utf8",
+          timeout: 60_000,
+        });
+        // The exit code alone is ambiguous (it is also non-zero when no trust
+        // settings exist). The OS trust state is the truth: if the CA was
+        // trusted before and still is, the user denied the keychain prompt.
+        if (wasTrusted && caTrusted()) {
+          const detail =
+            (result.stderr || result.stdout || "").trim() || "the keychain change was not authorized";
+          return { ok: false, error: detail };
+        }
+      }
+      for (let i = 0; i < 8; i += 1) {
+        const result = spawnSync(
+          "security",
+          ["delete-certificate", "-c", CA_COMMON_NAME, loginKeychain()],
+          { encoding: "utf8", timeout: 30_000 },
+        );
+        if (result.status !== 0) break;
+      }
+      return { ok: true };
+    },
+
+    writeManifest(appId, manifest) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      try {
+        mkdirSync(target.wefDir, { recursive: true });
+        const current = existsSync(target.manifestPath) ? readFileSync(target.manifestPath, "utf8") : null;
+        if (current !== manifest) writeFileSync(target.manifestPath, manifest, "utf8");
+        return { ok: true };
+      } catch (error) {
+        return {
+          ok: false,
+          error: `Could not write the ${target.label} manifest: ${String(error?.message ?? error)}`,
+        };
+      }
+    },
+
+    removeManifest(appId) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      rmSync(target.manifestPath, { force: true });
+      return { ok: true };
+    },
+
+    openApp(appId) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      if (!target.installed) {
+        return { ok: false, error: `${target.label} is not installed on this machine.` };
+      }
+      // The sandbox container id doubles as the app's bundle id on macOS.
+      const result = spawnSync("open", ["-b", target.container], { encoding: "utf8", timeout: 30_000 });
+      if (result.status !== 0) {
+        const detail =
+          (result.stderr || result.stdout || "").trim() || `Could not open ${target.label}.`;
+        logError(`open app failed: ${detail}`);
+        return { ok: false, error: detail };
+      }
+      return { ok: true };
+    },
+  };
+}
+
+// ── Windows ──────────────────────────────────────────────────────────────
+
+const WIN_DEVELOPER_KEY = "HKCU\\Software\\Microsoft\\Office\\16.0\\WEF\\Developer";
+
+/**
+ * Per-host manifest ids double as the registry value names. Keep in sync
+ * with WORD_ADDIN_MANIFEST_IDS in apps/server/src/word-addin.ts and with
+ * apps/desktop/build/installer.nsh (NSIS uninstall cleanup).
+ */
+const WIN_MANIFEST_IDS = {
+  word: "fdea378d-ff62-4a4f-af08-d1622c083957",
+  excel: "65facd67-9deb-4356-8072-e2cc6e36d9fe",
+  powerpoint: "db1cc438-a239-4b01-b732-2ff838ecca38",
+};
+
+/** @type {ReadonlyArray<{ id: "word" | "excel" | "powerpoint"; label: string; exe: string }>} */
+const WIN_OFFICE_APPS = [
+  { id: "word", label: "Word", exe: "WINWORD.EXE" },
+  { id: "excel", label: "Excel", exe: "EXCEL.EXE" },
+  { id: "powerpoint", label: "PowerPoint", exe: "POWERPNT.EXE" },
+];
+
+function runReg(args, timeout = 15_000) {
+  return spawnSync("reg.exe", args, { encoding: "utf8", timeout });
+}
+
+function runCertutil(args, timeout) {
+  return spawnSync("certutil", args, { encoding: "utf8", timeout });
+}
+
+function createWin32Backend({ userDataDir, certPaths }) {
+  function appPathsExecutable(exe) {
+    // App Paths is maintained by the Office installer for both MSI and
+    // Click-to-Run; the default value is the absolute executable path.
+    const result = runReg([
+      "query",
+      `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exe}`,
+      "/ve",
+    ]);
+    if (result.status !== 0) return null;
+    const value = parseRegSzValue(result.stdout);
+    return value && existsSync(value) ? value : null;
+  }
+
+  function manifestPathFor(appId) {
+    return join(userDataDir, "office-addin-manifests", `legalwork-${appId}.manifest.xml`);
+  }
+
+  function registryValuePresent(appId) {
+    return runReg(["query", WIN_DEVELOPER_KEY, "/v", WIN_MANIFEST_IDS[appId]]).status === 0;
+  }
+
+  function caThumbprint() {
+    const { caCertPath } = certPaths;
+    if (!existsSync(caCertPath)) return null;
+    try {
+      return certSha1ThumbprintFromPem(readFileSync(caCertPath, "utf8"));
+    } catch {
+      return null;
+    }
+  }
+
+  function officeAppById(appId) {
+    return WIN_OFFICE_APPS.find((entry) => entry.id === appId) ?? null;
+  }
+
+  function caTrusted() {
+    const { caCertPath, leafCertPath } = certPaths;
+    if (!existsSync(caCertPath) || !existsSync(leafCertPath)) return false;
+    const thumbprint = caThumbprint();
+    if (!thumbprint) return false;
+    // Presence in the CurrentUser Root store makes the CA a trusted root
+    // for WebView2/schannel; leafCertValid (checked at install) covers the
+    // chain itself.
+    return runCertutil(["-user", "-verifystore", "Root", thumbprint], 20_000).status === 0;
+  }
+
+  return {
+    platformId: "win32",
+
+    /** @returns {OfficeAppEntry[]} */
+    listApps() {
+      return WIN_OFFICE_APPS.map((entry) => {
+        const executable = appPathsExecutable(entry.exe);
+        return {
+          id: entry.id,
+          label: entry.label,
+          installed: executable != null,
+          manifestInstalled: existsSync(manifestPathFor(entry.id)) && registryValuePresent(entry.id),
+          ...(executable && isStoreOfficeExecutable(executable)
+            ? {
+                unsupportedReason: `${entry.label} is installed from the Microsoft Store, which cannot load locally installed add-ins. Install the Microsoft 365 desktop apps (from office.com) to use the LegalWork add-in.`,
+              }
+            : {}),
+        };
+      });
+    },
+
+    /**
+     * Windows registers each app individually: the registry value name must
+     * be the manifest's Id, so each app gets a single-host manifest with its
+     * own id.
+     */
+    manifestHost(appId) {
+      return appId;
+    },
+
+    caTrusted,
+
+    trustCa() {
+      const { caCertPath } = certPaths;
+      // Shows Windows' native root-store confirmation dialog; cancelling it
+      // makes certutil exit non-zero.
+      const result = runCertutil(["-user", "-addstore", "Root", caCertPath], 120_000);
+      if (result.status !== 0) {
+        return { ok: false, error: (result.stderr || result.stdout || "certutil -addstore failed").trim() };
+      }
+      return { ok: true };
+    },
+
+    untrustCa() {
+      const { caCertPath } = certPaths;
+      if (existsSync(caCertPath)) {
+        const wasTrusted = caTrusted();
+        // Delete by common name so stale CAs from older installs are swept
+        // too; delstore removes one match per invocation.
+        let lastResult = null;
+        for (let i = 0; i < 8; i += 1) {
+          const result = runCertutil(["-user", "-delstore", "Root", CA_COMMON_NAME], 120_000);
+          lastResult = result;
+          if (result.status !== 0) break;
+        }
+        // Like the keychain on macOS, removal shows a confirmation dialog;
+        // the store state is the truth about whether the user allowed it.
+        if (wasTrusted && caTrusted()) {
+          const detail =
+            (lastResult?.stderr || lastResult?.stdout || "").trim() ||
+            "the certificate removal was not authorized";
+          return { ok: false, error: detail };
+        }
+      }
+      return { ok: true };
+    },
+
+    writeManifest(appId, manifest) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      const manifestPath = manifestPathFor(appId);
+      try {
+        mkdirSync(dirname(manifestPath), { recursive: true });
+        const current = existsSync(manifestPath) ? readFileSync(manifestPath, "utf8") : null;
+        if (current !== manifest) writeFileSync(manifestPath, manifest, "utf8");
+      } catch (error) {
+        return {
+          ok: false,
+          error: `Could not write the ${target.label} manifest: ${String(error?.message ?? error)}`,
+        };
+      }
+      const result = runReg([
+        "add",
+        WIN_DEVELOPER_KEY,
+        "/v",
+        WIN_MANIFEST_IDS[appId],
+        "/t",
+        "REG_SZ",
+        "/d",
+        manifestPath,
+        "/f",
+      ]);
+      if (result.status !== 0) {
+        const detail = (result.stderr || result.stdout || "reg add failed").trim();
+        return { ok: false, error: `Could not register the ${target.label} manifest: ${detail}` };
+      }
+      return { ok: true };
+    },
+
+    removeManifest(appId) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      // A missing value also exits non-zero, so the exit code alone is
+      // ambiguous — re-query for the truth.
+      const result = runReg(["delete", WIN_DEVELOPER_KEY, "/v", WIN_MANIFEST_IDS[appId], "/f"]);
+      if (registryValuePresent(appId)) {
+        const detail = (result.stderr || result.stdout || "reg delete failed").trim();
+        return { ok: false, error: `Could not unregister the ${target.label} manifest: ${detail}` };
+      }
+      rmSync(manifestPathFor(appId), { force: true });
+      return { ok: true };
+    },
+
+    openApp(appId) {
+      const target = officeAppById(appId);
+      if (!target) return { ok: false, error: `Unknown Office app: ${appId}` };
+      const executable = appPathsExecutable(target.exe);
+      if (!executable) {
+        return { ok: false, error: `${target.label} is not installed on this machine.` };
+      }
+      try {
+        const child = spawn(executable, [], { detached: true, stdio: "ignore" });
+        child.on("error", (error) => logError(`open app failed: ${String(error?.message ?? error)}`));
+        child.unref();
+        return { ok: true };
+      } catch (error) {
+        const detail = String(error?.message ?? error);
+        logError(`open app failed: ${detail}`);
+        return { ok: false, error: detail };
+      }
+    },
+  };
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+/**
+ * Backend for the current platform, or null where installing the add-in is
+ * not supported.
+ *
+ * @param {object} deps
+ * @param {string} deps.userDataDir  Electron userData dir (manifest storage on Windows).
+ * @param {{ caCertPath: string; leafCertPath: string; leafKeyPath: string }} deps.certPaths
+ */
+export function createOfficeAddinPlatformBackend({ userDataDir, certPaths }) {
+  switch (platform()) {
+    case "darwin":
+      return createDarwinBackend({ certPaths });
+    case "win32":
+      return createWin32Backend({ userDataDir, certPaths });
+    default:
+      return null;
+  }
+}

--- a/apps/desktop/electron/office-addin-platform.test.mjs
+++ b/apps/desktop/electron/office-addin-platform.test.mjs
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { officeAddinCertToolAvailable, ensureLocalCert } from "./office-addin-cert.mjs";
+import {
+  certSha1ThumbprintFromPem,
+  isStoreOfficeExecutable,
+  parseRegSzValue,
+} from "./office-addin-platform.mjs";
+
+test("isStoreOfficeExecutable flags WindowsApps installs only", () => {
+  assert.ok(
+    isStoreOfficeExecutable("C:\\Program Files\\WindowsApps\\Microsoft.Office.Desktop_16051\\Office16\\WINWORD.EXE"),
+  );
+  assert.equal(
+    isStoreOfficeExecutable("C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE"),
+    false,
+  );
+  assert.equal(isStoreOfficeExecutable(null), false);
+});
+
+test("parseRegSzValue extracts REG_SZ data from reg.exe query output", () => {
+  const output = [
+    "",
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\WINWORD.EXE",
+    "    (Default)    REG_SZ    C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE",
+    "",
+  ].join("\r\n");
+  assert.equal(
+    parseRegSzValue(output),
+    "C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE",
+  );
+});
+
+test("parseRegSzValue expands REG_EXPAND_SZ environment references", () => {
+  const output =
+    "    Path    REG_EXPAND_SZ    %TESTPROGRAMFILES%\\Microsoft Office\\WINWORD.EXE";
+  assert.equal(
+    parseRegSzValue(output, { TESTPROGRAMFILES: "C:\\Program Files" }),
+    "C:\\Program Files\\Microsoft Office\\WINWORD.EXE",
+  );
+  // Unknown references stay verbatim instead of corrupting the path.
+  assert.equal(
+    parseRegSzValue(output, {}),
+    "%TESTPROGRAMFILES%\\Microsoft Office\\WINWORD.EXE",
+  );
+});
+
+test("parseRegSzValue returns null when no string value is present", () => {
+  assert.equal(parseRegSzValue(""), null);
+  assert.equal(parseRegSzValue("ERROR: The system was unable to find the specified registry key or value."), null);
+  assert.equal(parseRegSzValue(null), null);
+});
+
+test("certSha1ThumbprintFromPem rejects non-PEM input", () => {
+  assert.equal(certSha1ThumbprintFromPem(""), null);
+  assert.equal(certSha1ThumbprintFromPem("not a certificate"), null);
+  assert.equal(certSha1ThumbprintFromPem(null), null);
+});
+
+test(
+  "certSha1ThumbprintFromPem matches openssl's SHA-1 fingerprint",
+  { skip: !officeAddinCertToolAvailable() },
+  async () => {
+    const { spawnSync } = await import("node:child_process");
+    const { readFileSync } = await import("node:fs");
+    const dir = mkdtempSync(join(tmpdir(), "lw-thumbprint-"));
+    try {
+      const { caCertPath } = await ensureLocalCert(dir);
+      const thumbprint = certSha1ThumbprintFromPem(readFileSync(caCertPath, "utf8"));
+      assert.match(thumbprint, /^[0-9a-f]{40}$/);
+      const openssl = spawnSync(
+        process.env.LEGALWORK_OPENSSL_BIN?.trim() || "openssl",
+        ["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha1"],
+        { encoding: "utf8", timeout: 30_000 },
+      );
+      const expected = openssl.stdout.split("=")[1]?.trim().replaceAll(":", "").toLowerCase();
+      assert.equal(thumbprint, expected);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,17 +20,21 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs",
+    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs",
     "office:sideload": "node ./scripts/office-addin-sideload.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.3",
+    "@peculiar/asn1-schema": "^2.8.0",
+    "@peculiar/asn1-x509": "^2.8.0",
+    "@peculiar/x509": "^2.0.0",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "electron-updater": "^6.3.9",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
     "node-pty": "npm:@lydell/node-pty@1.2.0-beta.12",
+    "reflect-metadata": "^0.2.2",
     "yaml": "^2.6.1",
     "zod": "^4.3.6"
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/desktop",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "LegalWork desktop shell",
   "author": {
     "name": "LegalWork",
@@ -45,5 +45,5 @@
     "electron-devtools-installer": "^4.0.0"
   },
   "packageManager": "pnpm@10.27.0",
-  "opencodeRouterVersion": "0.0.12"
+  "opencodeRouterVersion": "0.0.13"
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@legalwork/desktop",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "LegalWork desktop shell",
   "author": {
     "name": "LegalWork",
@@ -41,5 +41,5 @@
     "electron-devtools-installer": "^4.0.0"
   },
   "packageManager": "pnpm@10.27.0",
-  "opencodeRouterVersion": "0.0.11"
+  "opencodeRouterVersion": "0.0.12"
 }

--- a/apps/desktop/scripts/office-addin-sideload.mjs
+++ b/apps/desktop/scripts/office-addin-sideload.mjs
@@ -2,10 +2,11 @@
  * Dev sideloading for the LegalWork Office add-in (Word, Excel, PowerPoint).
  *
  * Idempotent and best-effort: ensures the office-addin-dev-certs localhost
- * certificate exists (interactive keychain prompt on first run) and copies
- * the generated multi-host manifest into the sideload location of every
- * installed Office app. Runs as part of electron-dev; failures never block
- * the dev flow — the add-in listener simply stays off until fixed.
+ * certificate exists (interactive OS trust prompt on first run) and
+ * sideloads the generated multi-host manifest — into each installed Office
+ * app's wef folder on macOS, or via the HKCU WEF\Developer registry key on
+ * Windows. Runs as part of electron-dev; failures never block the dev flow
+ * — the add-in listener simply stays off until fixed.
  *
  * Requires apps/server to be built (dist/word-addin.js), which electron-dev
  * does right before invoking this script. Skip with LEGALWORK_WORD_ADDIN=0
@@ -36,13 +37,13 @@ async function main() {
 
   ensureDevCerts();
 
-  const manifest = await buildManifest();
-  if (!manifest) return;
+  const built = await buildManifest();
+  if (!built) return;
 
   if (platform() === "darwin") {
-    sideloadMac(manifest);
+    sideloadMac(built.manifest);
   } else if (platform() === "win32") {
-    log("Windows sideloading is not automated yet. See docs/word-addin.md (office-addin-debugging start).");
+    sideloadWindows(built.manifest, built.manifestId);
   } else {
     log("no Office sideload target on this platform");
   }
@@ -68,6 +69,8 @@ function devCertsVerified() {
   const result = spawnSync("npx", ["-y", "office-addin-dev-certs", "verify"], {
     stdio: "pipe",
     timeout: 120_000,
+    // npx is npx.cmd on Windows; Node refuses to spawn .cmd files without a shell.
+    shell: platform() === "win32",
   });
   return result.status === 0;
 }
@@ -81,13 +84,18 @@ function ensureDevCerts() {
   rmSync(join(homedir(), ".office-addin-dev-certs"), { recursive: true, force: true });
 
   log("localhost dev certificate missing or not trusted — running `npx office-addin-dev-certs install`");
-  log("(expect a one-time password prompt for the keychain trust step)");
+  log(
+    platform() === "win32"
+      ? "(expect a one-time Windows security dialog for the trust step)"
+      : "(expect a one-time password prompt for the keychain trust step)",
+  );
   if (!process.stdin.isTTY) {
     log("NOTE: no interactive terminal — the trust step will likely fail here.");
   }
   spawnSync("npx", ["-y", "office-addin-dev-certs", "install"], {
     stdio: "inherit",
     timeout: 180_000,
+    shell: platform() === "win32",
   });
 
   if (!devCertsVerified()) {
@@ -102,10 +110,15 @@ async function buildManifest() {
     log(`WARNING: ${manifestModulePath} not built yet; skipping manifest sideload`);
     return null;
   }
-  const { buildWordAddinManifest } = await import(pathToFileURL(manifestModulePath).href);
+  const { buildWordAddinManifest, WORD_ADDIN_MANIFEST_IDS } = await import(
+    pathToFileURL(manifestModulePath).href
+  );
   const portRaw = Number.parseInt(process.env.LEGALWORK_WORD_ADDIN_PORT ?? "", 10);
   const port = Number.isFinite(portRaw) && portRaw > 0 ? portRaw : 47443;
-  return buildWordAddinManifest({ baseUrl: `https://localhost:${port}` });
+  return {
+    manifest: buildWordAddinManifest({ baseUrl: `https://localhost:${port}` }),
+    manifestId: WORD_ADDIN_MANIFEST_IDS?.all ?? "47744a24-6fd7-4ee5-b981-97b16ce5d488",
+  };
 }
 
 function sideloadMac(manifest) {
@@ -130,6 +143,46 @@ function sideloadMac(manifest) {
       log(`${app}: WARNING: could not write manifest: ${error?.message ?? error}`);
     }
   }
+}
+
+/**
+ * Windows has no wef folder: the manifest lives at a stable path and is
+ * registered as a REG_SZ value under HKCU\...\WEF\Developer whose name is
+ * the manifest's Id and whose data is the manifest path — the same registry
+ * sideload Microsoft's office-addin-dev-settings performs. One multi-host
+ * registration covers Word, Excel, and PowerPoint.
+ */
+function sideloadWindows(manifest, manifestId) {
+  const dir = join(homedir(), ".legalwork", "office-addin-dev");
+  const target = join(dir, MANIFEST_FILENAME);
+  try {
+    mkdirSync(dir, { recursive: true });
+    const current = existsSync(target) ? readFileSync(target, "utf8") : null;
+    if (current !== manifest) writeFileSync(target, manifest, "utf8");
+  } catch (error) {
+    log(`WARNING: could not write manifest: ${error?.message ?? error}`);
+    return;
+  }
+  const result = spawnSync(
+    "reg.exe",
+    [
+      "add",
+      "HKCU\\Software\\Microsoft\\Office\\16.0\\WEF\\Developer",
+      "/v",
+      manifestId,
+      "/t",
+      "REG_SZ",
+      "/d",
+      target,
+      "/f",
+    ],
+    { stdio: "pipe", encoding: "utf8", timeout: 30_000 },
+  );
+  if (result.status !== 0) {
+    log(`WARNING: could not register manifest: ${(result.stderr || result.stdout || "").trim()}`);
+    return;
+  }
+  log("manifest registered for Word/Excel/PowerPoint (restart the Office apps to pick it up)");
 }
 
 main().catch((error) => {

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-router",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "opencode-router: Slack + Telegram bridge + directory routing for a running opencode server",
   "private": false,
   "type": "module",

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-router",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "opencode-router: Slack + Telegram bridge + directory routing for a running opencode server",
   "private": false,
   "type": "module",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-orchestrator",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "LegalWork host orchestrator for opencode + LegalWork server + opencode-router",
   "private": true,
   "type": "module",
@@ -47,8 +47,8 @@
     "@opencode-ai/sdk": "^1.17.3",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "opencode-router": "0.0.11",
-    "legalwork-server": "0.0.11",
+    "opencode-router": "0.0.12",
+    "legalwork-server": "0.0.12",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-orchestrator",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "LegalWork host orchestrator for opencode + LegalWork server + opencode-router",
   "private": true,
   "type": "module",
@@ -47,8 +47,8 @@
     "@opencode-ai/sdk": "^1.17.3",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "opencode-router": "0.0.12",
-    "legalwork-server": "0.0.12",
+    "opencode-router": "0.0.13",
+    "legalwork-server": "0.0.13",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-server",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Filesystem-backed API for LegalWork remote clients",
   "type": "module",
   "bin": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalwork-server",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Filesystem-backed API for LegalWork remote clients",
   "type": "module",
   "bin": {

--- a/apps/server/src/word-addin.e2e.test.ts
+++ b/apps/server/src/word-addin.e2e.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer } from "./server.js";
-import { buildWordAddinManifest } from "./word-addin.js";
+import { buildWordAddinManifest, WORD_ADDIN_MANIFEST_IDS } from "./word-addin.js";
 import { WORD_ADDIN_SHELL_VERSION } from "./word-addin-shell.js";
 import type { ServerConfig, WordAddinConfig } from "./types.js";
 
@@ -222,5 +222,36 @@ describe("buildWordAddinManifest", () => {
     expect(xml).toContain("<Version>1.0.0.0</Version>");
     expect(xml).toContain('SourceLocation DefaultValue="https://localhost:47443/word-addin/taskpane.html"');
     expect(xml).not.toContain("47443//word-addin");
+  });
+
+  test("declares all hosts under the multi-host id by default", () => {
+    const xml = buildWordAddinManifest({ baseUrl: "https://localhost:47443" });
+    expect(xml).toContain(`<Id>${WORD_ADDIN_MANIFEST_IDS.all}</Id>`);
+    expect(xml).toContain('<Host Name="Document"/>');
+    expect(xml).toContain('<Host Name="Workbook"/>');
+    expect(xml).toContain('<Host Name="Presentation"/>');
+  });
+
+  test("single-host manifests carry only their host and a per-host id", () => {
+    const cases = [
+      { host: "word", name: "Document", xsiType: 'xsi:type="Document"' },
+      { host: "excel", name: "Workbook", xsiType: 'xsi:type="Workbook"' },
+      { host: "powerpoint", name: "Presentation", xsiType: 'xsi:type="Presentation"' },
+    ] as const;
+    for (const { host, name, xsiType } of cases) {
+      const xml = buildWordAddinManifest({ baseUrl: "https://localhost:47443", host });
+      expect(xml).toContain(`<Id>${WORD_ADDIN_MANIFEST_IDS[host]}</Id>`);
+      expect(xml).toContain(`<Host Name="${name}"/>`);
+      expect(xml).toContain(`<Host ${xsiType}>`);
+      for (const other of cases) {
+        if (other.host === host) continue;
+        expect(xml).not.toContain(`<Host Name="${other.name}"/>`);
+        expect(xml).not.toContain(`<Host ${other.xsiType}>`);
+      }
+    }
+    // Office treats the manifest id as the add-in's identity — the per-host
+    // ids must be distinct from each other and from the multi-host id.
+    const ids = Object.values(WORD_ADDIN_MANIFEST_IDS);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });

--- a/apps/server/src/word-addin.ts
+++ b/apps/server/src/word-addin.ts
@@ -18,8 +18,26 @@ import { buildWordAddinRedirectorHtml, buildWordAddinShellHtml, WORD_ADDIN_SHELL
 
 export const WORD_ADDIN_PATH_PREFIX = "/word-addin";
 
-/** Stable identity of the add-in across installs; referenced by Word. */
-const WORD_ADDIN_MANIFEST_ID = "47744a24-6fd7-4ee5-b981-97b16ce5d488";
+export type WordAddinHost = "word" | "excel" | "powerpoint";
+
+/**
+ * Stable identities of the add-in across installs; referenced by Office.
+ * `all` is the original multi-host manifest id (macOS sideload folders,
+ * manual downloads). The per-host ids exist for Windows, where each Office
+ * app is registered individually under HKCU\...\WEF\Developer and the
+ * registry value name must be the manifest's Id — so per-app install needs
+ * per-app manifests with distinct ids.
+ *
+ * Keep in sync with the copies in
+ * apps/desktop/electron/office-addin-platform.mjs and
+ * apps/desktop/build/installer.nsh (the NSIS uninstaller cleanup).
+ */
+export const WORD_ADDIN_MANIFEST_IDS: Record<"all" | WordAddinHost, string> = {
+  all: "47744a24-6fd7-4ee5-b981-97b16ce5d488",
+  word: "fdea378d-ff62-4a4f-af08-d1622c083957",
+  excel: "65facd67-9deb-4356-8072-e2cc6e36d9fe",
+  powerpoint: "db1cc438-a239-4b01-b732-2ff838ecca38",
+};
 
 const CONTENT_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -146,13 +164,82 @@ function xmlEscape(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
+/** `<Hosts>` declaration names, in the manifest's declaration order. */
+const HOST_DECLARATIONS: ReadonlyArray<{ host: WordAddinHost; name: string }> = [
+  { host: "word", name: "Document" },
+  { host: "excel", name: "Workbook" },
+  { host: "powerpoint", name: "Presentation" },
+];
+
+/** VersionOverrides blocks, in the manifest's (historical) block order. */
+const VERSION_OVERRIDE_HOSTS: ReadonlyArray<{ host: WordAddinHost; xsiType: string; idInfix: string }> = [
+  { host: "word", xsiType: "Document", idInfix: "" },
+  { host: "powerpoint", xsiType: "Presentation", idInfix: "Ppt." },
+  { host: "excel", xsiType: "Workbook", idInfix: "Excel." },
+];
+
+function versionOverrideHostXml(xsiType: string, idInfix: string): string {
+  return `      <Host xsi:type="${xsiType}">
+        <DesktopFormFactor>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="LegalWork.${idInfix}Group">
+                <Label resid="LegalWork.GroupLabel"/>
+                <Icon>
+                  <bt:Image size="16" resid="LegalWork.Icon16"/>
+                  <bt:Image size="32" resid="LegalWork.Icon32"/>
+                  <bt:Image size="80" resid="LegalWork.Icon80"/>
+                </Icon>
+                <Control xsi:type="Button" id="LegalWork.${idInfix}OpenPane">
+                  <Label resid="LegalWork.OpenPane.Label"/>
+                  <Supertip>
+                    <Title resid="LegalWork.OpenPane.Label"/>
+                    <Description resid="LegalWork.OpenPane.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="LegalWork.Icon16"/>
+                    <bt:Image size="32" resid="LegalWork.Icon32"/>
+                    <bt:Image size="80" resid="LegalWork.Icon80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>LegalWork.TaskPane</TaskpaneId>
+                    <SourceLocation resid="LegalWork.Taskpane.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>`;
+}
+
 /**
- * Add-in only manifest (XML) for a Word task pane. The base URL is the
- * HTTPS listener this server starts; Word requires HTTPS even on localhost.
+ * Add-in only manifest (XML) for the Office task pane. The base URL is the
+ * HTTPS listener this server starts; Office requires HTTPS even on localhost.
+ *
+ * Without `host` this is the multi-host manifest (Word + Excel + PowerPoint)
+ * used on macOS and for manual downloads. With `host` it is a single-host
+ * manifest with that host's stable id — Windows registers each Office app
+ * individually in the registry, keyed by manifest id.
  */
-export function buildWordAddinManifest(input: { baseUrl: string; version?: string }): string {
+export function buildWordAddinManifest(input: {
+  baseUrl: string;
+  version?: string;
+  host?: WordAddinHost;
+}): string {
   const base = xmlEscape(input.baseUrl.replace(/\/+$/, ""));
   const version = /^\d+\.\d+\.\d+\.\d+$/.test(input.version ?? "") ? input.version : "1.0.0.0";
+  const manifestId = WORD_ADDIN_MANIFEST_IDS[input.host ?? "all"];
+  const hostDeclarations = HOST_DECLARATIONS.filter(
+    (entry) => !input.host || entry.host === input.host,
+  )
+    .map((entry) => `    <Host Name="${entry.name}"/>`)
+    .join("\n");
+  const versionOverrideHosts = VERSION_OVERRIDE_HOSTS.filter(
+    (entry) => !input.host || entry.host === input.host,
+  )
+    .map((entry) => versionOverrideHostXml(entry.xsiType, entry.idInfix))
+    .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>
 <OfficeApp
   xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
@@ -160,7 +247,7 @@ export function buildWordAddinManifest(input: { baseUrl: string; version?: strin
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides"
   xsi:type="TaskPaneApp">
-  <Id>${WORD_ADDIN_MANIFEST_ID}</Id>
+  <Id>${manifestId}</Id>
   <Version>${version}</Version>
   <ProviderName>Eigenwelt Labs</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
@@ -173,9 +260,7 @@ export function buildWordAddinManifest(input: { baseUrl: string; version?: strin
     <AppDomain>${base}</AppDomain>
   </AppDomains>
   <Hosts>
-    <Host Name="Document"/>
-    <Host Name="Workbook"/>
-    <Host Name="Presentation"/>
+${hostDeclarations}
   </Hosts>
   <DefaultSettings>
     <SourceLocation DefaultValue="${base}/word-addin/taskpane.html"/>
@@ -183,102 +268,7 @@ export function buildWordAddinManifest(input: { baseUrl: string; version?: strin
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
-      <Host xsi:type="Document">
-        <DesktopFormFactor>
-          <ExtensionPoint xsi:type="PrimaryCommandSurface">
-            <OfficeTab id="TabHome">
-              <Group id="LegalWork.Group">
-                <Label resid="LegalWork.GroupLabel"/>
-                <Icon>
-                  <bt:Image size="16" resid="LegalWork.Icon16"/>
-                  <bt:Image size="32" resid="LegalWork.Icon32"/>
-                  <bt:Image size="80" resid="LegalWork.Icon80"/>
-                </Icon>
-                <Control xsi:type="Button" id="LegalWork.OpenPane">
-                  <Label resid="LegalWork.OpenPane.Label"/>
-                  <Supertip>
-                    <Title resid="LegalWork.OpenPane.Label"/>
-                    <Description resid="LegalWork.OpenPane.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="LegalWork.Icon16"/>
-                    <bt:Image size="32" resid="LegalWork.Icon32"/>
-                    <bt:Image size="80" resid="LegalWork.Icon80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>LegalWork.TaskPane</TaskpaneId>
-                    <SourceLocation resid="LegalWork.Taskpane.Url"/>
-                  </Action>
-                </Control>
-              </Group>
-            </OfficeTab>
-          </ExtensionPoint>
-        </DesktopFormFactor>
-      </Host>
-      <Host xsi:type="Presentation">
-        <DesktopFormFactor>
-          <ExtensionPoint xsi:type="PrimaryCommandSurface">
-            <OfficeTab id="TabHome">
-              <Group id="LegalWork.Ppt.Group">
-                <Label resid="LegalWork.GroupLabel"/>
-                <Icon>
-                  <bt:Image size="16" resid="LegalWork.Icon16"/>
-                  <bt:Image size="32" resid="LegalWork.Icon32"/>
-                  <bt:Image size="80" resid="LegalWork.Icon80"/>
-                </Icon>
-                <Control xsi:type="Button" id="LegalWork.Ppt.OpenPane">
-                  <Label resid="LegalWork.OpenPane.Label"/>
-                  <Supertip>
-                    <Title resid="LegalWork.OpenPane.Label"/>
-                    <Description resid="LegalWork.OpenPane.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="LegalWork.Icon16"/>
-                    <bt:Image size="32" resid="LegalWork.Icon32"/>
-                    <bt:Image size="80" resid="LegalWork.Icon80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>LegalWork.TaskPane</TaskpaneId>
-                    <SourceLocation resid="LegalWork.Taskpane.Url"/>
-                  </Action>
-                </Control>
-              </Group>
-            </OfficeTab>
-          </ExtensionPoint>
-        </DesktopFormFactor>
-      </Host>
-      <Host xsi:type="Workbook">
-        <DesktopFormFactor>
-          <ExtensionPoint xsi:type="PrimaryCommandSurface">
-            <OfficeTab id="TabHome">
-              <Group id="LegalWork.Excel.Group">
-                <Label resid="LegalWork.GroupLabel"/>
-                <Icon>
-                  <bt:Image size="16" resid="LegalWork.Icon16"/>
-                  <bt:Image size="32" resid="LegalWork.Icon32"/>
-                  <bt:Image size="80" resid="LegalWork.Icon80"/>
-                </Icon>
-                <Control xsi:type="Button" id="LegalWork.Excel.OpenPane">
-                  <Label resid="LegalWork.OpenPane.Label"/>
-                  <Supertip>
-                    <Title resid="LegalWork.OpenPane.Label"/>
-                    <Description resid="LegalWork.OpenPane.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="LegalWork.Icon16"/>
-                    <bt:Image size="32" resid="LegalWork.Icon32"/>
-                    <bt:Image size="80" resid="LegalWork.Icon80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>LegalWork.TaskPane</TaskpaneId>
-                    <SourceLocation resid="LegalWork.Taskpane.Url"/>
-                  </Action>
-                </Control>
-              </Group>
-            </OfficeTab>
-          </ExtensionPoint>
-        </DesktopFormFactor>
-      </Host>
+${versionOverrideHosts}
     </Hosts>
     <Resources>
       <bt:Images>

--- a/docs/word-addin.md
+++ b/docs/word-addin.md
@@ -55,7 +55,10 @@ Then open Word/Excel/PowerPoint → Home → Add-ins → Developer Add-ins →
 LegalWork. (Restart the Office app once after the very first sideload.)
 
 Opt out with `LEGALWORK_WORD_ADDIN=0 pnpm dev`; re-run just the sideload
-with `pnpm office:sideload`. Windows sideloading is not automated yet.
+with `pnpm office:sideload`. On Windows the sideload writes the manifest to
+`~/.legalwork/office-addin-dev/` and registers it under
+`HKCU\Software\Microsoft\Office\16.0\WEF\Developer` (one multi-host
+registration covers Word, Excel, and PowerPoint).
 
 ## Manual setup (standalone CLI server)
 
@@ -100,7 +103,12 @@ cp legalwork-word-addin.manifest.xml \
 
 Then in Word: **Home → Add-ins ▾ (or Insert → My Add-ins) → Developer Add-ins → LegalWork**.
 
-**Word on Windows** — use the Office toolchain:
+**Word on Windows** — register the manifest in the registry (what
+`pnpm office:sideload` automates): save the manifest somewhere stable, then
+add a `REG_SZ` value under
+`HKCU\Software\Microsoft\Office\16.0\WEF\Developer` whose name is the
+manifest's `<Id>` and whose data is the manifest's full path. Alternatively
+use the Office toolchain:
 
 ```powershell
 npx office-addin-debugging start legalwork-word-addin.manifest.xml desktop --app word
@@ -195,7 +203,9 @@ open the pane.
 
 In a packaged desktop build, users install the add-in from **Settings →
 Office Add-ins** (a desktop-only global tab). Install/uninstall runs in the
-Electron main process (`apps/desktop/electron/office-addin-manager.mjs`):
+Electron main process (`office-addin-manager.mjs`, with the OS-specific
+pieces in `office-addin-platform.mjs`) and is supported on macOS and
+Windows:
 
 - **Certificate.** Generates a per-install CA that is *name-constrained to
   localhost/loopback* (`office-addin-cert.mjs`) — unlike the dev flow's
@@ -203,22 +213,44 @@ Electron main process (`apps/desktop/electron/office-addin-manager.mjs`):
   the machine it cannot sign for real domains; the constraint is proven by
   `office-addin-cert.test.mjs` (a CA-signed cert for `evil.example.com`
   fails validation). The CA key never leaves the machine and is never
-  shared between installs.
-- **Trust.** Adds the CA to the login keychain via one native auth prompt
-  (macOS). No sudo, no shared key. The constraint is enforced by the OS:
-  with the CA trusted, `security verify-cert` accepts the localhost leaf but
-  rejects a cert for any real domain signed by the same CA.
+  shared between installs. On macOS generation shells out to the system
+  LibreSSL; on Windows it runs in pure JS (`office-addin-cert-web.mjs`,
+  @peculiar/x509 on top of Node's native webcrypto) so no external tools
+  are needed. `office-addin-cert-web.test.mjs` proves the JS output —
+  including the name-constraint rejection — against the OpenSSL verifier.
+- **Trust.** macOS adds the CA to the login keychain via one native auth
+  prompt (`security add-trusted-cert`); Windows adds it to the CurrentUser
+  Root store via `certutil -user -addstore Root`, which shows one native
+  confirmation dialog (no admin). No sudo, no shared key. The name
+  constraint is enforced by both OSes' chain validation.
 - **Manifests.** Written per app: each of Word/Excel/PowerPoint is installed
   and uninstalled individually from the settings tab; the certificate and
-  listener are shared and are torn down with the last uninstall.
+  listener are shared and are torn down with the last uninstall. On macOS
+  the multi-host manifest is copied into each app's `wef` folder. On
+  Windows each app gets a *single-host* manifest with its own stable id
+  (`WORD_ADDIN_MANIFEST_IDS` in `apps/server/src/word-addin.ts`), registered
+  as a `REG_SZ` value under `HKCU\...\Office\16.0\WEF\Developer` (value
+  name = manifest id, data = manifest path in userData) — the same registry
+  sideload Microsoft's `office-addin-dev-settings` uses.
 - **Listener.** Persists an enabled flag (`office-addins.json` in userData);
   `startLegalworkServer` reads it and passes the cert/key/dist to the
   embedded server so the HTTPS listener comes up on every launch. Uninstall
   removes manifests, untrusts + deletes the CA, and stops the listener.
+- **Windows uninstaller.** The NSIS uninstaller
+  (`apps/desktop/build/installer.nsh`) removes the registry registrations
+  and the trusted CA when LegalWork itself is uninstalled, so Office apps
+  are not left pointing at a dead manifest. Auto-updates skip this cleanup.
 
 The packaged task pane bundle ships via electron-builder `extraResources`
-(`../app/dist-word-addin` → `word-addin-dist`). Currently macOS only;
-Windows install is stubbed (status reports `supported: false`).
+(`../app/dist-word-addin` → `word-addin-dist`) on all platforms.
+
+Windows notes: the pane requires an Office build that renders add-ins in
+**Edge WebView2** (Microsoft 365 current channel; WebView2 runtime
+installed). Older EdgeHTML/IE11 webviews block localhost loopback inside
+their AppContainer and are not supported. Office installed from the
+**Microsoft Store** cannot load registry-sideloaded add-ins at all — the
+installer detects this (WindowsApps executable path) and refuses with a
+clear error instead of appearing to succeed.
 
 Dev note: the `pnpm dev` flow still enables the listener via
 `LEGALWORK_WORD_ADDIN=1` and the dev certificate, independently of the
@@ -226,11 +258,7 @@ settings tab. In dev the tab may therefore show "Not installed" while the
 pane already works from the env path; in production (no env var) the tab is
 the sole control and its status is authoritative.
 
-## Production / desktop distribution (future work)
+## Known limitations
 
-- The desktop app can enable `wordAddin` on its embedded server and ship the
-  built bundle; the installer should install a trusted localhost certificate
-  (what `office-addin-dev-certs` does for dev) and drop the manifest into the
-  Word sideload location.
 - Settings navigation inside the pane is intentionally disabled; flows that
   need it (e.g. connecting a model provider) must be done in the LegalWork app.

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -311,13 +311,14 @@ export type OfficeAddinAppStatus = {
   installed: boolean;
   /** The user has installed the LegalWork add-in for this app. */
   enabled: boolean;
-  /** The LegalWork manifest is present in this app's sideload folder. */
+  /** The LegalWork manifest is sideloaded (wef folder on macOS, registry on Windows). */
   manifestInstalled: boolean;
 };
 
 export type OfficeAddinStatus = {
-  /** The current platform supports installing the add-in (macOS today). */
+  /** The current platform supports installing the add-in (macOS and Windows). */
   supported: boolean;
+  /** process.platform of the desktop app, e.g. "darwin" | "win32". */
   platform: string;
   /** OpenSSL (needed to generate the certificate) is available. */
   toolAvailable: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,15 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.17.3
         version: 1.17.3
+      '@peculiar/asn1-schema':
+        specifier: ^2.8.0
+        version: 2.8.0
+      '@peculiar/asn1-x509':
+        specifier: ^2.8.0
+        version: 2.8.0
+      '@peculiar/x509':
+        specifier: ^2.0.0
+        version: 2.0.0
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -260,6 +269,9 @@ importers:
       node-pty:
         specifier: npm:@lydell/node-pty@1.2.0-beta.12
         version: '@lydell/node-pty@1.2.0-beta.12'
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       yaml:
         specifier: ^2.6.1
         version: 2.8.2
@@ -1625,6 +1637,43 @@ packages:
   '@pdf-lib/upng@1.0.1':
     resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@2.0.0':
+    resolution: {integrity: sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==}
+    engines: {node: '>=20.0.0'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -2773,6 +2822,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
@@ -5475,6 +5528,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -5612,6 +5672,9 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -6203,6 +6266,10 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -8029,6 +8096,99 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@2.0.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -9123,6 +9283,12 @@ snapshots:
 
   aria-hidden@1.2.6:
     dependencies:
+      tslib: 2.8.1
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
       tslib: 2.8.1
 
   assert-plus@1.0.0:
@@ -12146,6 +12312,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -12299,6 +12471,8 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  reflect-metadata@0.2.2: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -13017,6 +13191,10 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,10 +338,10 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       legalwork-server:
-        specifier: 0.0.12
+        specifier: 0.0.13
         version: link:../server
       opencode-router:
-        specifier: 0.0.12
+        specifier: 0.0.13
         version: link:../opencode-router
       solid-js:
         specifier: 1.9.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,10 +326,10 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       legalwork-server:
-        specifier: 0.0.11
+        specifier: 0.0.12
         version: link:../server
       opencode-router:
-        specifier: 0.0.11
+        specifier: 0.0.12
         version: link:../opencode-router
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Summary

Makes the Office add-in (Word/Excel/PowerPoint task pane) fully installable on Windows from **Settings → Office Add-ins**, with no external tools required on end-user machines. macOS behavior is unchanged.

- **Platform backends** — OS-specific pieces (trust store, manifest sideloading, app detection/launch) extracted from `office-addin-manager.mjs` into `office-addin-platform.mjs`; the macOS implementation moved as-is, win32 added.
- **Trust (win32)** — `certutil -user -addstore Root` into the CurrentUser Root store (one native confirmation dialog, no admin), with the same prompt-denial detection as the macOS keychain flow.
- **Manifests (win32)** — per-app single-host manifests with stable ids (`WORD_ADDIN_MANIFEST_IDS` in `apps/server/src/word-addin.ts`), registered as `REG_SZ` values under `HKCU\...\Office\16.0\WEF\Developer` (value name = manifest id, data = manifest path) — the same registry sideload Microsoft's `office-addin-dev-settings` performs.
- **Certificates (win32)** — generated in pure JS (`office-addin-cert-web.mjs`, `@peculiar/x509` on Node's native webcrypto). The module only loads on win32; macOS keeps the system LibreSSL path untouched. Cross-generator tests verify the JS output with the OpenSSL verifier, including the localhost name-constraint rejection of an `evil.example.com` leaf.
- **Store Office guard** — Office installed from the Microsoft Store (WindowsApps path) can't load registry-sideloaded add-ins; install now fails fast with a clear error, before any OS prompts.
- **NSIS uninstall cleanup** (`build/installer.nsh`) — removes the registry registrations and the trusted CA when LegalWork is uninstalled; skipped during auto-updates.
- **Dev flow** — `pnpm office:sideload` now registers the manifest on Windows too; `npx` spawns fixed for Windows shells.
- **UI/i18n/docs** — platform-aware settings copy (keychain vs Windows security dialog) in EN/DE; `docs/word-addin.md` production section rewritten.

## Test plan

- [x] `pnpm --filter @legalwork/desktop test` — 34 pass (incl. new `office-addin-platform.test.mjs` and `office-addin-cert-web.test.mjs` cross-generator proofs)
- [x] `bun test src/word-addin.e2e.test.ts` — per-host manifest ids and host filtering
- [x] `pnpm typecheck`, `pnpm typecheck:electron`, `pnpm check:electron`
- [x] QA on a real Windows machine with real Office: install → open pane in Word → uninstall, deny-prompt paths, NSIS uninstall cleanup (WebView2-era Office required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)