### PR TITLE
fix(release): keep pnpm-lock.yaml consistent after CI version stamping

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -119,7 +119,12 @@ jobs:
         shell: bash
         env:
           ALPHA_VERSION: ${{ steps.alpha-version.outputs.alpha_version }}
-        run: node scripts/release/apply-version.mjs --version "$ALPHA_VERSION"
+        # Lockfile-only resync keeps pnpm-lock.yaml consistent with the stamped
+        # orchestrator dependency pins so later pnpm invocations don't reject
+        # the workspace (installs stay explicit + frozen before this step).
+        run: |
+          node scripts/release/apply-version.mjs --version "$ALPHA_VERSION"
+          pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Write notary API key
         if: env.MACOS_NOTARIZE == 'true'

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -211,7 +211,7 @@ jobs:
             $DRAFT_FLAG $PRERELEASE_FLAG
 
   verify-release:
-    name: Verify Release Versions
+    name: Verify Release Tag
     needs: resolve-release
     # SignPath trusted builds require every job leading to the Windows signing
     # request to use GitHub-hosted runners.
@@ -335,11 +335,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # After the frozen-lockfile install so the 0.0.0 placeholder specifiers
-      # still match pnpm-lock.yaml; electron-builder, the updater feed, and
-      # app.getVersion() all pick the stamped version up from package.json.
+      # After the frozen-lockfile install; electron-builder, the updater feed,
+      # and app.getVersion() all pick the stamped version up from package.json.
+      # The lockfile-only resync keeps pnpm-lock.yaml consistent with the
+      # stamped orchestrator dependency pins (workspace links, no re-resolution)
+      # so later pnpm invocations in this job don't reject the workspace.
       - name: Stamp release version from tag
-        run: node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+        shell: bash
+        run: |
+          node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+          pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Write Electron notary API key (macOS)
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
@@ -621,7 +626,10 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Stamp release version from tag
-        run: node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+        shell: bash
+        run: |
+          node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+          pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Resolve sidecar versions
         id: sidecar-versions
@@ -737,7 +745,10 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Stamp release version from tag
-        run: node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+        shell: bash
+        run: |
+          node scripts/release/apply-version.mjs --tag "$RELEASE_TAG"
+          pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Resolve package versions
         id: package-versions

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,12 @@ catalogs:
     react-dom: 18.2.0
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+# pnpm 11 re-verifies manifests vs lockfile before every `pnpm run` and
+# auto-installs on drift. Release builds intentionally drift: CI stamps the
+# tag version into package.json after the frozen-lockfile install
+# (scripts/release/apply-version.mjs), which the auto-install then rejects.
+# Installs are always explicit here, so skip the pre-run check.
+verifyDepsBeforeRun: false
 allowBuilds:
   "@whiskeysockets/baileys": true
   better-sqlite3: true


### PR DESCRIPTION
## Problem

The v0.1.0 release run failed in all five Electron build jobs with `ERR_PNPM_OUTDATED_LOCKFILE`. pnpm 11 re-verifies manifests vs lockfile before every `pnpm run` (`verify-deps-before-run`, effective default `install`) and spawns an install on drift — which in CI runs frozen and rejects the workspace. Stamping the orchestrator's exact `legalwork-server`/`opencode-router` pins (#19) after the frozen install creates exactly that drift. Locally the same check silently auto-heals the lockfile (frozen defaults off), which is why it never reproduced.

## Fix

- **Stamp steps resync the lockfile in the runner**: `pnpm install --lockfile-only --no-frozen-lockfile` right after `apply-version.mjs` (release: electron/sidecars/npm jobs; alpha: stamp step). Only the two importer specifiers change, resolutions stay `link:` workspace links (~4s, nothing committed). After this the "lockfile not up to date with package.json" condition cannot occur.
- **`verifyDepsBeforeRun: false`** in `pnpm-workspace.yaml`: installs are always explicit in this repo, and release builds drift by design.
- Rename the verify job to **Verify Release Tag** (missed in #19; steps were already updated).

## Verification

Simulated the CI sequence locally: frozen install state → stamp `v9.9.9` → lockfile-only resync (specifiers follow, 3.9s) → `pnpm --filter @legalwork/desktop run …` in CI mode **with the deps check force-enabled** runs clean. Both workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)