### PR TITLE
feat(onboarding): polish provider-selection and templates steps

### DIFF
--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { PaperGrainGradient } from "@legalwork/ui/react";
-import { ArrowRightIcon, GithubIcon, SearchIcon, SparklesIcon, TriangleAlertIcon } from "lucide-react";
+import { ArrowRightIcon, FlaskConicalIcon, SearchIcon, SparklesIcon, TriangleAlertIcon } from "lucide-react";
 
 import { Page, PageBackground, PageTitlebarRegion } from "@/components/page";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
@@ -41,14 +41,14 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                       Connect a model.
                     </h1>
                     <p className="mt-3 max-w-sm text-[14px] leading-[1.6] text-dls-secondary">
-                      LegalWork runs on this machine — your documents are only ever shared with the model you
+                      LegalWork runs on this machine. Your documents are only ever shared with the model you
                       connect, and nothing else.
                     </p>
                   </div>
 
-                  {/* Quick connect — subscriptions, for testing */}
+                  {/* Quick connect — subscription sign-in */}
                   <div className="space-y-2.5">
-                    <span className="lw-section-eyebrow uppercase text-dls-secondary/80">Quick connect · for testing</span>
+                    <span className="lw-section-eyebrow uppercase text-dls-secondary/80">Quick connect</span>
                     <button type="button" className={quickButtonClass} onClick={() => onConnect("openai", "oauth")}>
                       <SparklesIcon className="size-4 shrink-0 text-dls-secondary" />
                       <div className="min-w-0 flex-1">
@@ -57,14 +57,28 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                       </div>
                       <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
                     </button>
-                    <button type="button" className={quickButtonClass} onClick={() => onConnect("github-copilot", "oauth")}>
-                      <GithubIcon className="size-4 shrink-0 text-dls-secondary" />
+                  </div>
+
+                  {/* For testing — included free models (same path as skipping) */}
+                  <div className="space-y-2.5">
+                    <span className="lw-section-eyebrow uppercase text-dls-secondary/80">For testing</span>
+                    <button type="button" className={quickButtonClass} onClick={onSkip}>
+                      <FlaskConicalIcon className="size-4 shrink-0 text-dls-secondary" />
                       <div className="min-w-0 flex-1">
-                        <div className="text-[14px] font-medium text-dls-text">Sign in with GitHub Copilot</div>
-                        <div className="text-[12px] text-dls-secondary">Use your Copilot subscription.</div>
+                        <div className="text-[14px] font-medium text-dls-text">Use Eigenwelt free models</div>
+                        <div className="text-[12px] text-dls-secondary">Try LegalWork right away. No account, no key.</div>
                       </div>
                       <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
                     </button>
+                  </div>
+
+                  <div className="-mt-4 flex max-w-sm items-start gap-2.5">
+                    <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
+                    <p className="text-[12px] leading-relaxed text-amber-11">
+                      Free models are included to try LegalWork. Usage data is
+                      logged, so please keep privileged, client, and matter data out. For real
+                      work, connect your own model.
+                    </p>
                   </div>
 
                   {/* Enterprise / private — searchable list of every provider */}
@@ -80,27 +94,6 @@ export function ProviderSelectionStep({ onConnect, onSkip }: ProviderSelectionSt
                       </div>
                       <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
                     </button>
-                    <p className="text-[12px] leading-relaxed text-dls-secondary">
-                      Run on your own cloud — connect with your own keys, any OpenAI-compatible endpoint.
-                    </p>
-                  </div>
-
-                  <div className="flex flex-col gap-3">
-                    <button
-                      type="button"
-                      onClick={onSkip}
-                      className="self-start text-[13px] text-dls-secondary transition-colors hover:text-dls-text"
-                    >
-                      Skip for now, use free models
-                    </button>
-                    <div className="flex max-w-sm items-start gap-2.5 rounded-xl border border-amber-6/40 bg-amber-2/30 px-3.5 py-3">
-                      <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-amber-11" />
-                      <p className="text-[12px] leading-relaxed text-amber-11">
-                        Free models are included to try LegalWork. Usage data is
-                        logged, so please keep privileged, client, and matter data out. For real
-                        work, connect your own model above.
-                      </p>
-                    </div>
                   </div>
                 </div>
               </div>

--- a/apps/app/src/react-app/domains/onboarding/template-workflows-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/template-workflows-step.tsx
@@ -4,6 +4,7 @@ import { PaperGrainGradient } from "@legalwork/ui/react";
 import { ArrowRightIcon, FolderOpenIcon, Loader2 } from "lucide-react";
 
 import { Page, PageBackground, PageTitlebarRegion } from "@/components/page";
+import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 
 type TemplateWorkflowsStepProps = {
@@ -71,53 +72,53 @@ export function TemplateWorkflowsStep({ onStart, onSkip }: TemplateWorkflowsStep
           <ScrollAreaViewport>
             <div className="flex min-h-screen">
               {/* ---- Left: choose the templates folder ---- */}
-              <div className="flex w-full flex-col justify-center px-8 py-16 lg:w-[46%] lg:px-16">
-                <div className="flex w-full max-w-md flex-col gap-8">
-                  <div>
-                    <span className="lw-section-eyebrow uppercase text-dls-secondary">Step three · Your templates</span>
-                    <h1 className="mt-3 text-[36px] font-medium leading-[1.04] tracking-[-0.035em] text-dls-text">
-                      Turn your templates into workflows.
-                    </h1>
-                    <p className="mt-3 max-w-sm text-[14px] leading-[1.6] text-dls-secondary">
-                      Choose a folder with your firm&apos;s templates: engagement letters, contracts, memos.
-                      Tasks an agent to read each one and draft a reusable workflow for it while you finish
-                      setting up.
-                    </p>
-                  </div>
+              <div className="flex w-full flex-col px-8 pt-16 pb-10 lg:w-[46%] lg:px-16">
+                <div className="flex w-full flex-1 items-center">
+                  <div className="flex w-full max-w-md flex-col gap-8">
+                    <div>
+                      <span className="lw-section-eyebrow uppercase text-dls-secondary">Step three · Your templates</span>
+                      <h1 className="mt-3 text-[36px] font-medium leading-[1.04] tracking-[-0.035em] text-dls-text">
+                        Turn your templates into workflows.
+                      </h1>
+                      <p className="mt-3 max-w-sm text-[14px] leading-[1.6] text-dls-secondary">
+                        Choose a folder with your firm&apos;s templates: engagement letters, contracts, memos.
+                        Tasks an agent to read each one and draft a reusable workflow for it while you finish
+                        setting up.
+                      </p>
+                    </div>
 
-                  <div className="space-y-2.5">
-                    <span className="lw-section-eyebrow uppercase text-dls-secondary/80">Start in the background</span>
-                    <button type="button" className={quickButtonClass} onClick={() => void handleStart()} disabled={starting}>
-                      {starting ? (
-                        <Loader2 className="size-4 shrink-0 animate-spin text-dls-secondary" />
-                      ) : (
-                        <FolderOpenIcon className="size-4 shrink-0 text-dls-secondary" />
-                      )}
-                      <div className="min-w-0 flex-1">
-                        <div className="text-[14px] font-medium text-dls-text">
-                          {starting ? "Starting…" : "Choose your templates folder"}
+                    <div className="space-y-2.5">
+                      <span className="lw-section-eyebrow uppercase text-dls-secondary/80">Start in the background</span>
+                      <button type="button" className={quickButtonClass} onClick={() => void handleStart()} disabled={starting}>
+                        {starting ? (
+                          <Loader2 className="size-4 shrink-0 animate-spin text-dls-secondary" />
+                        ) : (
+                          <FolderOpenIcon className="size-4 shrink-0 text-dls-secondary" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <div className="text-[14px] font-medium text-dls-text">
+                            {starting ? "Starting…" : "Choose your templates folder"}
+                          </div>
+                          <div className="text-[12px] text-dls-secondary">
+                            One reusable workflow per template, with the original attached.
+                          </div>
                         </div>
-                        <div className="text-[12px] text-dls-secondary">
-                          One reusable workflow per template, with the original attached.
-                        </div>
-                      </div>
-                      <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
-                    </button>
-                    <p className="text-[12px] leading-relaxed text-dls-secondary">
-                      Runs on this computer with your selected model. The results land in your firm&apos;s
-                      library under Workflows.
-                    </p>
-                    {error ? <p className="text-[12px] leading-relaxed text-red-500">{error}</p> : null}
+                        <ArrowRightIcon className="size-4 shrink-0 text-dls-secondary/60 transition-transform group-hover:translate-x-0.5" />
+                      </button>
+                      <p className="text-[12px] leading-relaxed text-dls-secondary">
+                        Runs on this computer with your selected model. The results land in your firm&apos;s
+                        library under Workflows.
+                      </p>
+                      {error ? <p className="text-[12px] leading-relaxed text-red-500">{error}</p> : null}
+                    </div>
                   </div>
+                </div>
 
-                  <button
-                    type="button"
-                    onClick={onSkip}
-                    disabled={starting}
-                    className="self-start text-[13px] text-dls-secondary transition-colors hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    Skip for now. You can start this anytime from Workflows
-                  </button>
+                <div className="flex w-full max-w-md justify-end">
+                  <Button variant="outline" onClick={onSkip} disabled={starting}>
+                    Skip for now
+                    <ArrowRightIcon data-icon="inline-end" />
+                  </Button>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

UI polish for onboarding steps 2 and 3, verified live in the dev app.

### Provider selection (step 2)
- Restructured into three sections:
  - **Quick connect** — "Sign in with OpenAI" only (GitHub Copilot button removed)
  - **For testing** — new "Use Eigenwelt free models" card, wired to the same action as the old skip link
  - **Enterprise & private** — "Browse all providers", unchanged
- Free-models warning moved between the testing and enterprise sections and rendered as plain amber text (no border/background), pulled closer to the section above it
- Removed the redundant "Skip for now, use free models" bottom link and the "Run on your own cloud — connect with your own keys…" helper line
- Subtitle em dash replaced with a period

### Templates step (step 3)
- Inline "Skip for now. You can start this anytime from Workflows" text link replaced with an outline `Button` pinned to the bottom right of the left column; main content stays vertically centered above it

## Test plan
- [x] `tsc --noEmit` passes for @legalwork/app
- [x] Verified both covers visually in the running dev app (Electron) end to end: welcome → folder pick → step 2 → step 3 → session
- [x] "Use Eigenwelt free models" advances to step 3; "Skip for now" on step 3 finishes onboarding

## Note
While testing, found a pre-existing bug (not addressed here): `use-session-provider-auth.ts` reads `?onboarding=1` from the hash only once at mount, so when the welcome redirect adds the param after the session route is already mounted, steps 2–3 are silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)