### PR TITLE
fix(ci): put alpha sha in prerelease, not build metadata — pnpm can't workspace-link +sha versions

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -109,8 +109,13 @@ jobs:
           sha="${GITHUB_SHA:0:7}"
           sha="${sha:-local}"
           echo "Latest release tag: $latest_tag -> alpha base ${major}.${minor}.${next_patch}"
+          # The commit sha rides in the prerelease part (…-alpha.<run>.<sha>),
+          # not as +<sha> build metadata: pnpm refuses to workspace-link the
+          # exact-pinned internal deps (legalwork-server, opencode-router) when
+          # the stamped version carries build metadata, and falls back to the
+          # public npm registry (404 / name-squatted package).
           {
-            echo "alpha_version=${major}.${minor}.${next_patch}-alpha.${run}+${sha}"
+            echo "alpha_version=${major}.${minor}.${next_patch}-alpha.${run}.${sha}"
             echo "base_version=${major}.${minor}.${next_patch}"
             echo "release_tag=alpha-macos-v${major}.${minor}.${next_patch}-alpha.${run}-${sha}"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The alpha channel run for the v1.17.18 engine bump failed at **Stamp alpha version** ([run 29104193309](https://github.com/eigenweltlabs/legalwork/actions/runs/29104193309)):

```
[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/legalwork-server: Not Found - 404
```

## Root cause

Since #21, the stamp step runs `pnpm install --lockfile-only --no-frozen-lockfile` after stamping. When the stamped version carries **build metadata** (`0.1.4-alpha.35+ce66c40`), pnpm fails to workspace-link the exact-pinned internal deps that `apply-version.mjs` writes into `apps/orchestrator/package.json`, and resolves them against the public npm registry instead:

- `legalwork-server` → 404 (not published)
- `opencode-router` → version not found (an unrelated public package squats the name)

Verified by local repro of the exact CI steps: prerelease-only versions (`0.1.4-alpha.35`) link fine; any stamped version with `+sha` fails, even when only the package `version` fields carry it. Stable releases stamp plain tag versions and were never affected — the alpha workflow simply hadn't run since #21 landed (last successful alpha on 2026-07-06 predates it).

## Change

Move the commit sha from build metadata into a fourth prerelease identifier:

```
0.1.4-alpha.35+ce66c40  →  0.1.4-alpha.35.ce66c40
```

Semver ordering is preserved: `alpha.35.<sha> < alpha.36.<sha>` (numeric run counter compares first), and any stable `0.1.4` still beats every `0.1.4-alpha.*`. Nothing downstream parses the `+sha` back out — the run-specific release tag already used a dash form (`alpha-macos-v…-alpha.35-ce66c40`) since git tags can't contain `+`.

## Testing

- Local repro of the CI stamp + lockfile step on `dev`: fails with `+ce66c40`, passes with `.ce66c40` ✅
- Alpha workflow dispatched from this branch to validate end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)