### PR TITLE
feat(free-tier): per-launch id on eigenwelt-free requests

### DIFF
--- a/apps/app/src/app/lib/analytics.ts
+++ b/apps/app/src/app/lib/analytics.ts
@@ -6,7 +6,9 @@
  *   names, counts, durations, and coarse context (provider/model id, app
  *   version, platform).
  * - The distinct id lives in memory and rotates per app start — never
- *   persisted to localStorage or disk.
+ *   persisted to localStorage or disk. The local server mints it per launch;
+ *   desktop and Office pane adopt it via setAnalyticsDistinctId, with a
+ *   local mint as boot-time fallback.
  * - Location is capped at city level server-side (the "GeoIP city cap"
  *   transformation in the PostHog project — keep it enabled after GeoIP);
  *   events are anonymous ($process_person_profile: false).
@@ -95,6 +97,7 @@ export function isAnalyticsSending(): boolean {
 }
 
 // Per-launch analytics id: minted in memory on first use, never persisted.
+// Normally replaced by the server's launch id via setAnalyticsDistinctId.
 let runtimeDistinctId = "";
 
 export function getAnalyticsDistinctId(): string {
@@ -107,7 +110,7 @@ export function getAnalyticsDistinctId(): string {
   return runtimeDistinctId;
 }
 
-/** Adopt the desktop's per-launch id (Office pane) so desktop + pane count as one user. */
+/** Adopt the server's per-launch id so desktop + pane count as one user. */
 export function setAnalyticsDistinctId(id: string): void {
   const trimmed = id.trim();
   if (trimmed) runtimeDistinctId = trimmed;

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -1092,9 +1092,10 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
     runtimeVersions: () =>
       requestJson<LegalworkRuntimeSnapshot>(baseUrl, "/runtime/versions", { token, hostToken, timeoutMs: timeouts.status }),
     status: () => requestJson<LegalworkServerDiagnostics>(baseUrl, "/status", { token, hostToken, timeoutMs: timeouts.status }),
-    // Push the per-launch analytics identity for the Office pane (in-memory on the server).
-    setAnalyticsIdentity: (payload: { distinctId: string | null; analyticsEnabled: boolean }) =>
-      requestJson<{ ok: boolean }>(baseUrl, "/analytics/identity", {
+    // Sync analytics consent; the server answers with the per-launch
+    // distinct id (in-memory) for the caller to adopt.
+    setAnalyticsIdentity: (payload: { analyticsEnabled: boolean }) =>
+      requestJson<{ ok: boolean; distinctId?: string }>(baseUrl, "/analytics/identity", {
         token,
         hostToken,
         method: "PUT",

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 
 import { THINKING_PREF_KEY } from "../../app/constants";
-import { getAnalyticsDistinctId } from "../../app/lib/analytics";
+import { setAnalyticsDistinctId } from "../../app/lib/analytics";
 import { createLegalworkServerClient } from "../../app/lib/legalwork-server";
 import { coerceReleaseChannel } from "../../app/lib/release-channels";
 import { isDesktopRuntime } from "../../app/lib/runtime-env";
@@ -143,27 +143,24 @@ export function LocalProvider({ children }: LocalProviderProps) {
     writePersisted(PREFS_STORAGE_KEY, prefs);
   }, [prefs]);
 
-  // Push the analytics identity (per-launch id + consent) to the local server
-  // for the Office pane. In-memory on the server; retried briefly because the
-  // server may still be booting. Desktop only.
+  // Sync analytics consent with the local server and adopt its per-launch
+  // distinct id in return. In-memory on both sides; retried briefly because
+  // the server may still be booting. Desktop only. Until the round-trip
+  // succeeds, analytics falls back to a locally minted id.
   useEffect(() => {
     if (!isDesktopRuntime()) return;
     let cancelled = false;
-    const payload = {
-      // The id is only handed out while analytics is on.
-      distinctId: prefs.analyticsEnabled ? getAnalyticsDistinctId() : null,
-      analyticsEnabled: prefs.analyticsEnabled,
-    };
     void (async () => {
       for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
         try {
           const { normalizedBaseUrl, resolvedToken, resolvedHostToken } = await resolveLegalworkConnection();
           if (normalizedBaseUrl && (resolvedToken || resolvedHostToken)) {
-            await createLegalworkServerClient({
+            const result = await createLegalworkServerClient({
               baseUrl: normalizedBaseUrl,
               token: resolvedToken || undefined,
               hostToken: resolvedHostToken || undefined,
-            }).setAnalyticsIdentity(payload);
+            }).setAnalyticsIdentity({ analyticsEnabled: prefs.analyticsEnabled });
+            if (typeof result?.distinctId === "string") setAnalyticsDistinctId(result.distinctId);
             return;
           }
         } catch {

--- a/apps/server/src/eigenwelt-free.test.ts
+++ b/apps/server/src/eigenwelt-free.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { EIGENWELT_ANALYTICS_ID_HEADER, launchAnalyticsId } from "./launch-analytics-id.js";
 import {
   buildEigenweltFreeProviderBlock,
   eigenweltFreeDeviceId,
@@ -377,7 +378,7 @@ describe("eigenweltFreeDeviceId", () => {
 });
 
 describe("buildEigenweltFreeProviderBlock", () => {
-  test("carries the per-device key and both limit keys — no device header", () => {
+  test("carries the per-device key, the launch analytics id, and both limit keys", () => {
     const block = buildEigenweltFreeProviderBlock({ ...CACHED_MANIFEST }) as {
       npm: string;
       name: string;
@@ -389,12 +390,21 @@ describe("buildEigenweltFreeProviderBlock", () => {
     expect(block.options.baseURL).toBe(CACHED_MANIFEST.baseURL);
     // The device's own key travels as an Authorization header — the engine
     // spreads options into createOpenAICompatible, which ignores `apiKey`.
-    expect(block.options.headers).toEqual({ Authorization: `Bearer ${CACHED_MANIFEST.apiKey}` });
+    expect(block.options.headers).toEqual({
+      Authorization: `Bearer ${CACHED_MANIFEST.apiKey}`,
+      // Anonymous per-launch id — never the persistent device id.
+      [EIGENWELT_ANALYTICS_ID_HEADER]: launchAnalyticsId(),
+    });
     expect(block.options.apiKey).toBeUndefined();
     // Both limit keys are mandatory for the engine schema.
     expect(block.models["ewl-free-small"]?.limit).toEqual({ context: 32000, output: 16384 });
     expect(block.models["ewl-free-base"]?.limit).toEqual({ context: 128000, output: 16384 });
     // The manifest's description field must not leak into the engine config.
     expect("description" in (block.models["ewl-free-small"] as Record<string, unknown>)).toBe(false);
+  });
+
+  test("launch analytics id is stable within a process and is a UUID", () => {
+    expect(launchAnalyticsId()).toBe(launchAnalyticsId());
+    expect(launchAnalyticsId()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 });

--- a/apps/server/src/eigenwelt-free.ts
+++ b/apps/server/src/eigenwelt-free.ts
@@ -33,6 +33,7 @@ import { randomUUID } from "node:crypto";
 
 import constants from "../../../constants.json" with { type: "json" };
 
+import { EIGENWELT_ANALYTICS_ID_HEADER, launchAnalyticsId } from "./launch-analytics-id.js";
 import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -349,7 +350,12 @@ export function buildEigenweltFreeProviderBlock(manifest: EigenweltFreeManifest)
       // passes provider `options` verbatim to createOpenAICompatible, which
       // ignores an `apiKey` field — the key MUST travel as an Authorization
       // header (options.headers is verified to reach every request).
-      headers: { Authorization: `Bearer ${manifest.apiKey}` },
+      headers: {
+        Authorization: `Bearer ${manifest.apiKey}`,
+        // Anonymous per-launch id; the gateway reads it as the request's
+        // end user (user_header_name).
+        [EIGENWELT_ANALYTICS_ID_HEADER]: launchAnalyticsId(),
+      },
     },
     models: buildEigenweltModelsMap(manifest.models),
   };

--- a/apps/server/src/launch-analytics-id.ts
+++ b/apps/server/src/launch-analytics-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Anonymous per-launch id: minted once per server process and held in
+ * memory only — a restart rotates it, nothing is persisted. Sent as a
+ * header on eigenwelt-free requests and adopted by the desktop renderer
+ * and Office pane as their analytics distinct id, so one launch shares
+ * one id everywhere.
+ */
+import { randomUUID } from "node:crypto";
+
+export const EIGENWELT_ANALYTICS_ID_HEADER = "X-Eigenwelt-Analytics-Id";
+
+let launchId = "";
+
+export function launchAnalyticsId(): string {
+  if (!launchId) launchId = randomUUID();
+  return launchId;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -58,7 +58,8 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import { serve, type ServeResult } from "./serve-node.js";
-import { handleWordAddinRequest, loadWordAddinTls, setAnalyticsIdentity, WORD_ADDIN_PATH_PREFIX } from "./word-addin.js";
+import { launchAnalyticsId } from "./launch-analytics-id.js";
+import { handleWordAddinRequest, loadWordAddinTls, setAnalyticsConsent, WORD_ADDIN_PATH_PREFIX } from "./word-addin.js";
 import { OfficeToolRelay } from "./office-tools.js";
 import { registerOfficeToolRoutes } from "./routes/office-tools.js";
 import { BenchmarkRunner, type BenchmarkOpencodeClient } from "./benchmarks/runner.js";
@@ -1476,12 +1477,13 @@ function createRoutes(
   });
 
   addRoute(routes, "PUT", "/analytics/identity", "client", async (ctx) => {
-    // Desktop pushes its per-launch analytics identity here; the Office pane
-    // adopts it via the word-addin bootstrap. Held in memory only.
+    // Desktop pushes its analytics consent here and gets the per-launch
+    // distinct id back; the Office pane adopts it via the word-addin
+    // bootstrap. Held in memory only.
     requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
-    setAnalyticsIdentity({ distinctId: body.distinctId, analyticsEnabled: body.analyticsEnabled });
-    return jsonResponse({ ok: true });
+    setAnalyticsConsent({ analyticsEnabled: body.analyticsEnabled });
+    return jsonResponse({ ok: true, distinctId: launchAnalyticsId() });
   });
 
   addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) => {

--- a/apps/server/src/word-addin.ts
+++ b/apps/server/src/word-addin.ts
@@ -13,6 +13,7 @@ import { dirname, extname, join, normalize, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { ServerConfig, WordAddinConfig } from "./types.js";
+import { launchAnalyticsId } from "./launch-analytics-id.js";
 import type { ServeTlsOptions } from "./serve-node.js";
 import { buildWordAddinRedirectorHtml, buildWordAddinShellHtml, WORD_ADDIN_SHELL_VERSION } from "./word-addin-shell.js";
 
@@ -350,22 +351,19 @@ async function serveStaticFile(distPath: string, relativePath: string): Promise<
 }
 
 /**
- * The desktop app's analytics identity (per-launch distinct id + consent),
- * pushed via PUT /analytics/identity and served to the Office pane by the
- * bootstrap. In-memory only — the id rotates per launch and must not be
- * persisted; a server restart resets to "no id, analytics off".
+ * Analytics identity: the server-minted per-launch id plus the desktop's
+ * consent flag (pushed via PUT /analytics/identity). In-memory only — a
+ * server restart rotates the id and resets consent to off.
  */
-export type AnalyticsIdentity = { distinctId: string | null; enabled: boolean };
-let analyticsIdentity: AnalyticsIdentity = { distinctId: null, enabled: false };
+export type AnalyticsIdentity = { distinctId: string; enabled: boolean };
+let analyticsConsent = false;
 
-export function setAnalyticsIdentity(next: { distinctId?: unknown; analyticsEnabled?: unknown }): void {
-  const distinctId =
-    typeof next.distinctId === "string" && next.distinctId.trim() ? next.distinctId.trim() : null;
-  analyticsIdentity = { distinctId, enabled: next.analyticsEnabled === true };
+export function setAnalyticsConsent(next: { analyticsEnabled?: unknown }): void {
+  analyticsConsent = next.analyticsEnabled === true;
 }
 
 export function getAnalyticsIdentity(): AnalyticsIdentity {
-  return analyticsIdentity;
+  return { distinctId: launchAnalyticsId(), enabled: analyticsConsent };
 }
 
 /**
@@ -450,8 +448,8 @@ export async function handleWordAddinRequest(input: {
       token: config.token,
       hostToken: config.hostToken,
       wordAddinPort: wordAddin.port,
-      // Desktop analytics identity (per-launch, in-memory); the pane polls
-      // this endpoint so consent changes propagate.
+      // Analytics identity (per-launch, in-memory); the pane polls this
+      // endpoint so consent changes propagate.
       analyticsDistinctId: identity.distinctId,
       analyticsEnabled: identity.enabled,
       // Lets a cached shell detect it is outdated and reload itself once


### PR DESCRIPTION
Free-gateway requests carried no stable identifier, so each request's gateway-side log entry got a fresh random id.

- **`launch-analytics-id.ts` (new)** — one in-memory UUID per server process; never persisted, a restart rotates it.
- **`eigenwelt-free.ts`** — sends it as `X-Eigenwelt-Analytics-Id` on eigenwelt-free requests; the gateway reads it via `user_header_name` (companion PR: eigenweltlabs/model-api#7).
- **`PUT /analytics/identity`** — now takes only the consent flag and returns the id; the desktop renderer and Office pane adopt it as their analytics distinct id, with the locally minted id as boot-time fallback.

Old clients without the header keep the current behavior, so rollout is backward compatible.

## Testing

- `apps/server`: `tsc --noEmit` clean, `bun test src` 412 pass (incl. new tests for the header and id stability)
- `apps/app`: `tsc --noEmit` clean, `bun test tests/` 171 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)