### PR TITLE
fix(desktop): bundle fflate into the packaged app (v0.1.2 hotfix)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "electron-updater": "^6.3.9",
+    "fflate": "^0.8.3",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
     "node-pty": "npm:@lydell/node-pty@1.2.0-beta.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       jsonc-parser:
         specifier: ^3.2.1
         version: 3.3.1


### PR DESCRIPTION
## Fix: bundle `fflate` into the packaged desktop app

### The bug
v0.1.2 crashed at runtime on the benchmark's document paths:

```
Cannot find package 'fflate' imported from
/Applications/LegalWork.app/Contents/Resources/app.asar/server/dist/benchmarks/extract-text.js
```

(v0.1.2 has been rolled back to a draft.)

### Root cause
The desktop app ships the server as **unbundled `tsc` output**, so its runtime imports resolve against `app.asar/node_modules`. That folder is populated by electron-builder from a **manual allowlist of the server's runtime deps in `apps/desktop/package.json`** (better-sqlite3, drizzle-orm, zod, yaml, …). `fflate` — added to `apps/server` for the benchmark's `extract-text` / `task-zip` — was never mirrored into that allowlist, so it wasn't packaged. It worked in dev (pnpm hoists it across the workspace) but not when packaged.

Checked: `fflate` is the **only** server runtime dep missing from the desktop allowlist, so nothing else is lurking for the next release.

### Fix
- Add `fflate@^0.8.3` to `apps/desktop/package.json` dependencies (+ `pnpm-lock.yaml`).

### Verified
Built a local packaged app from this branch (`package:electron:dir`) and confirmed:
- `app.asar/node_modules/fflate/**` is present.
- `server/dist/benchmarks/{extract-text,task-zip}.js` resolve it.

### Follow-up (not in this PR)
Add a `release:review` check that fails if `apps/desktop` doesn't list every runtime dep the unbundled server imports, so this class of bug can't ship again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
