### PR TITLE
fix(engine): bump bundled opencode to v1.17.18 to fix session DB schema mismatch

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -47,7 +47,7 @@
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@lexical/react": "^0.35.0",
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.18",
     "@legalwork/types": "workspace:*",
     "@legalwork/ui": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "office:sideload": "node ./scripts/office-addin-sideload.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.18",
     "@peculiar/asn1-schema": "^2.8.0",
     "@peculiar/asn1-x509": "^2.8.0",
     "@peculiar/x509": "^2.0.0",

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -44,7 +44,7 @@
     "test:npx": "bun scripts/test-npx.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.18",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.13.0",
     "commander": "^12.1.0",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.18",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
     "opencode-router": "0.0.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -46,7 +46,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.18",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "fflate": "^0.8.3",

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.17.3"
+  "opencodeVersion": "v1.17.18"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.18
+        version: 1.17.18
       '@paper-design/shaders-react':
         specifier: 0.0.72
         version: 0.0.72(@types/react@19.2.14)(react@19.2.4)
@@ -240,8 +240,8 @@ importers:
   apps/desktop:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.18
+        version: 1.17.18
       '@peculiar/asn1-schema':
         specifier: ^2.8.0
         version: 2.8.0
@@ -298,8 +298,8 @@ importers:
   apps/opencode-router:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.18
+        version: 1.17.18
       '@slack/socket-mode':
         specifier: ^2.0.5
         version: 2.0.5
@@ -332,8 +332,8 @@ importers:
   apps/orchestrator:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.18
+        version: 1.17.18
       '@opentui/core':
         specifier: 0.1.77
         version: 0.1.77(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -378,8 +378,8 @@ importers:
   apps/server:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.18
+        version: 1.17.18
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -1578,8 +1578,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.17.3':
-    resolution: {integrity: sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg==}
+  '@opencode-ai/sdk@1.17.18':
+    resolution: {integrity: sha512-c/C9PhY8PrbcxDY+JIYtOZsrmMD0KzoVvxq+RGUrZ6LQp57SuVBbT4lfwA2G8Se5RNC1N5JtYjiuaXeECnF2SQ==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -8031,7 +8031,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.17.3':
+  '@opencode-ai/sdk@1.17.18':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary

Fixes #30 — `SQLiteError: no such column: replacement_seq` on every new session.

## Root cause

The stack trace (`SessionContextEpoch.requestReplacement`, `bun:sqlite`) comes from the bundled opencode engine, pinned at **v1.17.3** in `constants.json`. Upstream schema history:

- **2026-06-05** (`20260605003541_add_session_context_snapshot`, in v1.17.3): added `session_context_epoch.replacement_seq`.
- **2026-06-22** (`20260622142730_simplify_session_context_epoch`, shipped v1.17.10+): **dropped** `replacement_seq` (and `agent`, `revision`).

Production LegalWork intentionally uses opencode's default per-platform data dir (`%LOCALAPPDATA%\opencode` on Windows — see `apps/desktop/electron/runtime.mjs`). So any newer system-installed opencode (≥ v1.17.10) that touches that dir migrates the session DB forward and drops the column. The bundled v1.17.3 engine then queries `replacement_seq` on every `createUserMessage` and fails — exactly the reporter's symptom of every *new* session erroring while one long-running window (attached to a different engine process) keeps working.

## Change

- Bump pinned engine `constants.json` `opencodeVersion`: `v1.17.3` → `v1.17.18` (latest).
- Bump `@opencode-ai/sdk` to `^1.17.18` in the five workspace packages that depend on it, plus lockfile.

v1.17.18 no longer references `replacement_seq` and knows all newer migrations, so it works with both already-forward-migrated DBs and DBs still on the v1.17.3 schema (it migrates them forward). Upstream's schema changelog notes the simplify migration has no public HTTP API or generated SDK schema changes; release notes for 1.17.4–1.17.18 are additive/bugfix only.

All version references (`apps/server`, CI, release review script, sidecar prep, engine install command) read from `constants.json`, so the single bump covers them.

## Testing

- `pnpm typecheck` (app) ✅
- `apps/server`, `apps/orchestrator`, `apps/opencode-router` typecheck ✅
- `apps/server` `pnpm test:artifacts` — 22 pass, 0 fail ✅

## Follow-up (not in this PR)

The engine resolver falls back to PATH / known locations (`runtime.mjs` `resolveBinaryInfo`), so engine/DB skew can recur whenever a user has a different system opencode. Worth considering an `engineDoctor` warning when the resolved engine version differs from the pinned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)