### PR TITLE
Eigenwelt free-model provider (replaces OpenCode Zen default)

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -144,6 +144,12 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
+      - name: Bake Eigenwelt free-mint key
+        shell: bash
+        env:
+          EIGENWELT_FREE_MINT_KEY: ${{ secrets.EIGENWELT_FREE_MINT_KEY }}
+        run: node scripts/release/bake-mint-key.mjs
+
       - name: Build Electron alpha app
         shell: bash
         env:

--- a/.github/workflows/alpha-windows-x64.yml
+++ b/.github/workflows/alpha-windows-x64.yml
@@ -137,6 +137,12 @@ jobs:
           node scripts/release/apply-version.mjs --version "$ALPHA_VERSION"
           pnpm install --lockfile-only --no-frozen-lockfile
 
+      - name: Bake Eigenwelt free-mint key
+        shell: bash
+        env:
+          EIGENWELT_FREE_MINT_KEY: ${{ secrets.EIGENWELT_FREE_MINT_KEY }}
+        run: node scripts/release/bake-mint-key.mjs
+
       - name: Build Electron alpha app
         shell: bash
         env:

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -379,6 +379,12 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
+      - name: Bake Eigenwelt free-mint key
+        shell: bash
+        env:
+          EIGENWELT_FREE_MINT_KEY: ${{ secrets.EIGENWELT_FREE_MINT_KEY }}
+        run: node scripts/release/bake-mint-key.mjs
+
       - name: Build Electron app
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://github.com/user-attachments/assets/4a576c3a-7c2a-46c6-9856-1254282b1b70
 - **Tabular review** — extract terms across many documents into a sourced grid.
 - **Draft** briefs, memos, contracts, and engagement letters.
 - **Bring your own model** — AWS Bedrock, Azure OpenAI, or any provider. Your data is only ever shared with the model you choose.
+- **Free models included** — Eigenwelt provides free models to try LegalWork, no login required. Free-tier usage data is logged, so don't use them with privileged, client, or matter data — testing only — see [`TERMS.md`](./TERMS.md).
 - **Runs on this machine** by default; connect a remote worker only when you want to.
 - **Extend it** with skills, plugins, and MCP connectors, managed in **Settings → Extensions** and shared across every workspace.
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,6 +1,6 @@
 # LegalWork — Terms & Conditions
 
-**Last updated: 26 June 2026**
+**Last updated: 10 July 2026**
 
 LegalWork is a local-first desktop application published by **Eigenwelt Labs**
 (Berlin, Germany) ("Eigenwelt", "we", "us"). These Terms & Conditions ("Terms")
@@ -11,17 +11,20 @@ agree, do not use the App.
 ## 1. What LegalWork is
 
 LegalWork is a desktop "cowork" application for legal work — document review,
-drafting, and related tasks. It runs on your own computer. You bring your own AI
-model: you can run open-source models locally, or connect a hosted model using
-your own API keys. The App is free for individual use. Enterprise deployment and
-the Eigenwelt continual-learning training platform are offered separately under a
-commercial agreement.
+drafting, and related tasks. It runs on your own computer. You choose the AI
+model: you can run open-source models locally, connect a hosted model using
+your own API keys, or use the free models provided by Eigenwelt (Section 3).
+The App is free for individual use. Enterprise deployment and the Eigenwelt
+continual-learning training platform are offered separately under a commercial
+agreement.
 
 ## 2. Your account and your data stay local
 
 The App is local-first. Your documents, prompts, drafts, file contents, and the
 results of your tasks are stored and processed on your own device. We do not
-receive them.
+receive them, with one exception: if you use the free models described in
+Section 3, the prompts and outputs of those requests are sent to and logged by
+Eigenwelt.
 
 When you connect a third-party model provider (for example via your own API
 keys), the content you choose to send for inference is transmitted to that
@@ -30,7 +33,25 @@ agreement with that provider, not by these Terms. You are responsible for
 choosing providers appropriate for your confidentiality and professional
 obligations. If you run a model locally, no inference content leaves your device.
 
-## 3. Usage analytics (PostHog) — off unless you turn it on
+## 3. Free models provided by Eigenwelt
+
+The App includes free models provided by Eigenwelt for **testing purposes**.
+No account or login is required to use them.
+
+If you choose free models, we will log usage data for those requests. Please
+do not use free models with privileged, client, or matter data — use them
+only to try the App. The App shows a notice when a free model is in use.
+
+The free tier is usage-limited (a small per-device daily allowance and rate
+limits). Limits, the set of available free models, and the free tier itself
+may change or be withdrawn at any time.
+
+For real work, the paid **Eigenwelt Model API** uses prepaid organization
+credits and API keys owned by your firm, with zero prompt retention at the
+gateway: we record only token counts, the model used, cost, and timestamps —
+never prompt or output content.
+
+## 4. Usage analytics (PostHog) — off unless you turn it on
 
 To understand which features are used and to improve the product, the App can
 send **anonymous product-usage analytics** to [PostHog](https://posthog.com), our
@@ -60,14 +81,14 @@ The only exception is text you type directly into an explicit in-app survey fiel
 sent because you entered it for that purpose. Analytics is fire-and-forget and
 never blocks or slows the App.
 
-## 4. License
+## 5. License
 
 The LegalWork source code is made available under the license described in the
 [`LICENSE`](./LICENSE) file. These Terms govern your use of the official App
 builds we distribute and do not limit any rights granted to you under the
 open-source license.
 
-## 5. Acceptable use
+## 6. Acceptable use
 
 You agree to use the App lawfully and in accordance with your own professional and
 ethical obligations. You are responsible for the matters and data you process with
@@ -75,14 +96,14 @@ the App, including any duties of confidentiality, privilege, and data protection
 that apply to them. Do not use the App to violate the rights of others or any
 applicable law.
 
-## 6. No legal advice
+## 7. No legal advice
 
 LegalWork is a software tool that assists with legal work. It does not provide
 legal advice, and it is not a substitute for the professional judgment of a
 qualified lawyer. AI models can produce incorrect or incomplete output. You are
 responsible for reviewing and verifying any output before relying on it.
 
-## 7. No warranty
+## 8. No warranty
 
 The App is provided "as is" and "as available", without warranty of any kind,
 express or implied, including warranties of merchantability, fitness for a
@@ -90,7 +111,7 @@ particular purpose, and non-infringement. We do not warrant that the App will be
 uninterrupted, error-free, or that any output will be accurate or fit for your
 purpose.
 
-## 8. Limitation of liability
+## 9. Limitation of liability
 
 To the maximum extent permitted by law, Eigenwelt Labs will not be liable for any
 indirect, incidental, special, consequential, or punitive damages, or for any loss
@@ -98,20 +119,20 @@ of data, profits, or business, arising out of or in connection with your use of
 the App. Nothing in these Terms excludes liability that cannot be excluded under
 applicable law.
 
-## 9. Changes to these Terms
+## 10. Changes to these Terms
 
 We may update these Terms from time to time. When we do, we will update the "Last
-updated" date above. Material changes to how usage analytics works will be
-reflected here. Your continued use of the App after an update means you accept the
+updated" date above. Material changes to how usage analytics or the free models
+work will be reflected here. Your continued use of the App after an update means you accept the
 revised Terms.
 
-## 10. Governing law
+## 11. Governing law
 
 These Terms are governed by the laws of Germany, without regard to conflict-of-law
 rules. The courts of Berlin, Germany have jurisdiction over any dispute, to the
 extent permitted by applicable law.
 
-## 11. Contact
+## 12. Contact
 
 Questions about these Terms or about analytics:
 

--- a/apps/app/src/app/lib/eigenwelt-free-budget.ts
+++ b/apps/app/src/app/lib/eigenwelt-free-budget.ts
@@ -1,0 +1,137 @@
+/**
+ * Eigenwelt FREE-tier daily-limit handling.
+ *
+ * Every install's free-tier key is budget-capped per day by the Eigenwelt
+ * gateway (LiteLLM). Once the daily allowance is used up, the gateway answers
+ * HTTP 429 with an error message containing "Budget has been exceeded". The
+ * engine treats that like any transient provider error and retries with
+ * backoff forever. These helpers implement the LegalWork policy on top of the
+ * engine's retry loop:
+ *
+ * - detection is gated on the failing request's provider being
+ *   `eigenwelt-free` (all other providers and all other error kinds keep the
+ *   default retry behavior),
+ * - the engine gets at most {@link EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS}
+ *   attempts, after which the app aborts the run and renders a friendly
+ *   terminal "daily limit reached" card pointing at the upgrade page.
+ *
+ * Everything in here is pure/registry state so it can be unit tested without
+ * React or the engine.
+ *
+ * NOTE: this module deliberately mirrors (and stays independent of) the paid
+ * branch's `eigenwelt-budget.ts` so the two can merge without collisions; a
+ * shared refactor can happen once both are on the same branch.
+ */
+
+export const EIGENWELT_FREE_PROVIDER_ID = "eigenwelt-free";
+
+/** Upgrade/contact page, opened externally via `openDesktopUrl`. */
+export const EIGENWELT_FREE_UPGRADE_URL = "https://eigenweltlabs.com/contact";
+
+/** Stop the engine's retry loop after this many budget-exceeded attempts. */
+export const EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS = 3;
+
+export const EIGENWELT_FREE_LIMIT_TITLE = "Daily free-model limit reached";
+export const EIGENWELT_FREE_LIMIT_BODY =
+  "You've used today's free allowance. Upgrade for higher limits — or come back tomorrow.";
+export const EIGENWELT_FREE_UPGRADE_LABEL = "Upgrade";
+
+/**
+ * Text of the synthetic terminal error message injected into the transcript
+ * when the app stops a daily-limit retry loop. The chat renderer detects this
+ * exact copy (via {@link isEigenweltFreeLimitErrorText}) and swaps the plain
+ * error block for the dedicated limit card, so only stops the app itself
+ * gated on the eigenwelt-free provider ever render the card.
+ */
+export const EIGENWELT_FREE_LIMIT_ERROR_TEXT =
+  `${EIGENWELT_FREE_LIMIT_TITLE}. ${EIGENWELT_FREE_LIMIT_BODY}`;
+
+/** LiteLLM budget error marker (key-level daily budget: "Budget has been exceeded! Current cost: ... Max budget: ..."). */
+const BUDGET_MESSAGE_PATTERN = /budget has been exceeded/i;
+
+/**
+ * True only when the failing request went through the Eigenwelt free tier AND
+ * the error is LiteLLM's budget-exceeded. Any other provider (including the
+ * paid `eigenwelt` provider) or error keeps the engine's default retry
+ * behavior.
+ */
+export function isEigenweltFreeBudgetError(
+  providerId: string | null | undefined,
+  errorMessage: string | null | undefined,
+): boolean {
+  if (providerId !== EIGENWELT_FREE_PROVIDER_ID) return false;
+  if (!errorMessage) return false;
+  return BUDGET_MESSAGE_PATTERN.test(errorMessage);
+}
+
+/**
+ * True once the engine has burned through the allowed budget-exceeded
+ * attempts and the app must abort the run instead of letting it back off
+ * forever.
+ */
+export function shouldStopEigenweltFreeBudgetRetry(
+  providerId: string | null | undefined,
+  errorMessage: string | null | undefined,
+  attempt: number,
+): boolean {
+  if (!isEigenweltFreeBudgetError(providerId, errorMessage)) return false;
+  return attempt >= EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS;
+}
+
+/** Matches only the copy injected by the daily-limit stop path. */
+export function isEigenweltFreeLimitErrorText(text: string | null | undefined): boolean {
+  return Boolean(text && text.includes(EIGENWELT_FREE_LIMIT_TITLE));
+}
+
+/**
+ * Action block attached to the retry banner while the (up to 3) budget
+ * retries are still running, so the upgrade button is available before the
+ * run is stopped. Shape mirrors the engine's `SessionStatus` retry action.
+ */
+export function eigenweltFreeBudgetRetryAction(): {
+  reason: string;
+  provider: string;
+  title: string;
+  message: string;
+  label: string;
+  link?: string;
+} {
+  return {
+    reason: "budget_exceeded",
+    provider: EIGENWELT_FREE_PROVIDER_ID,
+    title: "Out of free usage?",
+    message: EIGENWELT_FREE_LIMIT_BODY,
+    label: EIGENWELT_FREE_UPGRADE_LABEL,
+    link: EIGENWELT_FREE_UPGRADE_URL,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pending-stop registry
+// ---------------------------------------------------------------------------
+//
+// The abort issued by the app makes the engine emit a `session.error` with a
+// generic MessageAbortedError ("The message was interrupted"). The session
+// surface marks the session here right before aborting; the event-sync layer
+// consumes the mark and substitutes the daily-limit copy so the terminal
+// message in the chat is the friendly limit card instead of the generic
+// interrupt.
+
+const PENDING_STOP_TTL_MS = 60_000;
+const pendingStops = new Map<string, number>();
+
+export function markEigenweltFreeBudgetStop(sessionId: string, now: number = Date.now()): void {
+  pendingStops.set(sessionId, now);
+}
+
+/**
+ * Returns true (once) when a daily-limit stop was marked for the session
+ * within the TTL. Consuming removes the mark so a later, unrelated session
+ * error is not mislabeled.
+ */
+export function consumeEigenweltFreeBudgetStop(sessionId: string, now: number = Date.now()): boolean {
+  const markedAt = pendingStops.get(sessionId);
+  if (markedAt === undefined) return false;
+  pendingStops.delete(sessionId);
+  return now - markedAt <= PENDING_STOP_TTL_MS;
+}

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -134,7 +134,22 @@ export type LegalworkSessionSnapshot = {
   status:
     | { type: "idle" }
     | { type: "busy" }
-    | { type: "retry"; attempt: number; message: string; next: number };
+    | {
+        type: "retry";
+        attempt: number;
+        message: string;
+        next: number;
+        // Mirrors the engine's `SessionStatus` retry action (the chat renders
+        // it as a titled block with an optional external-link button).
+        action?: {
+          reason: string;
+          provider: string;
+          title: string;
+          message: string;
+          label: string;
+          link?: string;
+        };
+      };
 };
 
 export type LegalworkPluginItem = {

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -21,6 +21,13 @@ import {
 } from "ai"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { openDesktopUrl } from "@/app/lib/desktop"
+import {
+  EIGENWELT_FREE_LIMIT_BODY,
+  EIGENWELT_FREE_LIMIT_TITLE,
+  EIGENWELT_FREE_UPGRADE_LABEL,
+  EIGENWELT_FREE_UPGRADE_URL,
+  isEigenweltFreeLimitErrorText,
+} from "@/app/lib/eigenwelt-free-budget"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
@@ -602,12 +609,48 @@ interface ErrorMessageProps {
 }
 
 function ErrorMessage({ error }: ErrorMessageProps) {
+  if (isEigenweltFreeLimitErrorText(error)) {
+    return <FreeLimitReachedMessage />
+  }
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
         <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
           <p className="whitespace-pre-wrap text-destructive">{error}</p>
+        </div>
+      </div>
+    </Message>
+  )
+}
+
+/**
+ * Terminal card for an Eigenwelt free-tier daily-limit stop (the app aborts
+ * the run after the allowed retries — see app/lib/eigenwelt-free-budget).
+ * Flat, lined border; friendly copy — the state resolves by upgrading or by
+ * waiting for tomorrow's allowance.
+ */
+function FreeLimitReachedMessage() {
+  return (
+    <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
+      <div className="flex w-full min-w-0 flex-col gap-2 rounded-lg border border-dls-border bg-dls-surface px-4 py-3">
+        <div className="flex items-start gap-2">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-700" />
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-medium text-foreground">
+              {EIGENWELT_FREE_LIMIT_TITLE}
+            </p>
+            <p className="text-sm text-muted-foreground">{EIGENWELT_FREE_LIMIT_BODY}</p>
+          </div>
+        </div>
+        <div className="ml-6">
+          <Button
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => void openDesktopUrl(EIGENWELT_FREE_UPGRADE_URL)}
+          >
+            {EIGENWELT_FREE_UPGRADE_LABEL}
+          </Button>
         </div>
       </div>
     </Message>

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -96,9 +96,9 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                     <div className="flex max-w-sm items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3">
                       <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
                       <p className="text-[12px] leading-relaxed text-amber-11">
-                        Free models are provided by Eigenwelt. Prompts and outputs are logged and
-                        used to improve our models — don&apos;t use them with client or matter data.
-                        For real work, connect your own model above.
+                        Free models are provided by Eigenwelt for testing only. Eigenwelt logs
+                        usage data for these requests — don&apos;t use them with privileged, client,
+                        or matter data. For real work, connect your own model above.
                       </p>
                     </div>
                   </div>

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -96,9 +96,9 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                     <div className="flex max-w-sm items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3">
                       <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
                       <p className="text-[12px] leading-relaxed text-amber-11">
-                        Free models are provided by Eigenwelt for testing only. Eigenwelt logs
-                        usage data for these requests — don&apos;t use them with privileged, client,
-                        or matter data. For real work, connect your own model above.
+                        Free models are provided by Eigenwelt to try LegalWork. Usage data is
+                        logged, so please keep privileged, client, and matter data out. For real
+                        work, connect your own model above.
                       </p>
                     </div>
                   </div>

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -96,9 +96,9 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                     <div className="flex max-w-sm items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3">
                       <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
                       <p className="text-[12px] leading-relaxed text-amber-11">
-                        Free models are slower, lower-quality test models, and these providers may
-                        train on what you send them. Don&apos;t use them with client or matter data;
-                        use them only to try LegalWork. Connect your own model above for real work.
+                        Free models are provided by Eigenwelt. Prompts and outputs are logged and
+                        used to improve our models — don&apos;t use them with client or matter data.
+                        For real work, connect your own model above.
                       </p>
                     </div>
                   </div>

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -96,7 +96,7 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                     <div className="flex max-w-sm items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3">
                       <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
                       <p className="text-[12px] leading-relaxed text-amber-11">
-                        Free models are provided by Eigenwelt to try LegalWork. Usage data is
+                        Free models are included to try LegalWork. Usage data is
                         logged, so please keep privileged, client, and matter data out. For real
                         work, connect your own model above.
                       </p>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -108,7 +108,7 @@ export type SessionSurfaceProps = {
   modelPickerOpen: boolean;
   modelUnavailable?: boolean;
   selectedModel: ModelRef;
-  /** True when the active model is a free OpenCode Zen model (no-key fallback). */
+  /** True when the active model is a free-tier model (no-key fallback). */
   freeModelSelected?: boolean;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
@@ -289,19 +289,19 @@ function TodoPanel(props: { todos: TodoItem[] }) {
 }
 
 /**
- * Banner shown above the composer whenever the active model is a free OpenCode
- * Zen model (the no-key fallback). Free Zen models are lower-performance and
- * their provider may train on the inputs they receive, so they must not be used
- * with client/matter data — only to try the app.
+ * Banner shown above the composer whenever the active model is a free model
+ * (the no-key fallback, served by Eigenwelt's free gateway). Free-tier
+ * prompts and outputs are logged and used to improve models, so they must
+ * not be used with client/matter data — only to try the app.
  */
 function FreeModelNotice() {
   return (
     <div className="flex items-start gap-2.5 border-b border-dls-border bg-amber-2/40 px-4 py-3">
       <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-11" />
       <p className="text-xs leading-relaxed text-amber-11">
-        <span className="font-medium">Free test model.</span>{" "}
-        Lower-quality, and this provider may train on what you send it. Don&apos;t
-        use it with client or matter data. Connect your own model for real work.
+        <span className="font-medium">Free Eigenwelt model.</span>{" "}
+        Prompts and outputs are logged and used to improve models. Don&apos;t use
+        it with client or matter data. Connect your own model for real work.
       </p>
     </div>
   );

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -307,7 +307,7 @@ function FreeModelNotice() {
     <div className="flex items-start gap-2.5 border-b border-dls-border bg-amber-2/40 px-4 py-3">
       <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-11" />
       <p className="text-xs leading-relaxed text-amber-11">
-        <span className="font-medium">Free Eigenwelt model.</span>{" "}
+        <span className="font-medium">Free model.</span>{" "}
         Usage data is logged, so please keep privileged, client, and matter data
         out. For real work, connect your own model.
       </p>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -7,6 +7,13 @@ import { Check, Minimize2, TriangleAlert } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
+import {
+  EIGENWELT_FREE_LIMIT_ERROR_TEXT,
+  eigenweltFreeBudgetRetryAction,
+  isEigenweltFreeBudgetError,
+  markEigenweltFreeBudgetStop,
+  shouldStopEigenweltFreeBudgetRetry,
+} from "@/app/lib/eigenwelt-free-budget";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { isOfficeAddinRuntime } from "@/app/lib/runtime-env";
@@ -55,6 +62,7 @@ import { QueuedMessagesPanel } from "@/react-app/domains/session/modals/queued-m
 import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
+  injectSessionErrorMessage,
   seedSessionState,
   snapshotKey as reactSnapshotKey,
   statusKey as reactStatusKey,
@@ -290,18 +298,18 @@ function TodoPanel(props: { todos: TodoItem[] }) {
 
 /**
  * Banner shown above the composer whenever the active model is a free model
- * (the no-key fallback, served by Eigenwelt's free gateway). Free-tier
- * prompts and outputs are logged and used to improve models, so they must
- * not be used with client/matter data — only to try the app.
+ * (the no-key fallback, served by Eigenwelt's free gateway). Free-tier usage
+ * data is logged, so free models are for testing only — never for
+ * privileged, client, or matter data.
  */
 function FreeModelNotice() {
   return (
     <div className="flex items-start gap-2.5 border-b border-dls-border bg-amber-2/40 px-4 py-3">
       <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-11" />
       <p className="text-xs leading-relaxed text-amber-11">
-        <span className="font-medium">Free Eigenwelt model.</span>{" "}
-        Prompts and outputs are logged and used to improve models. Don&apos;t use
-        it with client or matter data. Connect your own model for real work.
+        <span className="font-medium">Free Eigenwelt model — for testing only.</span>{" "}
+        Eigenwelt logs usage data for these requests. Don&apos;t use it with
+        privileged, client, or matter data. Connect your own model for real work.
       </p>
     </div>
   );
@@ -493,6 +501,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
   const initializedAutoOpenSessionRef = useRef<string | null>(null);
+  // One daily-limit stop per failing run (re-armed by session switch, a new
+  // busy attempt, or a failed abort).
+  const budgetStopFiredRef = useRef(false);
   const opencodeClient = useMemo(
     () => createClient(props.opencodeBaseUrl, undefined, { token: props.legalworkToken, mode: "legalwork" }),
     [props.opencodeBaseUrl, props.legalworkToken],
@@ -535,6 +546,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // switching sessions preserves each session's own in-progress composer.
     autoOpenedTargetRef.current = null;
     initializedAutoOpenSessionRef.current = null;
+    budgetStopFiredRef.current = false;
     setVerifiedOpenTargets([]);
   }, [props.sessionId]);
 
@@ -616,6 +628,58 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
     return "ready";
   }, [liveStatus, sending]);
+
+  // --- Eigenwelt free-tier daily-limit retries -----------------------------
+  // Gateway budget errors (LiteLLM 429 "Budget has been exceeded" on the
+  // free key's daily budget) never resolve on their own, so the engine's
+  // endless retry/backoff loop is pointless. Policy: let it retry up to 3
+  // attempts (with an upgrade action on the banner), then abort the run and
+  // surface the friendly terminal limit card. Gated on the session's selected
+  // provider being `eigenwelt-free`; every other provider/error keeps the
+  // engine's default retry behavior.
+  const budgetRetryActive =
+    liveStatus.type === "retry" &&
+    isEigenweltFreeBudgetError(props.selectedModel.providerID, liveStatus.message);
+  const retryStatusForDisplay = useMemo(() => {
+    if (liveStatus.type !== "retry") return null;
+    if (!budgetRetryActive || liveStatus.action) return liveStatus;
+    return { ...liveStatus, action: eigenweltFreeBudgetRetryAction() };
+  }, [budgetRetryActive, liveStatus]);
+  useEffect(() => {
+    // A fresh attempt (busy) re-arms the guard so a later prompt that hits
+    // the daily limit again is stopped again.
+    if (liveStatus.type === "busy") budgetStopFiredRef.current = false;
+  }, [liveStatus.type]);
+  useEffect(() => {
+    if (liveStatus.type !== "retry") return;
+    if (!shouldStopEigenweltFreeBudgetRetry(props.selectedModel.providerID, liveStatus.message, liveStatus.attempt)) return;
+    if (budgetStopFiredRef.current) return;
+    budgetStopFiredRef.current = true;
+    const attempt = liveStatus.attempt;
+    // Stop means stop (mirrors handleAbort): drop queued follow-ups so the
+    // queue-drain effect doesn't re-prompt straight into the same limit wall.
+    clearQueuedDrafts(props.sessionId);
+    // Render the terminal card immediately; the engine's abort error for the
+    // same turn reconciles into this message (see session-sync's
+    // budget-stop substitution).
+    injectSessionErrorMessage(props.workspaceId, props.sessionId, EIGENWELT_FREE_LIMIT_ERROR_TEXT);
+    markEigenweltFreeBudgetStop(props.sessionId);
+    void (async () => {
+      const aborted = await abortSessionSafe(
+        opencodeClient,
+        props.sessionId,
+        props.workspaceRoot.trim() || undefined,
+      );
+      if (!aborted) {
+        // Engine unreachable or scope mismatch — re-arm so the next retry
+        // event tries the abort again instead of backing off forever.
+        budgetStopFiredRef.current = false;
+        return;
+      }
+      captureAnalyticsEvent("task_run_free_limit_stopped", { attempts: attempt });
+      await snapshotQuery.refetch();
+    })();
+  }, [clearQueuedDrafts, liveStatus, opencodeClient, props.selectedModel.providerID, props.sessionId, props.workspaceId, props.workspaceRoot, snapshotQuery.refetch]);
   const renderedMessages = useMemo(
     () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
     [snapshot, transcriptState],
@@ -1365,7 +1429,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       <MessageList
                         messages={renderedMessages}
                         status={status}
-                        retryStatus={liveStatus.type === "retry" ? liveStatus : null}
+                        retryStatus={retryStatusForDisplay}
                       />
                     </MessageListProvider>
                   </EnvironmentVariableProvider>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -307,9 +307,9 @@ function FreeModelNotice() {
     <div className="flex items-start gap-2.5 border-b border-dls-border bg-amber-2/40 px-4 py-3">
       <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-11" />
       <p className="text-xs leading-relaxed text-amber-11">
-        <span className="font-medium">Free model.</span>{" "}
-        Usage data is logged, so please keep privileged, client, and matter data
-        out. For real work, connect your own model.
+        <span className="font-medium">Free test model.</span>{" "}
+        Lower-quality, and zero data retention is not guaranteed. Don&apos;t use
+        it with client or matter data. Connect your own model for real work.
       </p>
     </div>
   );

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -307,9 +307,9 @@ function FreeModelNotice() {
     <div className="flex items-start gap-2.5 border-b border-dls-border bg-amber-2/40 px-4 py-3">
       <TriangleAlert size={14} className="mt-0.5 shrink-0 text-amber-11" />
       <p className="text-xs leading-relaxed text-amber-11">
-        <span className="font-medium">Free Eigenwelt model — for testing only.</span>{" "}
-        Eigenwelt logs usage data for these requests. Don&apos;t use it with
-        privileged, client, or matter data. Connect your own model for real work.
+        <span className="font-medium">Free Eigenwelt model.</span>{" "}
+        Usage data is logged, so please keep privileged, client, and matter data
+        out. For real work, connect your own model.
       </p>
     </div>
   );

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -6,6 +6,7 @@ import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { createClient } from "@/app/lib/opencode";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
+import { consumeEigenweltFreeBudgetStop, EIGENWELT_FREE_LIMIT_ERROR_TEXT } from "@/app/lib/eigenwelt-free-budget";
 import { createSessionErrorUIMessage, describeOpencodeSessionError, snapshotToUIMessages } from "./usechat-adapter";
 import {
   parseDynamicToolUIPart,
@@ -621,7 +622,13 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.error") {
     const sessionId = sessionIdFromProperties(event.properties);
     if (sessionId) {
-      const errorText = describeOpencodeSessionError(sessionErrorFromProperties(event.properties));
+      // A daily-limit stop aborts the run from the app side, so the engine
+      // reports a generic MessageAbortedError here. Substitute the limit copy
+      // so the terminal chat message renders as the friendly limit card
+      // instead of "The message was interrupted".
+      const errorText = consumeEigenweltFreeBudgetStop(sessionId)
+        ? EIGENWELT_FREE_LIMIT_ERROR_TEXT
+        : describeOpencodeSessionError(sessionErrorFromProperties(event.properties));
       const runStartedAt = takeTaskRunStart(sessionId);
       if (runStartedAt !== null) {
         captureAnalyticsEvent("task_run_errored", {
@@ -1149,6 +1156,24 @@ export function seedSessionState(workspaceId: string, snapshot: LegalworkSession
 
   queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
   queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);
+}
+
+/**
+ * Surface a client-originated terminal error in the chat transcript.
+ *
+ * Uses the same per-turn keying as the live `session.error` handler (errored
+ * assistant message id, session id fallback) so the injected message
+ * reconciles with — instead of duplicating — the error the engine reports for
+ * the same turn. Used by the free-tier daily-limit stop path, which knows the
+ * run failed before the engine's abort error arrives.
+ */
+export function injectSessionErrorMessage(workspaceId: string, sessionId: string, text: string) {
+  const queryClient = getReactQueryClient();
+  useSessionActivityStore.getState().setError(workspaceId, sessionId, text);
+  queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId), (current = []) => {
+    const turnKey = latestAssistantMessageId(current) ?? sessionId;
+    return upsertMessage(current, createSessionErrorUIMessage(turnKey, text));
+  });
 }
 
 /**

--- a/apps/app/src/react-app/infra/provider-list-query.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.ts
@@ -95,10 +95,10 @@ export const EIGENWELT_FREE_PROVIDER_ID = "eigenwelt-free";
 
 /**
  * True when `model` is a *free-tier* model — the no-key models the app falls
- * back to when no paid provider is configured. Free-tier prompts and outputs
- * are logged and used to improve models (Eigenwelt free gateway) or may be
- * trained on (OpenCode Zen, the fallback when the Eigenwelt platform is
- * unreachable), so the UI warns before they're used with client/matter data.
+ * back to when no paid provider is configured. Usage data is logged for
+ * free-tier requests (Eigenwelt free gateway) or may be retained (OpenCode
+ * Zen, the fallback when the Eigenwelt platform is unreachable), so the UI
+ * warns before they're used with privileged, client, or matter data.
  *
  * Every model on the `eigenwelt-free` provider is free by definition. For the
  * built-in `opencode` provider only zero-cost models count, so genuinely-

--- a/apps/app/src/react-app/infra/provider-list-query.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.ts
@@ -89,26 +89,68 @@ export function isModelAvailableInConnectedProviders(
 /** The built-in OpenCode Zen provider id (its free tier works without a key). */
 export const OPENCODE_ZEN_PROVIDER_ID = "opencode";
 
+/** The Eigenwelt free-tier provider the server injects when the platform's
+ * free-models manifest is available (no login). Zen is disabled while it is. */
+export const EIGENWELT_FREE_PROVIDER_ID = "eigenwelt-free";
+
 /**
- * True when `model` is an OpenCode Zen *free-tier* model — the zero-cost models
- * the engine falls back to when no paid provider is configured. These are hosted
- * by OpenCode Zen, which (per their terms) may train on the inputs sent to them,
- * so the UI warns before they're used with client/matter data.
+ * True when `model` is a *free-tier* model — the no-key models the app falls
+ * back to when no paid provider is configured. Free-tier prompts and outputs
+ * are logged and used to improve models (Eigenwelt free gateway) or may be
+ * trained on (OpenCode Zen, the fallback when the Eigenwelt platform is
+ * unreachable), so the UI warns before they're used with client/matter data.
  *
- * Scoped to the built-in `opencode` provider so genuinely-private zero-cost
- * models (local Ollama / LM Studio endpoints) are NOT mistaken for free Zen
- * models. Paid Zen models report a non-zero cost and so are excluded too.
+ * Every model on the `eigenwelt-free` provider is free by definition. For the
+ * built-in `opencode` provider only zero-cost models count, so genuinely-
+ * private zero-cost models (local Ollama / LM Studio endpoints) are NOT
+ * mistaken for free-tier models and paid Zen models are excluded too.
  */
 export function isFreeOpencodeModel(
   value: ProviderListResponse | null | undefined,
   model: ModelRef | null | undefined,
 ): boolean {
   if (!model?.providerID || !model.modelID) return false;
-  if (model.providerID.trim().toLowerCase() !== OPENCODE_ZEN_PROVIDER_ID) return false;
+  const providerId = model.providerID.trim().toLowerCase();
+  if (providerId === EIGENWELT_FREE_PROVIDER_ID) return true;
+  if (providerId !== OPENCODE_ZEN_PROVIDER_ID) return false;
   const provider = getConnectedProviderItems(value).find((entry) => entry.id === model.providerID);
   const cost = provider?.models?.[model.modelID]?.cost;
   if (!cost) return false;
   return (cost.input ?? 0) === 0 && (cost.output ?? 0) === 0;
+}
+
+/**
+ * One-time free-tier migration for existing installs. Older installs
+ * persisted their selected/default model on the engine's built-in OpenCode
+ * Zen provider (`opencode`). When the server starts injecting the
+ * `eigenwelt-free` provider it also disables zen, which would strand that
+ * persisted selection behind a permanent "model no longer available" state.
+ *
+ * Returns the replacement ModelRef — the free provider's first model — when
+ * ALL of these hold, and null otherwise:
+ *  - the persisted model sits on the zen provider,
+ *  - zen no longer serves it (disabled providers drop out of `connected`),
+ *  - `eigenwelt-free` is connected and has at least one model.
+ *
+ * Null on an unloaded provider list, so callers can run it on every
+ * provider-list load: once the selection is remapped (or the user picks any
+ * non-zen model) the first condition fails and this is a no-op — idempotent
+ * by construction.
+ */
+export function remapZenSelectionToEigenweltFree(
+  value: ProviderListResponse | null | undefined,
+  model: ModelRef | null | undefined,
+): ModelRef | null {
+  if (!value) return null;
+  if (!model?.providerID || !model.modelID) return null;
+  if (model.providerID.trim().toLowerCase() !== OPENCODE_ZEN_PROVIDER_ID) return null;
+  if (isModelAvailableInConnectedProviders(value, model)) return null;
+  const free = getConnectedProviderItems(value).find(
+    (provider) => provider.id === EIGENWELT_FREE_PROVIDER_ID,
+  );
+  const firstModelId = Object.keys(free?.models ?? {})[0];
+  if (!firstModelId) return null;
+  return { providerID: EIGENWELT_FREE_PROVIDER_ID, modelID: firstModelId };
 }
 
 export function getConnectedProviderSnapshotChange(input: {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -576,8 +576,8 @@ export function SessionRoute() {
   }, [providerListQuery.data, local.prefs.defaultModel, setPrefs]);
   // Warn above the composer whenever the active model is a free-tier model
   // (the no-key fallback — Eigenwelt free gateway, or OpenCode Zen when the
-  // platform is unreachable). Free-tier prompts/outputs are logged and used
-  // to improve models, so they must not be used with client/matter data.
+  // platform is unreachable). Free models are for testing only (usage data
+  // is logged) — never for privileged, client, or matter data.
   const freeModelSelected = useMemo(
     () => isFreeOpencodeModel(providerListQuery.data, local.prefs.defaultModel),
     [providerListQuery.data, local.prefs.defaultModel],

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -153,6 +153,7 @@ import {
   isFreeOpencodeModel,
   isModelAvailableInConnectedProviders,
   refreshProviderListQueries,
+  remapZenSelectionToEigenweltFree,
   useProviderListQuery,
 } from "@/react-app/infra/provider-list-query";
 
@@ -557,9 +558,26 @@ export function SessionRoute() {
       !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel),
   );
   const hasUsableModel = Boolean(local.prefs.defaultModel && !selectedModelUnavailable);
-  // Warn above the composer whenever the active model is a free OpenCode Zen
-  // model (the no-key fallback) — those providers may train on inputs, so they
-  // must not be used with client/matter data.
+  // One-time free-tier migration for existing installs: a persisted default
+  // model on the engine's built-in Zen provider ("opencode") strands when the
+  // server injects the eigenwelt-free provider and disables zen. Auto-switch
+  // to the free provider's first model instead of leaving the user stuck on
+  // "model no longer available". Idempotent: after the switch (or any manual
+  // pick of a non-zen model) the remap returns null.
+  const { setPrefs } = local;
+  useEffect(() => {
+    const replacement = remapZenSelectionToEigenweltFree(
+      providerListQuery.data,
+      local.prefs.defaultModel,
+    );
+    if (!replacement) return;
+    setPrefs((previous) => ({ ...previous, defaultModel: replacement, modelVariant: null }));
+    toast(`Free models are now served by Eigenwelt — switched to ${resolveModelDisplayName(replacement.modelID)}.`);
+  }, [providerListQuery.data, local.prefs.defaultModel, setPrefs]);
+  // Warn above the composer whenever the active model is a free-tier model
+  // (the no-key fallback — Eigenwelt free gateway, or OpenCode Zen when the
+  // platform is unreachable). Free-tier prompts/outputs are logged and used
+  // to improve models, so they must not be used with client/matter data.
   const freeModelSelected = useMemo(
     () => isFreeOpencodeModel(providerListQuery.data, local.prefs.defaultModel),
     [providerListQuery.data, local.prefs.defaultModel],

--- a/apps/app/tests/eigenwelt-free-budget.test.ts
+++ b/apps/app/tests/eigenwelt-free-budget.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS,
+  EIGENWELT_FREE_LIMIT_ERROR_TEXT,
+  consumeEigenweltFreeBudgetStop,
+  eigenweltFreeBudgetRetryAction,
+  isEigenweltFreeBudgetError,
+  isEigenweltFreeLimitErrorText,
+  markEigenweltFreeBudgetStop,
+  shouldStopEigenweltFreeBudgetRetry,
+} from "../src/app/lib/eigenwelt-free-budget";
+
+const BUDGET_MESSAGE = "Budget has been exceeded! Current cost: 0.51, Max budget: 0.5";
+
+describe("isEigenweltFreeBudgetError", () => {
+  test("matches only the eigenwelt-free provider with a budget message", () => {
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", BUDGET_MESSAGE)).toBe(true);
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", "budget has been exceeded")).toBe(true);
+  });
+
+  test("never matches other providers — their retry behavior is untouched", () => {
+    expect(isEigenweltFreeBudgetError("eigenwelt", BUDGET_MESSAGE)).toBe(false);
+    expect(isEigenweltFreeBudgetError("anthropic", BUDGET_MESSAGE)).toBe(false);
+    expect(isEigenweltFreeBudgetError("openai", BUDGET_MESSAGE)).toBe(false);
+    expect(isEigenweltFreeBudgetError(null, BUDGET_MESSAGE)).toBe(false);
+    expect(isEigenweltFreeBudgetError(undefined, BUDGET_MESSAGE)).toBe(false);
+  });
+
+  test("never matches other error kinds for eigenwelt-free", () => {
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", "Rate limit exceeded")).toBe(false);
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", "connection reset")).toBe(false);
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", null)).toBe(false);
+    expect(isEigenweltFreeBudgetError("eigenwelt-free", "")).toBe(false);
+  });
+});
+
+describe("shouldStopEigenweltFreeBudgetRetry", () => {
+  test("allows exactly the configured attempts, then stops", () => {
+    for (let attempt = 1; attempt < EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS; attempt++) {
+      expect(shouldStopEigenweltFreeBudgetRetry("eigenwelt-free", BUDGET_MESSAGE, attempt)).toBe(false);
+    }
+    expect(
+      shouldStopEigenweltFreeBudgetRetry("eigenwelt-free", BUDGET_MESSAGE, EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS),
+    ).toBe(true);
+    expect(shouldStopEigenweltFreeBudgetRetry("eigenwelt-free", BUDGET_MESSAGE, 5)).toBe(true);
+  });
+
+  test("never stops other providers regardless of attempts", () => {
+    expect(shouldStopEigenweltFreeBudgetRetry("eigenwelt", BUDGET_MESSAGE, 99)).toBe(false);
+    expect(shouldStopEigenweltFreeBudgetRetry("anthropic", BUDGET_MESSAGE, 99)).toBe(false);
+    expect(shouldStopEigenweltFreeBudgetRetry("eigenwelt-free", "some other error", 99)).toBe(false);
+  });
+});
+
+describe("terminal error text", () => {
+  test("round-trips through the matcher", () => {
+    expect(isEigenweltFreeLimitErrorText(EIGENWELT_FREE_LIMIT_ERROR_TEXT)).toBe(true);
+  });
+
+  test("does not match the raw gateway error or unrelated errors", () => {
+    expect(isEigenweltFreeLimitErrorText(BUDGET_MESSAGE)).toBe(false);
+    expect(isEigenweltFreeLimitErrorText("The message was interrupted")).toBe(false);
+    expect(isEigenweltFreeLimitErrorText(null)).toBe(false);
+  });
+});
+
+describe("retry banner action", () => {
+  test("points at the upgrade/contact page", () => {
+    const action = eigenweltFreeBudgetRetryAction();
+    expect(action.link).toBe("https://eigenweltlabs.com/contact");
+    expect(action.provider).toBe("eigenwelt-free");
+    expect(action.title).toBe("Out of free usage?");
+    expect(action.label).toBe("Upgrade");
+  });
+});
+
+describe("pending-stop registry", () => {
+  test("consume is single-use", () => {
+    markEigenweltFreeBudgetStop("ses_a");
+    expect(consumeEigenweltFreeBudgetStop("ses_a")).toBe(true);
+    expect(consumeEigenweltFreeBudgetStop("ses_a")).toBe(false);
+  });
+
+  test("unmarked sessions never consume", () => {
+    expect(consumeEigenweltFreeBudgetStop("ses_never")).toBe(false);
+  });
+
+  test("marks expire after the TTL", () => {
+    const t0 = 1_000_000;
+    markEigenweltFreeBudgetStop("ses_b", t0);
+    expect(consumeEigenweltFreeBudgetStop("ses_b", t0 + 61_000)).toBe(false);
+  });
+
+  test("marks within the TTL are honored", () => {
+    const t0 = 2_000_000;
+    markEigenweltFreeBudgetStop("ses_c", t0);
+    expect(consumeEigenweltFreeBudgetStop("ses_c", t0 + 59_000)).toBe(true);
+  });
+});

--- a/apps/app/tests/free-model-migration.test.ts
+++ b/apps/app/tests/free-model-migration.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import {
+  EIGENWELT_FREE_PROVIDER_ID,
+  isFreeOpencodeModel,
+  remapZenSelectionToEigenweltFree,
+} from "../src/react-app/infra/provider-list-query";
+
+/**
+ * Free-tier migration for existing installs: persisted selections on the
+ * engine's built-in OpenCode Zen provider ("opencode") strand when the
+ * server injects eigenwelt-free and disables zen. remapZenSelectionToEigenweltFree
+ * is the pure decision function behind the auto-switch in session-route.tsx.
+ */
+
+const ZEN_MODEL = { providerID: "opencode", modelID: "big-pickle" };
+
+function providerList(input: {
+  zenConnected?: boolean;
+  freeConnected?: boolean;
+  freeModels?: Record<string, unknown>;
+}): ProviderListResponse {
+  const all: unknown[] = [];
+  const connected: string[] = [];
+  if (input.zenConnected) {
+    all.push({
+      id: "opencode",
+      name: "OpenCode Zen",
+      source: "custom",
+      models: { "big-pickle": { cost: { input: 0, output: 0 } } },
+    });
+    connected.push("opencode");
+  }
+  if (input.freeConnected) {
+    all.push({
+      id: EIGENWELT_FREE_PROVIDER_ID,
+      name: "Eigenwelt Free",
+      source: "config",
+      models: input.freeModels ?? { "ewl-free-small": {}, "ewl-free-base": {} },
+    });
+    connected.push(EIGENWELT_FREE_PROVIDER_ID);
+  }
+  return { all, connected, default: {} } as ProviderListResponse;
+}
+
+describe("remapZenSelectionToEigenweltFree", () => {
+  test("remaps a stranded zen selection to the free provider's first model", () => {
+    const value = providerList({ zenConnected: false, freeConnected: true });
+    expect(remapZenSelectionToEigenweltFree(value, ZEN_MODEL)).toEqual({
+      providerID: EIGENWELT_FREE_PROVIDER_ID,
+      modelID: "ewl-free-small",
+    });
+  });
+
+  test("does nothing before the provider list has loaded", () => {
+    expect(remapZenSelectionToEigenweltFree(null, ZEN_MODEL)).toBeNull();
+    expect(remapZenSelectionToEigenweltFree(undefined, ZEN_MODEL)).toBeNull();
+  });
+
+  test("does nothing while zen still serves the selected model", () => {
+    const value = providerList({ zenConnected: true, freeConnected: true });
+    expect(remapZenSelectionToEigenweltFree(value, ZEN_MODEL)).toBeNull();
+  });
+
+  test("does nothing when eigenwelt-free is not connected (zen down for other reasons)", () => {
+    const value = providerList({ zenConnected: false, freeConnected: false });
+    expect(remapZenSelectionToEigenweltFree(value, ZEN_MODEL)).toBeNull();
+  });
+
+  test("does nothing when eigenwelt-free has no models", () => {
+    const value = providerList({ zenConnected: false, freeConnected: true, freeModels: {} });
+    expect(remapZenSelectionToEigenweltFree(value, ZEN_MODEL)).toBeNull();
+  });
+
+  test("never touches selections on other providers", () => {
+    const value = providerList({ zenConnected: false, freeConnected: true });
+    expect(
+      remapZenSelectionToEigenweltFree(value, { providerID: "anthropic", modelID: "gone-model" }),
+    ).toBeNull();
+    expect(remapZenSelectionToEigenweltFree(value, null)).toBeNull();
+  });
+
+  test("is idempotent: the remapped selection itself never remaps again", () => {
+    const value = providerList({ zenConnected: false, freeConnected: true });
+    const replacement = remapZenSelectionToEigenweltFree(value, ZEN_MODEL);
+    expect(replacement).not.toBeNull();
+    expect(remapZenSelectionToEigenweltFree(value, replacement)).toBeNull();
+  });
+});
+
+describe("isFreeOpencodeModel with the eigenwelt-free provider", () => {
+  test("every eigenwelt-free model counts as free (warning banner shows)", () => {
+    const value = providerList({ freeConnected: true });
+    expect(
+      isFreeOpencodeModel(value, { providerID: EIGENWELT_FREE_PROVIDER_ID, modelID: "ewl-free-small" }),
+    ).toBe(true);
+  });
+
+  test("zero-cost zen models still count as free", () => {
+    const value = providerList({ zenConnected: true });
+    expect(isFreeOpencodeModel(value, ZEN_MODEL)).toBe(true);
+  });
+
+  test("other providers' models are not free-tier", () => {
+    const value = providerList({ freeConnected: true });
+    expect(isFreeOpencodeModel(value, { providerID: "anthropic", modelID: "claude" })).toBe(false);
+  });
+});

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -56,14 +56,18 @@ if (!existsSync(resolve(wordAddinDistDir, "taskpane.html"))) {
 const serverDistDir = resolve(repoRoot, "apps", "server", "dist");
 const constantsSrc = resolve(repoRoot, "constants.json");
 copyFileSync(constantsSrc, resolve(serverDistDir, "constants.json"));
-const serverJsPath = resolve(serverDistDir, "server.js");
-const serverJsSrc = readFileSync(serverJsPath, "utf8");
-const patched = serverJsSrc.replace(
-  /from\s+["']\.\.\/\.\.\/\.\.\/constants\.json["']/,
-  'from "./constants.json"',
-);
-if (patched !== serverJsSrc) {
-  writeFileSync(serverJsPath, patched, "utf8");
+// Every compiled module importing the repo-root constants.json needs the
+// same rewrite (server.js: opencodeVersion; eigenwelt-free.js: mint key).
+for (const jsFile of ["server.js", "eigenwelt-free.js"]) {
+  const jsPath = resolve(serverDistDir, jsFile);
+  const jsSrc = readFileSync(jsPath, "utf8");
+  const patched = jsSrc.replace(
+    /from\s+["']\.\.\/\.\.\/\.\.\/constants\.json["']/,
+    'from "./constants.json"',
+  );
+  if (patched !== jsSrc) {
+    writeFileSync(jsPath, patched, "utf8");
+  }
 }
 rmSync(packagedServerRoot, { recursive: true, force: true });
 cpSync(serverDistDir, resolve(packagedServerRoot, "dist"), { recursive: true });

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -7,6 +7,7 @@ import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./manag
 import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { keepLegalworkRuntimeConfigFileFresh, writeLegalworkRuntimeConfigFile } from "./legalwork-runtime-config.js";
+import { refreshEigenweltFreeManifest } from "./eigenwelt-free.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -40,6 +41,12 @@ if (!config.opencodeBaseUrl && process.env.LEGALWORK_MANAGE_OPENCODE === "1") {
     // on every runtime-DB write — so disposes always pick up current state.
     const runtimeConfigPath = await writeLegalworkRuntimeConfigFile(config, workspace.id);
     keepLegalworkRuntimeConfigFileFresh(config, workspace.id);
+    // Fire-and-forget: refresh the free-tier manifest disk cache; on change,
+    // rewrite the engine config file so the free provider (and the zen
+    // disable that rides on it) update on the next instance rebuild.
+    void refreshEigenweltFreeManifest(config)
+      .then((changed) => (changed ? writeLegalworkRuntimeConfigFile(config, workspace.id) : undefined))
+      .catch(() => undefined);
     const managedOpencodeCwd = process.env.LEGALWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
     managedOpencode = await createManagedOpencodeServer({

--- a/apps/server/src/eigenwelt-free.test.ts
+++ b/apps/server/src/eigenwelt-free.test.ts
@@ -365,10 +365,10 @@ describe("buildEigenweltFreeProviderBlock", () => {
     expect(block.npm).toBe("@ai-sdk/openai-compatible");
     expect(block.name).toBe("Eigenwelt Free");
     expect(block.options.baseURL).toBe(CACHED_MANIFEST.baseURL);
-    // The device's own key — limits are per-key on the gateway now, so no
-    // x-litellm-end-user-id header may be injected.
-    expect(block.options.apiKey).toBe(CACHED_MANIFEST.apiKey);
-    expect(block.options.headers).toBeUndefined();
+    // The device's own key travels as an Authorization header — the engine
+    // spreads options into createOpenAICompatible, which ignores `apiKey`.
+    expect(block.options.headers).toEqual({ Authorization: `Bearer ${CACHED_MANIFEST.apiKey}` });
+    expect(block.options.apiKey).toBeUndefined();
     // Both limit keys are mandatory for the engine schema.
     expect(block.models["ewl-free-small"]?.limit).toEqual({ context: 32000, output: 16384 });
     expect(block.models["ewl-free-base"]?.limit).toEqual({ context: 128000, output: 16384 });

--- a/apps/server/src/eigenwelt-free.test.ts
+++ b/apps/server/src/eigenwelt-free.test.ts
@@ -46,6 +46,7 @@ type FakePlatform = {
   freeModelsCalls: number;
   freeKeyCalls: number;
   lastFreeKeyDeviceId: string | undefined;
+  lastFreeKeyMintHeader: string | undefined;
   close: () => Promise<void>;
   failFreeModels: boolean;
   failFreeKey: boolean;
@@ -61,6 +62,7 @@ async function startFakePlatform(): Promise<FakePlatform> {
     freeModelsCalls: 0,
     freeKeyCalls: 0,
     lastFreeKeyDeviceId: undefined,
+    lastFreeKeyMintHeader: undefined,
     close: async () => {},
     failFreeModels: false,
     failFreeKey: false,
@@ -82,6 +84,9 @@ async function startFakePlatform(): Promise<FakePlatform> {
     }
     if (req.method === "POST" && req.url === "/api/public/free-key") {
       platform.freeKeyCalls += 1;
+      platform.lastFreeKeyMintHeader = Array.isArray(req.headers["x-eigenwelt-mint-key"])
+        ? req.headers["x-eigenwelt-mint-key"][0]
+        : req.headers["x-eigenwelt-mint-key"];
       let body = "";
       req.on("data", (chunk) => {
         body += String(chunk);
@@ -115,6 +120,7 @@ async function startFakePlatform(): Promise<FakePlatform> {
 
 const previousPlatformUrl = process.env.EIGENWELT_PLATFORM_URL;
 const previousRuntimeDb = process.env.LEGALWORK_RUNTIME_DB;
+const previousMintKey = process.env.EIGENWELT_FREE_MINT_KEY;
 const cleanups: Array<() => Promise<void> | void> = [];
 
 afterEach(async () => {
@@ -124,6 +130,8 @@ afterEach(async () => {
   else process.env.EIGENWELT_PLATFORM_URL = previousPlatformUrl;
   if (previousRuntimeDb === undefined) delete process.env.LEGALWORK_RUNTIME_DB;
   else process.env.LEGALWORK_RUNTIME_DB = previousRuntimeDb;
+  if (previousMintKey === undefined) delete process.env.EIGENWELT_FREE_MINT_KEY;
+  else process.env.EIGENWELT_FREE_MINT_KEY = previousMintKey;
 });
 
 async function setupPlatform(): Promise<FakePlatform> {
@@ -170,6 +178,20 @@ describe("mintEigenweltFreeDeviceKey", () => {
     expect(manifest.apiKey).toBe(FREE_KEY_PAYLOAD.apiKey);
     expect(manifest.baseURL).toBe(FREE_KEY_PAYLOAD.baseURL);
     expect(manifest.models.map((model) => model.id)).toEqual(["ewl-free-small", "ewl-free-base"]);
+  });
+
+  test("sends the baked-in mint token header (env override)", async () => {
+    const platform = await setupPlatform();
+    process.env.EIGENWELT_FREE_MINT_KEY = "mint-token-under-test";
+    await mintEigenweltFreeDeviceKey("device-under-test-1234");
+    expect(platform.lastFreeKeyMintHeader).toBe("mint-token-under-test");
+  });
+
+  test("omits the mint token header when no token is configured", async () => {
+    const platform = await setupPlatform();
+    delete process.env.EIGENWELT_FREE_MINT_KEY;
+    await mintEigenweltFreeDeviceKey("device-under-test-1234");
+    expect(platform.lastFreeKeyMintHeader).toBeUndefined();
   });
 
   test("rejects when the platform is unreachable", async () => {

--- a/apps/server/src/eigenwelt-free.test.ts
+++ b/apps/server/src/eigenwelt-free.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildEigenweltFreeProviderBlock,
+  eigenweltFreeDeviceId,
+  eigenweltFreeManifestCachePath,
+  fetchEigenweltFreeModels,
+  mintEigenweltFreeDeviceKey,
+  readCachedEigenweltFreeManifest,
+  refreshEigenweltFreeManifest,
+  resetEigenweltFreeManifestRefreshThrottleForTests,
+} from "./eigenwelt-free.js";
+import type { ServerConfig } from "./types.js";
+
+const FREE_MODELS = [
+  { id: "ewl-free-small", name: "EWL Free Small", description: "Fast free model", contextLength: 32000 },
+  { id: "ewl-free-base" },
+];
+
+/** What POST /api/public/free-key returns: this device's own key. */
+const FREE_KEY_PAYLOAD = {
+  apiKey: "sk-device-key-1",
+  baseURL: "https://free.gateway.test/v1",
+  models: FREE_MODELS,
+};
+
+/** What GET /api/public/free-models returns: NO key, just the catalog. */
+const FREE_MODELS_PAYLOAD = {
+  baseURL: "https://free.gateway.test/v1",
+  models: FREE_MODELS,
+};
+
+/** A cached manifest as written after a successful mint. */
+const CACHED_MANIFEST = {
+  baseURL: "https://free.gateway.test/v1",
+  apiKey: "sk-device-key-cached",
+  models: FREE_MODELS,
+};
+
+type FakePlatform = {
+  url: string;
+  freeModelsCalls: number;
+  freeKeyCalls: number;
+  lastFreeKeyDeviceId: string | undefined;
+  close: () => Promise<void>;
+  failFreeModels: boolean;
+  failFreeKey: boolean;
+  modelsPayload: Record<string, unknown>;
+  keyPayload: Record<string, unknown>;
+};
+
+/** Throwaway local HTTP server standing in for the Eigenwelt platform's
+ * public free-tier endpoints (free-models + free-key). */
+async function startFakePlatform(): Promise<FakePlatform> {
+  const platform: FakePlatform = {
+    url: "",
+    freeModelsCalls: 0,
+    freeKeyCalls: 0,
+    lastFreeKeyDeviceId: undefined,
+    close: async () => {},
+    failFreeModels: false,
+    failFreeKey: false,
+    modelsPayload: { ...FREE_MODELS_PAYLOAD },
+    keyPayload: { ...FREE_KEY_PAYLOAD },
+  };
+
+  const server: Server = createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/api/public/free-models") {
+      platform.freeModelsCalls += 1;
+      if (platform.failFreeModels) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "gateway unreachable" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(platform.modelsPayload));
+      return;
+    }
+    if (req.method === "POST" && req.url === "/api/public/free-key") {
+      platform.freeKeyCalls += 1;
+      let body = "";
+      req.on("data", (chunk) => {
+        body += String(chunk);
+      });
+      req.on("end", () => {
+        try {
+          platform.lastFreeKeyDeviceId = (JSON.parse(body) as { deviceId?: string }).deviceId;
+        } catch {
+          platform.lastFreeKeyDeviceId = undefined;
+        }
+        if (platform.failFreeKey) {
+          res.writeHead(429, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "rate limited" }));
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(platform.keyPayload));
+      });
+      return;
+    }
+    res.writeHead(404).end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("fake platform failed to bind");
+  platform.url = `http://127.0.0.1:${address.port}`;
+  platform.close = () => new Promise<void>((resolve) => server.close(() => resolve()));
+  return platform;
+}
+
+const previousPlatformUrl = process.env.EIGENWELT_PLATFORM_URL;
+const previousRuntimeDb = process.env.LEGALWORK_RUNTIME_DB;
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  resetEigenweltFreeManifestRefreshThrottleForTests();
+  if (previousPlatformUrl === undefined) delete process.env.EIGENWELT_PLATFORM_URL;
+  else process.env.EIGENWELT_PLATFORM_URL = previousPlatformUrl;
+  if (previousRuntimeDb === undefined) delete process.env.LEGALWORK_RUNTIME_DB;
+  else process.env.LEGALWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+async function setupPlatform(): Promise<FakePlatform> {
+  const platform = await startFakePlatform();
+  cleanups.push(() => platform.close());
+  process.env.EIGENWELT_PLATFORM_URL = platform.url;
+  return platform;
+}
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      { id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local" },
+    ],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function setupRuntimeDb(): Promise<{ root: string; config: ServerConfig }> {
+  const root = await mkdtemp(join(tmpdir(), "legalwork-eigenwelt-free-"));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  process.env.LEGALWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return { root, config: serverConfig(root) };
+}
+
+describe("mintEigenweltFreeDeviceKey", () => {
+  test("POSTs the device id and returns the per-device key manifest", async () => {
+    const platform = await setupPlatform();
+    const manifest = await mintEigenweltFreeDeviceKey("device-under-test-1234");
+    expect(platform.freeKeyCalls).toBe(1);
+    expect(platform.lastFreeKeyDeviceId).toBe("device-under-test-1234");
+    expect(manifest.apiKey).toBe(FREE_KEY_PAYLOAD.apiKey);
+    expect(manifest.baseURL).toBe(FREE_KEY_PAYLOAD.baseURL);
+    expect(manifest.models.map((model) => model.id)).toEqual(["ewl-free-small", "ewl-free-base"]);
+  });
+
+  test("rejects when the platform is unreachable", async () => {
+    const platform = await setupPlatform();
+    await platform.close();
+    await expect(mintEigenweltFreeDeviceKey("device-under-test-1234")).rejects.toThrow(
+      /Could not reach the Eigenwelt platform/,
+    );
+  });
+
+  test("rejects when the platform refuses the mint (429)", async () => {
+    const platform = await setupPlatform();
+    platform.failFreeKey = true;
+    await expect(mintEigenweltFreeDeviceKey("device-under-test-1234")).rejects.toThrow(
+      /did not issue a free key \(HTTP 429\)/,
+    );
+  });
+
+  test("rejects an incomplete payload (missing apiKey)", async () => {
+    const platform = await setupPlatform();
+    platform.keyPayload = { baseURL: "https://free.gateway.test/v1", models: [] };
+    await expect(mintEigenweltFreeDeviceKey("device-under-test-1234")).rejects.toThrow(
+      /invalid free-key payload/,
+    );
+  });
+});
+
+describe("fetchEigenweltFreeModels", () => {
+  test("fetches baseURL and models (no key in this endpoint)", async () => {
+    await setupPlatform();
+    const manifest = await fetchEigenweltFreeModels();
+    expect(manifest.baseURL).toBe(FREE_MODELS_PAYLOAD.baseURL);
+    expect(manifest.models.map((model) => model.id)).toEqual(["ewl-free-small", "ewl-free-base"]);
+  });
+
+  test("rejects when the platform is unreachable", async () => {
+    const platform = await setupPlatform();
+    await platform.close();
+    await expect(fetchEigenweltFreeModels()).rejects.toThrow(/Could not reach the Eigenwelt platform/);
+  });
+
+  test("rejects an invalid payload (missing baseURL)", async () => {
+    const platform = await setupPlatform();
+    platform.modelsPayload = { models: [] };
+    await expect(fetchEigenweltFreeModels()).rejects.toThrow(/invalid free-models manifest/);
+  });
+});
+
+describe("refreshEigenweltFreeManifest", () => {
+  test("first run mints the device key (free-key, not free-models) and caches it", async () => {
+    const platform = await setupPlatform();
+    const { root, config } = await setupRuntimeDb();
+
+    const changed = await refreshEigenweltFreeManifest(config);
+    expect(changed).toBe(true);
+    expect(platform.freeKeyCalls).toBe(1);
+    expect(platform.freeModelsCalls).toBe(0);
+
+    // The mint carried the persisted install device id.
+    const deviceId = (await readFile(join(root, "eigenwelt-free-device-id"), "utf8")).trim();
+    expect(platform.lastFreeKeyDeviceId).toBe(deviceId);
+
+    const cached = await readCachedEigenweltFreeManifest(config);
+    expect(cached?.apiKey).toBe(FREE_KEY_PAYLOAD.apiKey);
+    expect(cached?.baseURL).toBe(FREE_KEY_PAYLOAD.baseURL);
+    expect(cached?.models.map((model) => model.id)).toEqual(["ewl-free-small", "ewl-free-base"]);
+
+    // A second call within the throttle window does nothing (no fetch).
+    const again = await refreshEigenweltFreeManifest(config);
+    expect(again).toBe(false);
+    expect(platform.freeKeyCalls).toBe(1);
+    expect(platform.freeModelsCalls).toBe(0);
+  });
+
+  test("NEVER re-mints while a key is cached — refresh only updates models, key preserved", async () => {
+    const platform = await setupPlatform();
+    platform.modelsPayload = {
+      baseURL: "https://free.gateway.test/v2",
+      models: [{ id: "ewl-free-next", contextLength: 64000 }],
+    };
+    const { config } = await setupRuntimeDb();
+    await writeFile(eigenweltFreeManifestCachePath(config), JSON.stringify(CACHED_MANIFEST), "utf8");
+
+    const changed = await refreshEigenweltFreeManifest(config);
+    expect(changed).toBe(true);
+    // The mint endpoint must not be touched: re-minting rotates (and thereby
+    // invalidates) this device's key on the platform side.
+    expect(platform.freeKeyCalls).toBe(0);
+    expect(platform.freeModelsCalls).toBe(1);
+
+    const cached = await readCachedEigenweltFreeManifest(config);
+    expect(cached?.apiKey).toBe(CACHED_MANIFEST.apiKey); // key preserved
+    expect(cached?.baseURL).toBe("https://free.gateway.test/v2"); // baseURL refreshed
+    expect(cached?.models.map((model) => model.id)).toEqual(["ewl-free-next"]); // models refreshed
+  });
+
+  test("unchanged free-models payload does not rewrite the cache", async () => {
+    const platform = await setupPlatform();
+    const { config } = await setupRuntimeDb();
+    await writeFile(eigenweltFreeManifestCachePath(config), JSON.stringify(CACHED_MANIFEST), "utf8");
+
+    // The fake platform serves exactly the cached baseURL/models.
+    platform.modelsPayload = { baseURL: CACHED_MANIFEST.baseURL, models: CACHED_MANIFEST.models };
+    const changed = await refreshEigenweltFreeManifest(config);
+    expect(changed).toBe(false);
+    expect(platform.freeKeyCalls).toBe(0);
+    expect(platform.freeModelsCalls).toBe(1);
+    expect((await readCachedEigenweltFreeManifest(config))?.apiKey).toBe(CACHED_MANIFEST.apiKey);
+  });
+
+  test("free-models failure keeps the cached manifest (offline fallback)", async () => {
+    const platform = await setupPlatform();
+    platform.failFreeModels = true;
+    const { config } = await setupRuntimeDb();
+    await writeFile(eigenweltFreeManifestCachePath(config), JSON.stringify(CACHED_MANIFEST), "utf8");
+
+    const changed = await refreshEigenweltFreeManifest(config);
+    expect(changed).toBe(false);
+    expect(platform.freeModelsCalls).toBe(1);
+    expect(platform.freeKeyCalls).toBe(0); // failure must NOT trigger a mint
+
+    // The last good manifest (incl. the key) still backs the free provider.
+    const cached = await readCachedEigenweltFreeManifest(config);
+    expect(cached?.apiKey).toBe(CACHED_MANIFEST.apiKey);
+    expect(cached?.models.map((model) => model.id)).toEqual(["ewl-free-small", "ewl-free-base"]);
+  });
+
+  test("mint failure leaves no cache; the next refresh retries the mint", async () => {
+    const platform = await setupPlatform();
+    platform.failFreeKey = true;
+    const { config } = await setupRuntimeDb();
+
+    expect(await refreshEigenweltFreeManifest(config)).toBe(false);
+    expect(platform.freeKeyCalls).toBe(1);
+    expect(await readCachedEigenweltFreeManifest(config)).toBeNull();
+
+    // Recovery: platform mints on the next (unthrottled) attempt.
+    platform.failFreeKey = false;
+    resetEigenweltFreeManifestRefreshThrottleForTests();
+    expect(await refreshEigenweltFreeManifest(config)).toBe(true);
+    expect(platform.freeKeyCalls).toBe(2);
+    expect((await readCachedEigenweltFreeManifest(config))?.apiKey).toBe(FREE_KEY_PAYLOAD.apiKey);
+  });
+
+  test("corrupt cache counts as no key: refresh mints", async () => {
+    const platform = await setupPlatform();
+    const { config } = await setupRuntimeDb();
+    await writeFile(eigenweltFreeManifestCachePath(config), "not json {", "utf8");
+    expect(await readCachedEigenweltFreeManifest(config)).toBeNull();
+
+    const changed = await refreshEigenweltFreeManifest(config);
+    expect(changed).toBe(true);
+    expect(platform.freeKeyCalls).toBe(1);
+    expect((await readCachedEigenweltFreeManifest(config))?.apiKey).toBe(FREE_KEY_PAYLOAD.apiKey);
+  });
+});
+
+describe("readCachedEigenweltFreeManifest", () => {
+  test("missing cache file yields null", async () => {
+    const { config } = await setupRuntimeDb();
+    expect(await readCachedEigenweltFreeManifest(config)).toBeNull();
+  });
+
+  test("structurally invalid cache (no apiKey) is ignored", async () => {
+    const { config } = await setupRuntimeDb();
+    await writeFile(
+      eigenweltFreeManifestCachePath(config),
+      JSON.stringify({ baseURL: "https://x.test", models: [] }),
+      "utf8",
+    );
+    expect(await readCachedEigenweltFreeManifest(config)).toBeNull();
+  });
+});
+
+describe("eigenweltFreeDeviceId", () => {
+  test("mints once, persists to disk, and stays stable", async () => {
+    const { root, config } = await setupRuntimeDb();
+    const first = await eigenweltFreeDeviceId(config);
+    expect(first.length).toBeGreaterThan(0);
+    expect((await readFile(join(root, "eigenwelt-free-device-id"), "utf8")).trim()).toBe(first);
+    expect(await eigenweltFreeDeviceId(config)).toBe(first);
+  });
+});
+
+describe("buildEigenweltFreeProviderBlock", () => {
+  test("carries the per-device key and both limit keys — no device header", () => {
+    const block = buildEigenweltFreeProviderBlock({ ...CACHED_MANIFEST }) as {
+      npm: string;
+      name: string;
+      options: { baseURL: string; apiKey: string; headers?: Record<string, string> };
+      models: Record<string, { limit: { context: number; output: number } }>;
+    };
+    expect(block.npm).toBe("@ai-sdk/openai-compatible");
+    expect(block.name).toBe("Eigenwelt Free");
+    expect(block.options.baseURL).toBe(CACHED_MANIFEST.baseURL);
+    // The device's own key — limits are per-key on the gateway now, so no
+    // x-litellm-end-user-id header may be injected.
+    expect(block.options.apiKey).toBe(CACHED_MANIFEST.apiKey);
+    expect(block.options.headers).toBeUndefined();
+    // Both limit keys are mandatory for the engine schema.
+    expect(block.models["ewl-free-small"]?.limit).toEqual({ context: 32000, output: 16384 });
+    expect(block.models["ewl-free-base"]?.limit).toEqual({ context: 128000, output: 16384 });
+    // The manifest's description field must not leak into the engine config.
+    expect("description" in (block.models["ewl-free-small"] as Record<string, unknown>)).toBe(false);
+  });
+});

--- a/apps/server/src/eigenwelt-free.ts
+++ b/apps/server/src/eigenwelt-free.ts
@@ -31,12 +31,30 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 
+import constants from "../../../constants.json" with { type: "json" };
+
 import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
-/** Base URL of the Eigenwelt platform (overridable for tests/staging). */
+/**
+ * Base URL of the Eigenwelt platform (overridable for tests/staging).
+ * Until the platform app is deployed, the free gateway itself serves the
+ * public free-key/free-models endpoints (free-mint sidecar), so the default
+ * is the gateway host; flip to the platform host when it ships.
+ */
 export function eigenweltPlatformUrl(): string {
-  return (process.env.EIGENWELT_PLATFORM_URL ?? "https://platform.eigenwelt.ai").replace(/\/+$/, "");
+  return (process.env.EIGENWELT_PLATFORM_URL ?? "https://free-api.eigenweltlabs.com").replace(/\/+$/, "");
+}
+
+/**
+ * Baked-in mint token the free-key endpoint requires (x-eigenwelt-mint-key).
+ * A bot filter, not auth: the release workflows inject the real value into
+ * constants.json from the EIGENWELT_FREE_MINT_KEY repo secret before the
+ * server builds (the checked-in value is empty — this repo is public). The
+ * env var overrides for dev/tests.
+ */
+export function eigenweltFreeMintKey(): string {
+  return process.env.EIGENWELT_FREE_MINT_KEY ?? constants.eigenweltFreeMintKey ?? "";
 }
 
 /** A model entry as the platform manifest reports it. */
@@ -126,11 +144,18 @@ function parseEigenweltFreeManifest(value: unknown): EigenweltFreeManifest | nul
  */
 export async function mintEigenweltFreeDeviceKey(deviceId: string): Promise<EigenweltFreeManifest> {
   const platform = eigenweltPlatformUrl();
+  const mintKey = eigenweltFreeMintKey();
   let response: Response;
   try {
     response = await fetch(`${platform}/api/public/free-key`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        // Required by the mint endpoint (401 without it) — see
+        // eigenweltFreeMintKey. free-models needs no token.
+        ...(mintKey ? { "x-eigenwelt-mint-key": mintKey } : {}),
+      },
       body: JSON.stringify({ deviceId }),
     });
   } catch {

--- a/apps/server/src/eigenwelt-free.ts
+++ b/apps/server/src/eigenwelt-free.ts
@@ -10,7 +10,7 @@
  * apiKey exists it is never re-requested; later refreshes only update the
  * model list (and baseURL) via GET `/api/public/free-models`.
  *
- * Free traffic is logged and used to improve models, unlike the paid
+ * Usage data for free traffic is logged (testing tier), unlike the paid
  * `eigenwelt` provider (connect flow, zero retention), which stays untouched.
  *
  * Design constraints this module satisfies:

--- a/apps/server/src/eigenwelt-free.ts
+++ b/apps/server/src/eigenwelt-free.ts
@@ -320,9 +320,11 @@ export function buildEigenweltFreeProviderBlock(manifest: EigenweltFreeManifest)
     options: {
       baseURL: manifest.baseURL,
       // This device's own free-gateway key (minted via /api/public/free-key).
-      // Rate/budget limits are enforced per key by the gateway — no
-      // per-request device header needed.
-      apiKey: manifest.apiKey,
+      // Rate/budget limits are enforced per key by the gateway. The engine
+      // passes provider `options` verbatim to createOpenAICompatible, which
+      // ignores an `apiKey` field — the key MUST travel as an Authorization
+      // header (options.headers is verified to reach every request).
+      headers: { Authorization: `Bearer ${manifest.apiKey}` },
     },
     models: buildEigenweltModelsMap(manifest.models),
   };

--- a/apps/server/src/eigenwelt-free.ts
+++ b/apps/server/src/eigenwelt-free.ts
@@ -1,0 +1,329 @@
+/**
+ * Eigenwelt FREE tier — the no-login provider every install gets.
+ *
+ * Access model: one virtual key PER DEVICE. On first refresh the server
+ * POSTs its persisted device id to `${EIGENWELT_PLATFORM_URL}/api/public/free-key`
+ * and receives `{apiKey, baseURL, models}` — a rate-limited, budget-capped
+ * key minted just for this install. The platform derives the key alias from
+ * the device id, so re-posting the same id ROTATES the key (the old one is
+ * invalidated). Because of that, the mint happens ONCE: while a cached
+ * apiKey exists it is never re-requested; later refreshes only update the
+ * model list (and baseURL) via GET `/api/public/free-models`.
+ *
+ * Free traffic is logged and used to improve models, unlike the paid
+ * `eigenwelt` provider (connect flow, zero retention), which stays untouched.
+ *
+ * Design constraints this module satisfies:
+ *  - buildLegalworkRuntimeConfigObject must never block on the network, so
+ *    the manifest (key + models) is served from a DISK CACHE under the
+ *    server's runtime storage dir. refreshEigenweltFreeManifest() updates
+ *    that cache out-of-band (fire-and-forget from cli.ts / embedded.ts) and
+ *    reports whether it changed so the caller can rewrite the engine config
+ *    file.
+ *  - A missing/corrupt cache simply means "no free provider yet"; the next
+ *    refresh (or app restart with a reachable platform) mints a key and
+ *    heals it.
+ *  - Per-device limits live on the KEY itself (LiteLLM per-key rpm/budget),
+ *    so no per-request device header is needed — the device id's only job
+ *    is identifying this install to the mint endpoint.
+ */
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+/** Base URL of the Eigenwelt platform (overridable for tests/staging). */
+export function eigenweltPlatformUrl(): string {
+  return (process.env.EIGENWELT_PLATFORM_URL ?? "https://platform.eigenwelt.ai").replace(/\/+$/, "");
+}
+
+/** A model entry as the platform manifest reports it. */
+export type EigenweltManifestModel = {
+  id: string;
+  name?: string;
+  contextLength?: number;
+  toolCall?: boolean;
+  reasoning?: boolean;
+};
+
+/**
+ * Map manifest models to the engine's provider `models` block. `limit` MUST
+ * carry BOTH context and output: one missing key silently invalidates the
+ * whole runtime config in the engine's schema and kills all plugins
+ * (verified).
+ */
+export function buildEigenweltModelsMap(models: EigenweltManifestModel[]): Record<string, unknown> {
+  return Object.fromEntries(
+    models.map((model) => [
+      model.id,
+      {
+        name: model.name ?? model.id,
+        tool_call: model.toolCall ?? true,
+        reasoning: model.reasoning ?? false,
+        limit: { context: model.contextLength ?? 128_000, output: 16_384 },
+      },
+    ]),
+  );
+}
+
+/** Provider id of the free, always-available Eigenwelt tier. */
+export const EIGENWELT_FREE_PROVIDER_ID = "eigenwelt-free";
+
+/**
+ * The engine's built-in OpenCode Zen provider id. It auto-connects
+ * anonymously; listing it in `disabled_providers` disables it (checked in
+ * both the provider loader and the list handler). We disable it ONLY while
+ * our free provider is actually available — otherwise a first launch with
+ * the platform unreachable would lose free models entirely.
+ */
+export const OPENCODE_ZEN_PROVIDER_ID = "opencode";
+
+/** Free-manifest models may carry a description; the engine schema has no
+ * such field, so it is accepted here and dropped when building the config. */
+export type EigenweltFreeManifestModel = EigenweltManifestModel & { description?: string };
+
+/** Disk-cache shape: the per-device key plus the last known gateway URL and
+ * model list. `apiKey` is minted once (free-key) and preserved across model
+ * refreshes (free-models). */
+export type EigenweltFreeManifest = {
+  baseURL: string;
+  apiKey: string;
+  models: EigenweltFreeManifestModel[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseModels(value: unknown): EigenweltFreeManifestModel[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter(
+    (model): model is EigenweltFreeManifestModel =>
+      isRecord(model) && typeof model.id === "string" && model.id.length > 0,
+  );
+}
+
+function parseEigenweltFreeManifest(value: unknown): EigenweltFreeManifest | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.baseURL !== "string" || !value.baseURL) return null;
+  if (typeof value.apiKey !== "string" || !value.apiKey) return null;
+  const models = parseModels(value.models);
+  if (!models) return null;
+  return { baseURL: value.baseURL, apiKey: value.apiKey, models };
+}
+
+/**
+ * Mint this device's own free-gateway key: POST the persisted device id to
+ * the platform's public free-key endpoint. Returns the full manifest
+ * `{apiKey, baseURL, models}`. Throws with a clear message when the platform
+ * is unreachable, rate-limits the mint, or returns an invalid payload.
+ *
+ * WARNING: minting for an already-known device id ROTATES the key on the
+ * platform side (old key invalidated) — callers must only mint when no
+ * cached key exists.
+ */
+export async function mintEigenweltFreeDeviceKey(deviceId: string): Promise<EigenweltFreeManifest> {
+  const platform = eigenweltPlatformUrl();
+  let response: Response;
+  try {
+    response = await fetch(`${platform}/api/public/free-key`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ deviceId }),
+    });
+  } catch {
+    throw new Error("Could not reach the Eigenwelt platform.");
+  }
+  if (!response.ok) {
+    throw new Error(`The Eigenwelt platform did not issue a free key (HTTP ${response.status}).`);
+  }
+  const payload = (await response.json().catch(() => null)) as unknown;
+  const manifest = parseEigenweltFreeManifest(payload);
+  if (!manifest) {
+    throw new Error("The Eigenwelt platform returned an invalid free-key payload.");
+  }
+  return manifest;
+}
+
+/**
+ * Fetch the platform's free-models manifest (gateway baseURL + model list —
+ * no key; keys are per-device via mintEigenweltFreeDeviceKey). Throws with a
+ * clear message when the platform is unreachable or the payload is invalid —
+ * callers fall back to the disk cache.
+ */
+export async function fetchEigenweltFreeModels(): Promise<{
+  baseURL: string;
+  models: EigenweltFreeManifestModel[];
+}> {
+  const platform = eigenweltPlatformUrl();
+  let response: Response;
+  try {
+    response = await fetch(`${platform}/api/public/free-models`, { headers: { Accept: "application/json" } });
+  } catch {
+    throw new Error("Could not reach the Eigenwelt platform.");
+  }
+  if (!response.ok) {
+    throw new Error(`Could not reach the Eigenwelt platform (HTTP ${response.status}).`);
+  }
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!isRecord(payload) || typeof payload.baseURL !== "string" || !payload.baseURL) {
+    throw new Error("The Eigenwelt platform returned an invalid free-models manifest.");
+  }
+  const models = parseModels(payload.models);
+  if (!models) {
+    throw new Error("The Eigenwelt platform returned an invalid free-models manifest.");
+  }
+  return { baseURL: payload.baseURL, models };
+}
+
+/** On-disk cache of this device's free-tier manifest (key + models), so
+ * offline restarts still get the free provider. Lives next to the runtime DB. */
+export function eigenweltFreeManifestCachePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), "eigenwelt-free-manifest.json");
+}
+
+/**
+ * Read the cached manifest. Missing or corrupt cache files are treated as
+ * "no manifest" (null) — never throws.
+ */
+export async function readCachedEigenweltFreeManifest(config: ServerConfig): Promise<EigenweltFreeManifest | null> {
+  try {
+    const raw = await readFile(eigenweltFreeManifestCachePath(config), "utf8");
+    return parseEigenweltFreeManifest(JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedEigenweltFreeManifest(config: ServerConfig, manifest: EigenweltFreeManifest): Promise<void> {
+  const path = eigenweltFreeManifestCachePath(config);
+  await mkdir(dirname(path), { recursive: true });
+  // Atomic (temp file + rename) so a concurrent config build never reads a
+  // partial cache.
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmp, JSON.stringify(manifest), "utf8");
+  await rename(tmp, path);
+}
+
+const FREE_MANIFEST_REFRESH_THROTTLE_MS = 10 * 60 * 1000;
+const freeManifestRefreshLastRun = new Map<string, number>();
+
+/** Test-only: clear the refresh throttle so a test can drive several
+ * refreshes against the same cache path. */
+export function resetEigenweltFreeManifestRefreshThrottleForTests(): void {
+  freeManifestRefreshLastRun.clear();
+}
+
+/**
+ * Refresh the on-disk free-tier cache from the platform.
+ *
+ * Two modes, decided by the cache:
+ *  - no cached key: mint this device's key ONCE via POST /api/public/free-key
+ *    (deviceId = the persisted install id) and cache {apiKey, baseURL, models};
+ *  - cached key present: NEVER re-mint (the platform rotates — and thereby
+ *    invalidates — the key for a known device id); only GET
+ *    /api/public/free-models and update models + baseURL around the kept key.
+ *
+ * Fire-and-forget safe: throttled to one attempt per cache path per 10
+ * minutes, never throws, and only writes when the manifest actually changed.
+ * Returns true when the cache changed — the caller should then rewrite the
+ * engine-visible runtime config file (writeLegalworkRuntimeConfigFile) so
+ * the free provider (and the zen disable that rides on it) update.
+ *
+ * An intentionally-empty model list IS written: the platform is
+ * authoritative, and config injection already guards on >= 1 model, so an
+ * emptied manifest removes the free provider and re-enables zen.
+ */
+export async function refreshEigenweltFreeManifest(config: ServerConfig): Promise<boolean> {
+  try {
+    const path = eigenweltFreeManifestCachePath(config);
+    const now = Date.now();
+    const last = freeManifestRefreshLastRun.get(path) ?? 0;
+    if (now - last < FREE_MANIFEST_REFRESH_THROTTLE_MS) return false;
+    freeManifestRefreshLastRun.set(path, now);
+
+    const cached = await readCachedEigenweltFreeManifest(config);
+
+    let manifest: EigenweltFreeManifest;
+    try {
+      if (cached) {
+        // Key exists — refresh only the model catalog (and baseURL).
+        const { baseURL, models } = await fetchEigenweltFreeModels();
+        manifest = { ...cached, baseURL, models };
+      } else {
+        // First run (or corrupt cache): mint this device's key.
+        manifest = await mintEigenweltFreeDeviceKey(await eigenweltFreeDeviceId(config));
+      }
+    } catch (error) {
+      // Platform unreachable / invalid payload / mint refused — keep serving
+      // the cache (or stay without a free provider until the next attempt).
+      console.debug(
+        `eigenwelt free-manifest refresh skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return false;
+    }
+
+    if (cached && JSON.stringify(cached) === JSON.stringify(manifest)) return false;
+    await writeCachedEigenweltFreeManifest(config, manifest);
+    return true;
+  } catch (error) {
+    console.debug(
+      `eigenwelt free-manifest refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+const DEVICE_ID_FILE = "eigenwelt-free-device-id";
+const deviceIdByPath = new Map<string, Promise<string>>();
+
+/**
+ * Stable per-install id sent to the platform's free-key mint endpoint.
+ * A random UUID persisted in the runtime storage dir; memoized per path so
+ * it stays stable within a process even if the file write fails.
+ */
+export function eigenweltFreeDeviceId(config: ServerConfig): Promise<string> {
+  const path = join(runtimeStorageDir(config), DEVICE_ID_FILE);
+  const existing = deviceIdByPath.get(path);
+  if (existing) return existing;
+  const promise = loadOrCreateDeviceId(path).catch(() => randomUUID());
+  deviceIdByPath.set(path, promise);
+  return promise;
+}
+
+async function loadOrCreateDeviceId(path: string): Promise<string> {
+  try {
+    const raw = (await readFile(path, "utf8")).trim();
+    if (raw) return raw;
+  } catch {
+    // Missing file — mint a new id below.
+  }
+  const id = randomUUID();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${id}\n`, "utf8");
+  return id;
+}
+
+/**
+ * Build the engine provider block for the free tier. Mirrors the paid
+ * provider's shape (npm/name/options/models); buildEigenweltModelsMap
+ * guarantees every model carries BOTH limit.context and limit.output — one
+ * missing key silently invalidates the whole runtime config in the engine
+ * schema and kills all plugins.
+ */
+export function buildEigenweltFreeProviderBlock(manifest: EigenweltFreeManifest): Record<string, unknown> {
+  return {
+    npm: "@ai-sdk/openai-compatible",
+    name: "Eigenwelt Free",
+    options: {
+      baseURL: manifest.baseURL,
+      // This device's own free-gateway key (minted via /api/public/free-key).
+      // Rate/budget limits are enforced per key by the gateway — no
+      // per-request device header needed.
+      apiKey: manifest.apiKey,
+    },
+    models: buildEigenweltModelsMap(manifest.models),
+  };
+}

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -11,6 +11,7 @@ import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeE
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { keepLegalworkRuntimeConfigFileFresh, writeLegalworkRuntimeConfigFile } from "./legalwork-runtime-config.js";
+import { refreshEigenweltFreeManifest } from "./eigenwelt-free.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
 
@@ -63,6 +64,12 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       // on every runtime-DB write — so disposes always pick up current state.
       const runtimeConfigPath = await writeLegalworkRuntimeConfigFile(config, workspace.id);
       keepLegalworkRuntimeConfigFileFresh(config, workspace.id);
+      // Fire-and-forget: refresh the free-tier manifest disk cache; on
+      // change, rewrite the engine config file so the free provider (and the
+      // zen disable that rides on it) update on the next instance rebuild.
+      void refreshEigenweltFreeManifest(config)
+        .then((changed) => (changed ? writeLegalworkRuntimeConfigFile(config, workspace.id) : undefined))
+        .catch(() => undefined);
       const cwd = options.opencodeCwd
         || process.env.LEGALWORK_MANAGED_OPENCODE_CWD?.trim()
         || workspace.path;

--- a/apps/server/src/legalwork-runtime-config.test.ts
+++ b/apps/server/src/legalwork-runtime-config.test.ts
@@ -179,10 +179,10 @@ describe("eigenwelt free provider injection", () => {
     expect(free.name).toBe("Eigenwelt Free");
     // This device's own key inline in options — intentional for the free tier.
     expect(free.options?.baseURL).toBe("https://free.gateway.test/v1");
-    expect(free.options?.apiKey).toBe("sk-device-key-1");
+    expect(free.options?.headers?.Authorization).toBe("Bearer sk-device-key-1");
     // Limits are keyed on the virtual key itself now; the old
     // x-litellm-end-user-id header must NOT be injected anymore.
-    expect(free.options?.headers).toBeUndefined();
+    expect(free.options?.apiKey).toBeUndefined();
     // BOTH limit keys are mandatory: one missing key silently invalidates
     // the whole runtime config in the engine schema and kills all plugins.
     expect(free.models?.["ewl-free-small"]?.limit).toEqual({ context: 32000, output: 16384 });
@@ -199,7 +199,7 @@ describe("eigenwelt free provider injection", () => {
     await writeLegalworkRuntimeConfigFile(config, "ws_1");
     const rebuilt = await readConfigFile(config);
     const rebuiltFree = (rebuilt.provider as Record<string, FreeProviderBlock>)["eigenwelt-free"];
-    expect(rebuiltFree.options?.apiKey).toBe("sk-device-key-1");
+    expect(rebuiltFree.options?.headers?.Authorization).toBe("Bearer sk-device-key-1");
   });
 
   test("no disk cache: no eigenwelt-free block and zen stays enabled", async () => {

--- a/apps/server/src/legalwork-runtime-config.test.ts
+++ b/apps/server/src/legalwork-runtime-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,6 +8,7 @@ import {
   legalworkRuntimeConfigFilePath,
   writeLegalworkRuntimeConfigFile,
 } from "./legalwork-runtime-config.js";
+import { eigenweltFreeManifestCachePath } from "./eigenwelt-free.js";
 import { GLOBAL_TOOL_PERMISSIONS_ID, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -136,5 +137,122 @@ describe("legalwork runtime config file", () => {
     // Global tool key + this workspace's own external_directory, merged.
     expect(permission.bash).toBe("ask");
     expect(permission.external_directory).toEqual({ "/tmp/shared/*": "allow" });
+  });
+});
+
+describe("eigenwelt free provider injection", () => {
+  // The cached manifest now carries this DEVICE's own key (minted once via
+  // /api/public/free-key) — limits are per-key on the gateway.
+  const FREE_MANIFEST = {
+    baseURL: "https://free.gateway.test/v1",
+    apiKey: "sk-device-key-1",
+    models: [
+      { id: "ewl-free-small", name: "EWL Free Small", contextLength: 32000 },
+      { id: "ewl-free-base" },
+    ],
+  };
+
+  type FreeProviderBlock = {
+    npm?: string;
+    name?: string;
+    options?: { baseURL?: string; apiKey?: string; headers?: Record<string, string> };
+    models?: Record<string, { name?: string; tool_call?: boolean; reasoning?: boolean; limit?: { context?: number; output?: number } }>;
+  };
+
+  test("seeded disk cache: injects eigenwelt-free (both limit keys, per-device apiKey, no device header) and disables zen", async () => {
+    const { config } = await setup();
+    await writeFile(eigenweltFreeManifestCachePath(config), JSON.stringify(FREE_MANIFEST), "utf8");
+    // The user's runtime DB may disable other providers — preserved, deduped.
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      disabled_providers: ["openrouter", "opencode"],
+    }));
+
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    const parsed = await readConfigFile(config);
+
+    const free = (parsed.provider as Record<string, FreeProviderBlock>)[
+      "eigenwelt-free"
+    ];
+    expect(free).toBeDefined();
+    expect(free.npm).toBe("@ai-sdk/openai-compatible");
+    expect(free.name).toBe("Eigenwelt Free");
+    // This device's own key inline in options — intentional for the free tier.
+    expect(free.options?.baseURL).toBe("https://free.gateway.test/v1");
+    expect(free.options?.apiKey).toBe("sk-device-key-1");
+    // Limits are keyed on the virtual key itself now; the old
+    // x-litellm-end-user-id header must NOT be injected anymore.
+    expect(free.options?.headers).toBeUndefined();
+    // BOTH limit keys are mandatory: one missing key silently invalidates
+    // the whole runtime config in the engine schema and kills all plugins.
+    expect(free.models?.["ewl-free-small"]?.limit).toEqual({ context: 32000, output: 16384 });
+    expect(free.models?.["ewl-free-base"]?.limit).toEqual({ context: 128000, output: 16384 });
+    expect(free.models?.["ewl-free-small"]?.tool_call).toBe(true);
+    expect(free.models?.["ewl-free-small"]?.reasoning).toBe(false);
+
+    const disabled = parsed.disabled_providers as string[];
+    expect(disabled).toContain("opencode");
+    expect(disabled).toContain("openrouter");
+    expect(disabled.filter((id) => id === "opencode")).toHaveLength(1);
+
+    // The cached device key is stable across config rebuilds.
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    const rebuilt = await readConfigFile(config);
+    const rebuiltFree = (rebuilt.provider as Record<string, FreeProviderBlock>)["eigenwelt-free"];
+    expect(rebuiltFree.options?.apiKey).toBe("sk-device-key-1");
+  });
+
+  test("no disk cache: no eigenwelt-free block and zen stays enabled", async () => {
+    const { config } = await setup();
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    const parsed = await readConfigFile(config);
+    expect((parsed.provider as Record<string, unknown> | undefined)?.["eigenwelt-free"]).toBeUndefined();
+    // Zen must NOT be disabled when the free provider is unavailable —
+    // otherwise a first launch with the platform down loses free models.
+    const disabled = (parsed.disabled_providers ?? []) as string[];
+    expect(disabled).not.toContain("opencode");
+  });
+
+  test("corrupt disk cache is ignored; empty-model cache injects nothing", async () => {
+    const { config } = await setup();
+    await writeFile(eigenweltFreeManifestCachePath(config), "not json {", "utf8");
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    let parsed = await readConfigFile(config);
+    expect((parsed.provider as Record<string, unknown> | undefined)?.["eigenwelt-free"]).toBeUndefined();
+    expect(((parsed.disabled_providers ?? []) as string[])).not.toContain("opencode");
+
+    // A valid manifest with zero models must not inject the provider either.
+    await writeFile(
+      eigenweltFreeManifestCachePath(config),
+      JSON.stringify({ ...FREE_MANIFEST, models: [] }),
+      "utf8",
+    );
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    parsed = await readConfigFile(config);
+    expect((parsed.provider as Record<string, unknown> | undefined)?.["eigenwelt-free"]).toBeUndefined();
+    expect(((parsed.disabled_providers ?? []) as string[])).not.toContain("opencode");
+  });
+
+  test("free provider merges with runtime-DB providers without clobbering them", async () => {
+    const { config } = await setup();
+    await writeFile(eigenweltFreeManifestCachePath(config), JSON.stringify(FREE_MANIFEST), "utf8");
+    // Paid eigenwelt provider (connect flow) lives in the runtime DB.
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      provider: {
+        eigenwelt: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Eigenwelt Model API",
+          options: { baseURL: "https://paid.gateway.test/v1" },
+          models: { "ewl-pro": { name: "EWL Pro", limit: { context: 200000, output: 16384 } } },
+        },
+      },
+    }));
+
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    const parsed = await readConfigFile(config);
+    const providers = parsed.provider as Record<string, FreeProviderBlock>;
+    expect(providers.eigenwelt?.name).toBe("Eigenwelt Model API");
+    expect(providers["eigenwelt-free"]?.name).toBe("Eigenwelt Free");
   });
 });

--- a/apps/server/src/legalwork-runtime-config.ts
+++ b/apps/server/src/legalwork-runtime-config.ts
@@ -38,6 +38,12 @@ import {
   runtimePluginList,
   runtimeStorageDir,
 } from "./runtime-opencode-config-store.js";
+import {
+  buildEigenweltFreeProviderBlock,
+  EIGENWELT_FREE_PROVIDER_ID,
+  OPENCODE_ZEN_PROVIDER_ID,
+  readCachedEigenweltFreeManifest,
+} from "./eigenwelt-free.js";
 
 const LEGALWORK_AGENT_PROMPT = `You are LegalWork — an AI agent that works alongside legal professionals inside a law firm.
 
@@ -94,9 +100,32 @@ export async function buildLegalworkRuntimeConfigObject(
         await readGlobalToolPermissions(config),
       )
     : {};
-  const disabledProviders = runtimeDisabledProviderList(runtimeConfig);
+  // Free Eigenwelt tier: served from the DISK CACHE only — config building
+  // must never block on the network. refreshEigenweltFreeManifest (cli.ts /
+  // embedded.ts) keeps the cache fresh out-of-band (minting this device's
+  // key once, then only refreshing models) and triggers a rewrite of this
+  // file when it changes. Config-defined providers are always reported
+  // "connected" by the engine, which is exactly the desired no-login behavior
+  // for the free tier. Injected only when the cache holds a key AND at least
+  // one model.
+  const freeManifest = config ? await readCachedEigenweltFreeManifest(config) : null;
+  const freeProvider = freeManifest && freeManifest.models.length > 0
+    ? buildEigenweltFreeProviderBlock(freeManifest)
+    : null;
+  const disabledProviders = [
+    ...runtimeDisabledProviderList(runtimeConfig),
+    // Disable the engine's anonymous OpenCode Zen provider ONLY while our
+    // free provider is actually available — otherwise a first launch with
+    // the platform down would lose free models entirely.
+    ...(freeProvider ? [OPENCODE_ZEN_PROVIDER_ID] : []),
+  ].filter((item, index, list) => list.indexOf(item) === index);
+  const providerMap = {
+    ...(runtimeConfig.provider ?? {}),
+    ...(freeProvider ? { [EIGENWELT_FREE_PROVIDER_ID]: freeProvider } : {}),
+  };
   return {
     ...runtimeConfig,
+    ...(Object.keys(providerMap).length ? { provider: providerMap } : {}),
     default_agent: runtimeConfig.default_agent ?? "legalwork",
     agent: {
       ...runtimeAgentMap(runtimeConfig),

--- a/apps/server/src/session-read-model.ts
+++ b/apps/server/src/session-read-model.ts
@@ -31,7 +31,25 @@ const sessionSummarySchema = z
 export const sessionStatusSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("idle") }),
   z.object({ type: z.literal("busy") }),
-  z.object({ type: z.literal("retry"), attempt: z.number(), message: z.string(), next: z.number() }),
+  z.object({
+    type: z.literal("retry"),
+    attempt: z.number(),
+    message: z.string(),
+    next: z.number(),
+    // Engine-provided action block for actionable retries (e.g. re-auth or
+    // upgrade prompts). Must survive the snapshot path or the app's retry
+    // banner loses its button on reload.
+    action: z
+      .object({
+        reason: z.string(),
+        provider: z.string(),
+        title: z.string(),
+        message: z.string(),
+        label: z.string(),
+        link: z.string().optional(),
+      })
+      .optional(),
+  }),
 ]);
 
 export const sessionTodoSchema = z

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,4 @@
 {
-  "opencodeVersion": "v1.17.18"
+  "opencodeVersion": "v1.17.18",
+  "eigenweltFreeMintKey": ""
 }

--- a/scripts/release/bake-mint-key.mjs
+++ b/scripts/release/bake-mint-key.mjs
@@ -1,0 +1,18 @@
+// Injects the Eigenwelt free-mint token (EIGENWELT_FREE_MINT_KEY env, from
+// the repo secret of the same name) into constants.json before the server
+// builds. The checked-in value is EMPTY — this repo is public; the token
+// ships only inside release binaries. It is a bot filter, not auth: the
+// free-key mint endpoint 401s without it. See
+// apps/server/src/eigenwelt-free.ts (eigenweltFreeMintKey).
+import { readFileSync, writeFileSync } from "node:fs";
+
+const key = process.env.EIGENWELT_FREE_MINT_KEY;
+if (!key) {
+  console.error("EIGENWELT_FREE_MINT_KEY is not set — the packaged app could not mint free keys");
+  process.exit(1);
+}
+const path = new URL("../../constants.json", import.meta.url);
+const constants = JSON.parse(readFileSync(path, "utf8"));
+constants.eigenweltFreeMintKey = key;
+writeFileSync(path, `${JSON.stringify(constants, null, 2)}\n`);
+console.log("baked eigenweltFreeMintKey into constants.json");


### PR DESCRIPTION
## What

Every install gets a no-login **Eigenwelt Free** provider (`eigenwelt-free`) served from the Eigenwelt free gateway, replacing the engine's anonymous OpenCode Zen fallback as the default free tier. Standalone off `dev` — independent of the paid Eigenwelt Model API / EWL-hosted-deployment branch.

## Free gateway routing

- `apps/server/src/eigenwelt-free.ts` fetches the platform's free-tier manifest and builds an `@ai-sdk/openai-compatible` provider block pointed at the free gateway `baseURL`.
- `buildLegalworkRuntimeConfigObject` injects the provider from a **disk cache only** — config building never blocks on the network. `refreshEigenweltFreeManifest` (fire-and-forget from `cli.ts`/`embedded.ts`, 10-minute throttle, atomic temp-file+rename writes) keeps the cache fresh and triggers an engine-config rewrite when it changes.
- Every model carries both `limit.context` and `limit.output` — one missing key silently invalidates the entire runtime config in the engine schema and kills all plugins.

## Zen disabled only when the free manifest is present

`disabled_providers` gains `"opencode"` **only while the cached manifest holds a key and at least one model**. A first launch with the platform unreachable (or an intentionally emptied manifest) keeps/restores Zen, so free models are never lost entirely. User-disabled providers from the runtime DB are preserved and deduped.

## Per-device key minting

- A random install id is persisted at `<runtime-storage>/eigenwelt-free-device-id`.
- First refresh POSTs it to `/api/public/free-key` and caches `{apiKey, baseURL, models}`; rate/budget limits live on the key itself (no per-request device header).
- Minting for a known device id **rotates** (invalidates) the key platform-side, so while a cached key exists the server never re-mints — later refreshes only update models/baseURL via GET `/api/public/free-models`.

## Warning copy

Onboarding skip-notice and the composer `FreeModelNotice` now name Eigenwelt and state plainly that free-tier prompts and outputs are logged and used to improve models — not for client/matter data. `isFreeOpencodeModel` treats every `eigenwelt-free` model as free-tier (zero-cost Zen detection unchanged, local Ollama/LM Studio still excluded).

## Existing-install migration

Model selection persists **client-side only**: `localStorage["legalwork.preferences"].defaultModel` (plus legacy `MODEL_PREF_KEY` and per-workspace session overrides) — nothing server-side. So the remap is client-side: on provider-list load, when the persisted default model sits on the `opencode` provider, Zen no longer serves it, and `eigenwelt-free` is connected with ≥1 model, `session-route.tsx` auto-switches to the free provider's first model and shows a one-line toast. Pure decision helper `remapZenSelectionToEigenweltFree` is idempotent by construction (the remapped selection never matches again) and a no-op on unloaded lists, missing/empty free provider, or non-Zen selections.

## Tests

- `apps/server/src/eigenwelt-free.test.ts` — fake platform HTTP server: mint-once semantics, never re-mint while cached, offline fallback, corrupt-cache recovery, throttle, provider-block shape.
- `apps/server/src/legalwork-runtime-config.test.ts` — injection from seeded cache, zen-disable coupling, corrupt/empty-manifest guards, merge with runtime-DB providers.
- `apps/app/tests/free-model-migration.test.ts` — remap decision matrix + free-tier detection.
- `apps/server`: typecheck clean, 407 pass / 0 fail. `apps/app`: typecheck clean, 159 pass / 0 fail.

## Note for the paid-provider branch

`eigenweltPlatformUrl`, `EigenweltManifestModel`, and `buildEigenweltModelsMap` are defined in `eigenwelt-free.ts` here (they previously lived in the paid branch's `eigenwelt-auth.ts`). When the paid branch rebases onto this, it should import them from `eigenwelt-free.ts` instead of redefining them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)