### PR TITLE
fix(engine): survive "database is locked" on restart (crash every 2nd launch)

### DIFF
--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createManagedOpencodeServer } from "./managed-opencode.js";
+
+// A stand-in for the opencode binary: it fails the first
+// FAKE_OPENCODE_FAIL_UNTIL starts with the same "database is locked" message a
+// not-yet-reaped predecessor produces, then comes up healthy. Invocation count
+// is tracked in a file so the test can assert how many attempts happened.
+const FAKE_OPENCODE = `#!/usr/bin/env node
+const fs = require("node:fs");
+const counter = process.env.FAKE_OPENCODE_COUNTER;
+const failUntil = Number(process.env.FAKE_OPENCODE_FAIL_UNTIL || "0");
+let n = 0;
+try { n = Number(fs.readFileSync(counter, "utf8")) || 0; } catch {}
+n += 1;
+fs.writeFileSync(counter, String(n));
+const portIdx = process.argv.indexOf("--port");
+const port = portIdx >= 0 ? process.argv[portIdx + 1] : "0";
+if (n <= failUntil) {
+  process.stderr.write("Error: Unexpected error\\n\\ndatabase is locked\\n");
+  process.exit(1);
+}
+process.stdout.write("opencode server listening on http://127.0.0.1:" + port + "\\n");
+process.on("SIGTERM", () => process.exit(0));
+setInterval(() => {}, 1 << 30);
+`;
+
+let dir: string | null = null;
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = null;
+});
+
+function fakeBin(failUntil: number): { bin: string; counter: string } {
+  dir = mkdtempSync(join(tmpdir(), "managed-opencode-"));
+  const bin = join(dir, "fake-opencode");
+  const counter = join(dir, "counter");
+  writeFileSync(bin, FAKE_OPENCODE, "utf8");
+  chmodSync(bin, 0o755);
+  return { bin, counter };
+}
+
+test("retries the engine spawn while the DB is locked, then succeeds", async () => {
+  const { bin, counter } = fakeBin(2); // fail twice, succeed on the 3rd
+  const server = await createManagedOpencodeServer({
+    bin,
+    cwd: dir!,
+    env: { FAKE_OPENCODE_COUNTER: counter, FAKE_OPENCODE_FAIL_UNTIL: "2" },
+  });
+  try {
+    expect(server.url).toContain("http://127.0.0.1:");
+    expect(Number(readFileSync(counter, "utf8"))).toBe(3); // 2 locked + 1 healthy
+  } finally {
+    await server.close();
+  }
+}, 20000);
+
+test("does NOT retry a non-lock start failure (fails fast)", async () => {
+  // fail "forever" but with a lock message would retry; use a bin that exits
+  // with a different error so the loop must give up on the first attempt.
+  dir = mkdtempSync(join(tmpdir(), "managed-opencode-"));
+  const bin = join(dir, "fake-opencode");
+  const counter = join(dir, "counter");
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const counter = process.env.FAKE_OPENCODE_COUNTER;
+let n = 0; try { n = Number(fs.readFileSync(counter, "utf8")) || 0; } catch {}
+fs.writeFileSync(counter, String(n + 1));
+process.stderr.write("Error: config parse failed\\n");
+process.exit(1);
+`,
+    "utf8",
+  );
+  chmodSync(bin, 0o755);
+  await expect(
+    createManagedOpencodeServer({ bin, cwd: dir, env: { FAKE_OPENCODE_COUNTER: counter } }),
+  ).rejects.toThrow(/config parse failed/);
+  expect(Number(readFileSync(counter, "utf8"))).toBe(1); // exactly one attempt
+}, 20000);

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -26,8 +26,29 @@ export type OpencodeExecutionSnapshot = {
 
 const SECRET_ENV_PATTERN = /(TOKEN|PASSWORD|USERNAME|AUTH|SECRET|KEY|CREDENTIAL)/i;
 
+// opencode keeps a single persistent SQLite DB (WAL mode) shared across every
+// launch. When the app restarts, the previous engine's OS file lock can still
+// be releasing as the new one starts, so the fresh `serve` fails to open the
+// DB with "database is locked". That is transient — it clears within a second
+// or two once the old process is fully reaped — so we retry the spawn with
+// backoff instead of surfacing it as a boot failure. See close(), which now
+// waits for the previous engine to ACTUALLY exit so this race is rare.
+const START_MAX_ATTEMPTS = 4;
+const START_RETRY_BASE_MS = 500;
+const DB_LOCKED_PATTERN = /database is locked|database table is locked|SQLITE_BUSY/i;
+
+// close() gives the engine this long to handle SIGTERM (flush + WAL checkpoint
+// + release the lock cleanly) before escalating to SIGKILL. It resolves as soon
+// as the process exits; the value is only a ceiling on a graceful shutdown.
+const SIGTERM_GRACE_MS = 3000;
+const SIGKILL_GRACE_MS = 2000;
+
 function randomSecret(): string {
   return randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function findFreePortOnce(hostname: string): Promise<number> {
@@ -55,52 +76,16 @@ async function findFreePort(hostname: string, excludedPorts: number[] = []): Pro
   throw new Error("Failed to resolve free port outside the excluded set");
 }
 
-export async function createManagedOpencodeServer(options: {
-  bin?: string;
-  cwd: string;
-  hostname?: string;
-  port?: number;
-  excludedPorts?: number[];
-  timeoutMs?: number;
-  env?: Record<string, string | undefined>;
-}): Promise<ManagedOpencodeServer> {
-  const hostname = options.hostname ?? "127.0.0.1";
-  const port = options.port ?? await findFreePort(hostname, options.excludedPorts);
-  const username = randomSecret();
-  const password = randomSecret();
-  const args = ["serve", "--hostname", hostname, "--port", String(port), "--cors", "*"];
-  const command = options.bin?.trim() || "opencode";
-  const env = {
-    ...process.env,
-    ...options.env,
-    OPENCODE_SERVER_USERNAME: username,
-    OPENCODE_SERVER_PASSWORD: password,
-  };
-  const injectedEnv = Object.entries({
-    ...(options.env ?? {}),
-    OPENCODE_SERVER_USERNAME: username,
-    OPENCODE_SERVER_PASSWORD: password,
-  })
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
-    .map(([name, value]) => ({
-      name,
-      value: SECRET_ENV_PATTERN.test(name) ? "<redacted>" : value,
-      redacted: SECRET_ENV_PATTERN.test(name),
-    }))
-    .sort((left, right) => left.name.localeCompare(right.name));
-  const child: ChildProcess = spawn(options.bin?.trim() || "opencode", args, {
-    cwd: options.cwd,
-    env,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  let closePromise: Promise<void> | null = null;
-  const exited = new Promise<void>((resolve) => {
-    child.once("exit", () => resolve());
-  });
-
-  const url = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`)), options.timeoutMs ?? 15000);
+/** Resolve with the server URL once the child prints "opencode server
+ * listening", or reject if it exits / errors / times out first. The reject
+ * message carries the child's captured output so callers can detect a
+ * transient "database is locked" start failure. */
+function waitForServerReady(child: ChildProcess, timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timeout waiting for OpenCode server after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
     let output = "";
     const done = (value: string) => {
       clearTimeout(timeout);
@@ -123,38 +108,112 @@ export async function createManagedOpencodeServer(options: {
       output += chunk.toString();
     });
     child.once("error", fail);
-    child.once("exit", (code) => fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)));
+    child.once("exit", (code) =>
+      fail(new Error(`OpenCode server exited with code ${code}${output.trim() ? `\n${output}` : ""}`)),
+    );
   });
+}
 
-  return {
-    url,
-    username,
-    password,
-    pid: child.pid ?? null,
-    execution: {
-      command,
-      args,
-      cwd: options.cwd,
-      env: injectedEnv,
-    },
-    close() {
-      closePromise ??= (async () => {
-        if (child.exitCode !== null) return;
-        if (!child.killed) child.kill("SIGTERM");
-        const timeout = new Promise<void>((resolve) => {
-          setTimeout(() => resolve(), 1000);
-        });
-        await Promise.race([exited, timeout]);
-        if (child.exitCode === null) {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // Process already exited.
-          }
-          await Promise.race([exited, new Promise<void>((resolve) => setTimeout(() => resolve(), 500))]);
+/** A terminate function scoped to one child: SIGTERM, wait for the process to
+ * ACTUALLY exit (so callers never start a replacement engine while this one
+ * still holds the DB lock), then SIGKILL if it overstays. Memoized so repeated
+ * close() calls share one shutdown. */
+function makeTerminator(child: ChildProcess, exited: Promise<void>): () => Promise<void> {
+  let closePromise: Promise<void> | null = null;
+  const alive = () => child.exitCode === null && child.signalCode === null;
+  return () => {
+    closePromise ??= (async () => {
+      if (!alive()) return;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Already gone.
+      }
+      await Promise.race([exited, delay(SIGTERM_GRACE_MS)]);
+      if (alive()) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Already gone.
         }
-      })();
-      return closePromise;
-    },
+        await Promise.race([exited, delay(SIGKILL_GRACE_MS)]);
+      }
+    })();
+    return closePromise;
   };
+}
+
+export async function createManagedOpencodeServer(options: {
+  bin?: string;
+  cwd: string;
+  hostname?: string;
+  port?: number;
+  excludedPorts?: number[];
+  timeoutMs?: number;
+  env?: Record<string, string | undefined>;
+}): Promise<ManagedOpencodeServer> {
+  const hostname = options.hostname ?? "127.0.0.1";
+  const username = randomSecret();
+  const password = randomSecret();
+  const command = options.bin?.trim() || "opencode";
+  const env = {
+    ...process.env,
+    ...options.env,
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+  };
+  const injectedEnv = Object.entries({
+    ...(options.env ?? {}),
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+  })
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([name, value]) => ({
+      name,
+      value: SECRET_ENV_PATTERN.test(name) ? "<redacted>" : value,
+      redacted: SECRET_ENV_PATTERN.test(name),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < START_MAX_ATTEMPTS; attempt += 1) {
+    // Fresh free port each attempt: a start failure never bound a port, and a
+    // retry should steer clear of one a slow-dying predecessor may still hold.
+    const port = options.port ?? (await findFreePort(hostname, options.excludedPorts));
+    const args = ["serve", "--hostname", hostname, "--port", String(port), "--cors", "*"];
+    const child: ChildProcess = spawn(command, args, {
+      cwd: options.cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const exited = new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+    const terminate = makeTerminator(child, exited);
+
+    try {
+      const url = await waitForServerReady(child, options.timeoutMs ?? 15000);
+      return {
+        url,
+        username,
+        password,
+        pid: child.pid ?? null,
+        execution: { command, args, cwd: options.cwd, env: injectedEnv },
+        close: terminate,
+      };
+    } catch (error) {
+      lastError = error;
+      // Make sure this attempt's child is fully gone before retrying or giving
+      // up, so it never lingers holding the port or the DB lock.
+      await terminate();
+      const locked = error instanceof Error && DB_LOCKED_PATTERN.test(error.message);
+      if (!locked || attempt === START_MAX_ATTEMPTS - 1) throw error;
+      const backoff = START_RETRY_BASE_MS * 2 ** attempt; // 500ms, 1s, 2s
+      console.warn(
+        `[managed-opencode] engine DB locked on start (attempt ${attempt + 1}/${START_MAX_ATTEMPTS}); retrying in ${backoff}ms`,
+      );
+      await delay(backoff);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("OpenCode server failed to start");
 }


### PR DESCRIPTION
## Symptom

On the test machine, the packaged alpha (`0.1.5-alpha.37`) crashes on ~every second restart. Support bundle:

```
engine stderr: "OpenCode server exited with code 1 / Error: Unexpected error / database is locked"
→ assertLegalworkServerReady throws (main.mjs:752) → "LegalWork server did not stay running after startup" → boot-failure screen
```

## Root cause

The bundled opencode engine keeps **one persistent SQLite DB (WAL) shared across every launch**. On app quit, `managed-opencode.ts` `close()` sent `SIGTERM` with a 1s grace, then `SIGKILL`, and **returned without confirming the process had actually exited**. So a fast relaunch spawned a new `opencode serve` while the previous engine's OS file lock was still releasing → the fresh engine failed to open the DB (`database is locked`) → exit 1 → whole runtime boot fails. The alternating "every second restart" pattern is the timing signature of racing a not-yet-dead predecessor. (Independently confirmed the engine can leak: found a 2h20m-old orphaned dev opencode still holding its DB.)

## Fix (`managed-opencode.ts`)

1. **`close()` now waits for the process to actually exit** before resolving — `SIGTERM` with a 3s ceiling (so opencode can checkpoint its WAL and release the lock cleanly), then `SIGKILL` + wait. App quit/restart no longer leaves the engine holding the lock for the next launch.
2. **Spawn retries on `database is locked`** with backoff (500ms/1s/2s, 4 attempts, fresh port each try), so a slow-dying predecessor can't turn a transient lock into a boot failure. Non-lock failures still fail fast.

## Test

`managed-opencode.test.ts` spawns a fake engine that reports `database is locked` twice then comes up healthy — **fails without the retry, passes with it** — and asserts a non-lock failure does *not* retry. Server typecheck passes.

## Note

This is an engine/client change, so it needs a **new alpha build** to reach the test machine (the earlier free-provider fix was server-side and didn't). Rare edge case not covered: if the app is hard-killed (SIGKILL of Electron), opencode can still orphan and hold the lock persistently — the retry mitigates but can't reap it. Follow-up option: reap a stale engine on startup via a PID file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)