### PR TITLE
feat(auth): add "Sign in with Anthropic" provider

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   Plus,
   Search,
+  TriangleAlert,
   X,
 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
@@ -302,9 +303,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
-  const isClaudeProMaxMethod = (method: ProviderAuthMethod) => {
+  // The "Claude Pro/Max" method signs in with a consumer Claude subscription
+  // rather than a Console API key. Anthropic's Consumer Terms restrict that
+  // OAuth to Claude Code / claude.ai, so we surface a warning before use.
+  const isClaudeSubscriptionMethod = (method: ProviderAuthMethod) => {
     const label = method.label.toLowerCase();
-    return method.type === "oauth" && (label.includes("pro/max") || label.includes("create an api key"));
+    return method.type === "oauth" && label.includes("pro/max");
   };
 
   const entries = useMemo<ProviderAuthEntry[]>(() => {
@@ -317,9 +321,6 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       .flatMap((id) => {
         const provider = providersById.get(id);
         const entryMethods = (methods[id] ?? []).filter((method) => {
-          if (isAnthropicProvider(id, provider?.name) && isClaudeProMaxMethod(method)) {
-            return false;
-          }
           if (!isOpenAiProvider(id, provider?.name)) return true;
           if (method.type !== "oauth") return true;
           if (isRemoteWorker) return isOpenAiHeadlessMethod(method);
@@ -1060,6 +1061,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
         ? "Use OpenAI's device flow for remote workers, where the browser callback may not resolve on your local machine."
         : "Use OpenAI's device flow when the local browser callback is unreliable.";
     }
+    if (isAnthropicProvider(entry.id, entry.name) && isClaudeSubscriptionMethod(method)) {
+      return "Sign in with your Claude Pro/Max subscription. See the warning above — third-party subscription use may violate Anthropic's terms.";
+    }
     if (method.type === "oauth") {
       return "Continue in the browser and let LegalWork finish the connection automatically.";
     }
@@ -1068,6 +1072,29 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     }
     return "Paste a secret key that LegalWork stores locally on this device.";
   };
+
+  const anthropicSubscriptionWarning = (
+    <div className="flex items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3 text-[12px] leading-relaxed text-amber-11">
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+      <span>
+        Claude Pro/Max sign-in uses your personal Claude subscription. Anthropic&apos;s Consumer Terms
+        limit this OAuth to Claude Code and claude.ai, so third-party use may violate those terms and
+        can be blocked without notice. For reliable, permitted access, use &ldquo;Create an API Key&rdquo;
+        or enter an Anthropic API key instead.
+      </span>
+    </div>
+  );
+
+  const selectedEntryHasClaudeSubscription = Boolean(
+    selectedEntry &&
+      isAnthropicProvider(selectedEntry.id, selectedEntry.name) &&
+      selectedEntry.methods.some(isClaudeSubscriptionMethod),
+  );
+  const oauthSessionIsClaudeSubscription = Boolean(
+    oauthSession &&
+      isAnthropicProvider(oauthSession.providerId) &&
+      oauthSession.methodLabel.toLowerCase().includes("pro/max"),
+  );
 
   return (
     <Dialog
@@ -1198,6 +1225,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       Back
                     </Button>
                   </div>
+                  {selectedEntryHasClaudeSubscription ? anthropicSubscriptionWarning : null}
                   <div className="grid gap-2">
                     {selectedEntry.methods.map((method) => (
                       <button
@@ -1293,6 +1321,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="text-xs text-dls-secondary">
                     Complete sign-in in your browser, then paste the code here.
                   </div>
+                  {oauthSessionIsClaudeSubscription ? anthropicSubscriptionWarning : null}
                   {oauthInstructions ? (
                     <div className="break-all rounded-xl border border-dls-border bg-dls-hover px-3 py-2 font-mono text-[11px] text-dls-secondary">
                       {oauthInstructions}

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -4,6 +4,7 @@ import { ArrowRightIcon, GithubIcon, SearchIcon, SparklesIcon, TriangleAlertIcon
 
 import { Page, PageBackground, PageTitlebarRegion } from "@/components/page";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
+import { ProviderIcon } from "../../design-system/provider-icon";
 
 type ProviderSelectionStepProps = {
   // Pre-selects `providerId` and opens the real connect flow in the session.
@@ -54,6 +55,16 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                       <div className="min-w-0 flex-1">
                         <div className="text-[14px] font-medium text-dls-text">Sign in with OpenAI</div>
                         <div className="text-[12px] text-dls-secondary">Use your ChatGPT subscription — no API key.</div>
+                      </div>
+                      <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
+                    </button>
+                    <button type="button" className={quickButtonClass} onClick={() => onConnect("anthropic", "oauth")}>
+                      <ProviderIcon providerId="anthropic" size={16} className="shrink-0 text-dls-secondary" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[14px] font-medium text-dls-text">Sign in with Anthropic</div>
+                        <div className="text-[12px] text-dls-secondary">
+                          Use your Claude Pro/Max subscription — subject to Anthropic&apos;s terms.
+                        </div>
                       </div>
                       <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
                     </button>

--- a/apps/server/src/legalwork-runtime-config.test.ts
+++ b/apps/server/src/legalwork-runtime-config.test.ts
@@ -70,6 +70,9 @@ describe("legalwork runtime config file", () => {
     expect(mcp.posthog?.enabled).toBe(true);
     expect(parsed.default_agent).toBe("legalwork");
     expect(Array.isArray(parsed.plugin)).toBe(true);
+    // The Anthropic auth plugin must be wired so "Sign in with Anthropic"
+    // (Claude Pro/Max + Console API-key OAuth) methods are offered by the engine.
+    expect(parsed.plugin as string[]).toContain("opencode-anthropic-auth");
     const agents = parsed.agent as Record<string, Record<string, unknown>>;
     expect(agents.reviewer?.model).toBe("opencode/big-pickle");
   });

--- a/apps/server/src/legalwork-runtime-config.ts
+++ b/apps/server/src/legalwork-runtime-config.ts
@@ -109,6 +109,10 @@ export async function buildLegalworkRuntimeConfigObject(
     },
     plugin: [
       "opencode-chrome-devtools",
+      // Adds "Sign in with Anthropic" auth methods (Claude Pro/Max subscription
+      // OAuth + "Create an API Key" console OAuth) to the provider list. Without
+      // this plugin the engine only offers manual Anthropic API-key entry.
+      "opencode-anthropic-auth",
       legalworkExtensionsPreviewPluginPath(),
       legalworkCapabilitiesKnowledgePluginPath(),
       legalworkAnthropicAdaptiveThinkingPluginPath(),


### PR DESCRIPTION
## Summary
- Adds Anthropic as a first-class sign-in option next to the existing "Sign in with OpenAI" (ChatGPT) flow: a quick-connect button in onboarding + the Anthropic OAuth methods surfaced in the provider modal.
- Loads the `opencode-anthropic-auth` engine plugin so the provider list actually exposes those methods ("Claude Pro/Max" subscription OAuth and "Create an API Key" via Console). Without it, only manual Anthropic API-key entry was available.
- Surfaces a warning on the Claude Pro/Max subscription flow (see **Risk**).

## Why
- Customer request: mirror the "Sign in with ChatGPT" experience for Anthropic. The plumbing was already provider-agnostic (Anthropic label, icon, and pinned ordering existed), but the OAuth methods were hidden and the auth plugin wasn't loaded.

## Issue
- Closes #

## Scope
- `apps/server/src/legalwork-runtime-config.ts` — add `opencode-anthropic-auth` to the engine plugin list.
- `apps/app/.../onboarding/provider-selection-step.tsx` — "Sign in with Anthropic" quick-connect button (`onConnect("anthropic", "oauth")`).
- `apps/app/.../provider-auth/provider-auth-modal.tsx` — stop hiding Anthropic OAuth methods; add a subscription-flow warning in the method-picker and OAuth-code views.
- `apps/server/src/legalwork-runtime-config.test.ts` — assert the auth plugin is wired.

## Out of scope
- No changes to the engine's OAuth implementation itself (client id, endpoints, token handling live in the `opencode-anthropic-auth` plugin / opencode engine).
- No new backend redirect/callback routes (the OAuth round-trip runs inside the engine via the SDK, same as OpenAI).

## Testing
### Ran
- `bun test src/legalwork-runtime-config.test.ts` (apps/server)
- `bun test tests/` (apps/app)
- `tsc -p tsconfig.json --noEmit` (apps/app)

### Result
- pass/fail: **pass** — server config 4/4, app suite 149/149.
- typecheck: no errors in changed files. One pre-existing repo-wide `TS5101` (`baseUrl` deprecation in `apps/app/tsconfig.json`) is unrelated to this diff.

## CI status
- pass: expected
- code-related failures: none observed locally
- external/env/auth blockers: `pnpm install` postinstall for `electron` (403) and `better-sqlite3` native build fail in this sandbox; neither affects the app typecheck or the tests above.

## Manual verification
1. Onboarding → "Sign in with Anthropic" opens the provider modal preselected to Anthropic.
2. Method picker lists Claude Pro/Max (OAuth), Create an API Key (OAuth), and manual API key; the amber warning renders above the methods for the subscription flow.
3. Selecting Claude Pro/Max opens the browser and the paste-code view, which also shows the warning.

## Evidence
- N/A (no runtime screenshot — the OAuth flow requires a live Anthropic sign-in; UI additions verified via tests/typecheck).

## Risk
- **Compliance:** The "Claude Pro/Max" flow authenticates with a consumer Claude subscription. Since Feb 2026, Anthropic's Consumer Terms restrict that OAuth to Claude Code / claude.ai, and server-side safeguards can block third-party subscription use. This was surfaced per the customer's request; the UI carries a clear warning and points users to the Console API-key path (compliant) as the alternative. If Anthropic tightens enforcement, the subscription flow may stop working — the API-key methods are unaffected.
- The engine installs `opencode-anthropic-auth` from npm on demand (same mechanism as `opencode-chrome-devtools`).

## Rollback
- Revert this commit. Removing the plugin entry hides the Anthropic OAuth methods again; the onboarding button and modal changes are self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Au1qmvGz67EUG6ntkn72GS)_