### PR TITLE
fix(recorder): playback + first-run setup fixes

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1947,6 +1947,8 @@ export default {
   "recorder.engine_unavailable":
     "The local transcription engine is not available on this platform/build.",
   "recorder.setup_title": "Sources, language & model",
+  "recorder.model_required_hint": "Recording needs a transcription model. Choose one and download it first.",
+  "recorder.model_required_cta": "Download a model",
   "recorder.source_microphone": "Microphone",
   "recorder.source_system": "System audio",
   "recorder.source_app": "App audio",
@@ -2019,7 +2021,7 @@ export default {
     "Suggest 3 critical follow-up questions I should ask right now, based on the conversation so far.",
   "recorder.models_title": "Local models",
   "recorder.models_subtitle":
-    "From small and light to best-in-class. All models transcribe English and German fully on this device.",
+    "Download a model to start recording — it's required. From small and light to best-in-class, all run fully on this device and transcribe English and German.",
   "recorder.recordings_title": "Recordings",
   "recorder.recordings_subtitle": "Stored locally in",
   "recorder.recordings_empty": "No recordings yet.",

--- a/apps/app/src/react-app/domains/recorder/model-tier-select.tsx
+++ b/apps/app/src/react-app/domains/recorder/model-tier-select.tsx
@@ -154,8 +154,12 @@ export function ModelTierSelect(props: { disabled?: boolean }) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const recommendedId = store.bootstrap?.device?.recommendedModelId;
-  const currentTier = tierForModelId(store.modelId) ?? MODEL_TIERS[1];
-  const currentModel = store.bootstrap?.models.find((entry) => entry.id === currentTier.modelId);
+  // null when the user hasn't picked a model yet — the trigger shows a
+  // "choose a model" placeholder and recording stays disabled until they do.
+  const selectedTier = tierForModelId(store.modelId);
+  const currentModel = selectedTier
+    ? store.bootstrap?.models.find((entry) => entry.id === selectedTier.modelId)
+    : undefined;
   const currentInstalled = currentModel?.state === "installed";
 
   const pick = (tier: ModelTier) => {
@@ -179,12 +183,20 @@ export function ModelTierSelect(props: { disabled?: boolean }) {
           render={
             <Button variant="outline" size="sm" className="h-8 min-w-[180px] justify-between">
               <span className="flex items-center gap-2">
-                <span className="font-medium text-ink">{tierName(currentTier.key)}</span>
-                {!currentInstalled ? (
-                  <span className="text-2xs text-subtext">
-                    {currentModel?.state === "downloading" ? "…" : t("recorder.model_download_short")}
+                {selectedTier ? (
+                  <>
+                    <span className="font-medium text-ink">{tierName(selectedTier.key)}</span>
+                    {!currentInstalled ? (
+                      <span className="text-2xs text-subtext">
+                        {currentModel?.state === "downloading" ? "…" : t("recorder.model_download_short")}
+                      </span>
+                    ) : null}
+                  </>
+                ) : (
+                  <span className="font-medium text-subtext">
+                    {t("recorder.model_select_placeholder")}
                   </span>
-                ) : null}
+                )}
               </span>
               <ChevronsUpDown className="size-3.5 opacity-60" />
             </Button>

--- a/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
+++ b/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
@@ -525,8 +525,13 @@ export function RecorderPane(props: {
                 </Button>
               )
             ) : (
-              <Button disabled={!canRecord} onClick={() => void store.startRecording(title || undefined)}>
-                <Mic data-icon="inline-start" />
+              <Button
+                disabled={!canRecord}
+                onClick={() => void store.startRecording(title || undefined)}
+                className="gap-2"
+              >
+                <span className="size-2.5 shrink-0 rounded-full bg-danger" aria-hidden />
+                <Mic className="size-4 text-danger" />
                 {t("recorder.record")}
               </Button>
             )}
@@ -594,7 +599,7 @@ export function RecorderPane(props: {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-1">
-              <Button variant="outline" size="sm" onClick={() => navigate("/settings/recorder")}>
+              <Button variant="outline" size="sm" onClick={() => navigate("/settings/recorder?tab=dictation")}>
                 <Settings2 data-icon="inline-start" />
                 {t("recorder.dictation_configure")}
               </Button>
@@ -670,6 +675,15 @@ export function RecorderPane(props: {
               />
             </div>
           </div>
+          {!selectedInstalled && !isRecording ? (
+            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-warning/40 bg-warning-soft px-3 py-2 text-sm text-ink">
+              <HardDrive className="size-4 shrink-0 text-warning" />
+              <span className="min-w-0 flex-1">{t("recorder.model_required_hint")}</span>
+              <Button variant="outline" size="sm" onClick={() => navigate("/settings/recorder")}>
+                {t("recorder.model_required_cta")}
+              </Button>
+            </div>
+          ) : null}
         </SectionCard>
 
         {/* While recording, a slim status row replaces the old live-transcript

--- a/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
+++ b/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
@@ -133,6 +133,14 @@ function recordingAudioSrc(recordingId: string): string {
   return `lw-recording://audio/${encodeURIComponent(recordingId)}`;
 }
 
+// Only one recording plays at a time: whichever <audio> starts pauses the
+// previously playing one (row buttons and the modal player all share this).
+let activeRecordingAudio: HTMLAudioElement | null = null;
+function claimRecordingAudio(el: HTMLAudioElement) {
+  if (activeRecordingAudio && activeRecordingAudio !== el) activeRecordingAudio.pause();
+  activeRecordingAudio = el;
+}
+
 /**
  * Play a finished recording in place. The <audio> element loads the
  * `lw-recording://` URL natively, so play() stays inside the click gesture
@@ -144,7 +152,15 @@ function RecordingPlayer(props: { recordingId: string; compact?: boolean }) {
   const src = recordingAudioSrc(props.recordingId);
 
   if (!props.compact) {
-    return <audio src={src} controls preload="metadata" className="h-9 w-full min-w-0" />;
+    return (
+      <audio
+        src={src}
+        controls
+        preload="metadata"
+        className="h-9 w-full min-w-0"
+        onPlay={(event) => claimRecordingAudio(event.currentTarget)}
+      />
+    );
   }
 
   return <RecordingPlayButton src={src} />;
@@ -180,7 +196,10 @@ function RecordingPlayButton(props: { src: string }) {
         src={props.src}
         preload="none"
         className="hidden"
-        onPlay={() => setPlaying(true)}
+        onPlay={(event) => {
+          claimRecordingAudio(event.currentTarget);
+          setPlaying(true);
+        }}
         onPause={() => setPlaying(false)}
         onEnded={() => setPlaying(false)}
       />

--- a/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
+++ b/apps/app/src/react-app/domains/recorder/recorder-pane.tsx
@@ -142,6 +142,23 @@ function claimRecordingAudio(el: HTMLAudioElement) {
 }
 
 /**
+ * MediaRecorder writes the webm with no duration in its header (it's unknown
+ * while streaming), so <audio>.duration reads Infinity and the scrubber pins to
+ * the far right. Force the browser to compute the real duration by seeking past
+ * the end once, then snap back to the start.
+ */
+function fixInfiniteDuration(el: HTMLAudioElement) {
+  if (el.duration !== Infinity) return;
+  const onDurationChange = () => {
+    if (el.duration === Infinity || Number.isNaN(el.duration)) return;
+    el.removeEventListener("durationchange", onDurationChange);
+    el.currentTime = 0;
+  };
+  el.addEventListener("durationchange", onDurationChange);
+  el.currentTime = 1e101;
+}
+
+/**
  * Play a finished recording in place. The <audio> element loads the
  * `lw-recording://` URL natively, so play() stays inside the click gesture
  * (first play works) and the file streams with seeking. `compact` (list rows)
@@ -158,6 +175,7 @@ function RecordingPlayer(props: { recordingId: string; compact?: boolean }) {
         controls
         preload="metadata"
         className="h-9 w-full min-w-0"
+        onLoadedMetadata={(event) => fixInfiniteDuration(event.currentTarget)}
         onPlay={(event) => claimRecordingAudio(event.currentTarget)}
       />
     );

--- a/apps/app/src/react-app/domains/recorder/recorder-store.ts
+++ b/apps/app/src/react-app/domains/recorder/recorder-store.ts
@@ -214,15 +214,6 @@ function readPref(key: string, fallback: string): string {
   }
 }
 
-/** Raw stored value (null when the user never set it), to tell default from choice. */
-function readStoredPref(key: string): string | null {
-  try {
-    return localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
 function writePref(key: string, value: string) {
   try {
     localStorage.setItem(key, value);
@@ -232,12 +223,14 @@ function writePref(key: string, value: string) {
 }
 
 function readSourcesPref(): AudioCaptureSourceKind[] {
-  const raw = readPref(SOURCES_PREF_KEY, "microphone");
+  // Default to capturing both the mic and system audio (call recordings want
+  // both); unsupported sources are filtered out at capture time per platform.
+  const raw = readPref(SOURCES_PREF_KEY, "microphone,system");
   const parsed = raw
     .split(",")
     .map((item) => item.trim())
     .filter((item): item is AudioCaptureSourceKind => item === "microphone" || item === "system");
-  return parsed.length ? parsed : ["microphone"];
+  return parsed.length ? parsed : ["microphone", "system"];
 }
 
 function readLanguagePref(): AudioTranscribeLanguage {
@@ -270,6 +263,23 @@ function missingPermissionKinds(
     const state = permissions[kind];
     if (kind === "microphone") return state === "denied" || state === "restricted";
     return state === "denied" || state === "restricted" || state === "not-determined";
+  });
+}
+
+/**
+ * Kinds not yet granted — used to surface the permission panel PROACTIVELY (on
+ * entering the recorder) rather than only after a failed start. Unlike
+ * {@link missingPermissionKinds}, an undetermined microphone counts here too so
+ * the user can grant everything the raw recorder needs up front.
+ */
+function ungrantedPermissionKinds(
+  permissions: AudioCapturePermissions | null,
+  kinds: AudioPermissionKind[],
+): AudioPermissionKind[] {
+  if (!permissions) return [];
+  return kinds.filter((kind) => {
+    const state = permissions[kind];
+    return state !== "granted" && state !== "unknown";
   });
 }
 
@@ -599,7 +609,7 @@ export const useRecorderStore = create<RecorderState & RecorderActions>((set, ge
     systemDictation: null,
     dictationState: "idle",
     dictationRecordingId: null,
-    modelId: readPref(MODEL_PREF_KEY, "whisper-small"),
+    modelId: readPref(MODEL_PREF_KEY, ""),
     language: readLanguagePref(),
     sources: readSourcesPref(),
     diarizing: false,
@@ -619,6 +629,14 @@ export const useRecorderStore = create<RecorderState & RecorderActions>((set, ge
         get().refreshPermissions(),
         get().refreshSystemDictation(),
       ]);
+      // Surface any OS permission the raw recorder still needs (microphone /
+      // the macOS system-audio recording pane) up front, so the user grants it
+      // before pressing Record instead of bouncing off a failed start.
+      const needed = ungrantedPermissionKinds(
+        get().permissions,
+        requiredPermissionKinds(get().sources),
+      );
+      if (needed.length) set({ permissionsNeeded: needed });
       void get().prewarm();
       void get().ensureDiarizationReady();
     },
@@ -638,18 +656,13 @@ export const useRecorderStore = create<RecorderState & RecorderActions>((set, ge
       try {
         const bootstrap = await audioRecorderBootstrap();
         set({ bootstrap });
-        // Repoint the selection when it references a model that no longer
-        // exists (old Base/Turbo tiers) or the user never chose one — pick the
-        // model recommended for this device so nothing is silently unselectable.
+        // Clear a stale selection that no longer maps to a real model (e.g. an
+        // old Base/Turbo tier) so the user consciously picks + downloads one.
+        // Never auto-select a model on their behalf — recording requires an
+        // explicit, installed choice.
         const chosen = get().modelId;
-        const stored = readStoredPref(MODEL_PREF_KEY);
-        const known = bootstrap.models.some((model) => model.id === chosen);
-        if (!known || !stored) {
-          const recommended = bootstrap.device?.recommendedModelId;
-          const fallback = bootstrap.models.find((model) => model.id === recommended)
-            ? recommended
-            : bootstrap.models.find((model) => model.plan === "free")?.id ?? chosen;
-          if (fallback && fallback !== chosen) set({ modelId: fallback });
+        if (chosen && !bootstrap.models.some((model) => model.id === chosen)) {
+          set({ modelId: "" });
         }
       } catch (error) {
         set({ error: error instanceof Error ? error.message : String(error) });

--- a/apps/app/src/react-app/domains/settings/pages/recorder-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/recorder-view.tsx
@@ -5,6 +5,7 @@
  * lean — just record.
  */
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { HardDrive, Keyboard, Languages, Mic, ShieldCheck } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -34,7 +35,16 @@ import { DictationSetupDialog } from "./dictation-setup-dialog";
 
 export function RecorderSettingsView() {
   const store = useRecorderStore();
-  const [tab, setTab] = useState<"models" | "dictation">("models");
+  const [searchParams] = useSearchParams();
+  // Callers deep-link the tab: "Dictate anywhere" opens ?tab=dictation, model
+  // entries default to the models tab.
+  const [tab, setTab] = useState<"models" | "dictation">(
+    searchParams.get("tab") === "dictation" ? "dictation" : "models",
+  );
+  useEffect(() => {
+    const requested = searchParams.get("tab");
+    if (requested === "dictation" || requested === "models") setTab(requested);
+  }, [searchParams]);
   const [changingDictation, setChangingDictation] = useState(false);
   const [dictationSetupOpen, setDictationSetupOpen] = useState(false);
   const [loginItem, setLoginItem] = useState<{ openAtLogin: boolean; requiresApproval: boolean } | null>(null);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2005,7 +2005,7 @@ export function SessionRoute() {
       onSelectAgent={setSelectedAgent}
     />
     <WhatsNewDialog hasWorkspaces={workspaces.length > 0} workspacesReady={!effectiveLoading} />
-    <TranscriptionIntroDialog workspacesReady={!effectiveLoading} />
+    <TranscriptionIntroDialog workspacesReady={!effectiveLoading} onOpenRecorder={showRecorderPane} />
     <SessionSearchDialog
       open={sessionSearchOpen}
       onClose={() => setSessionSearchOpen(false)}

--- a/apps/app/src/react-app/shell/transcription-intro.tsx
+++ b/apps/app/src/react-app/shell/transcription-intro.tsx
@@ -6,7 +6,6 @@
  * new announcement is still pending so the two never stack.
  */
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { FeatureAnnouncementModal } from "@/react-app/design-system/modals/feature-announcement-modal";
 import { isDesktopRuntime, isOfficeAddinRuntime } from "@/app/utils";
@@ -32,8 +31,7 @@ function markSeen(): void {
   }
 }
 
-export function TranscriptionIntroDialog(props: { workspacesReady: boolean }) {
-  const navigate = useNavigate();
+export function TranscriptionIntroDialog(props: { workspacesReady: boolean; onOpenRecorder: () => void }) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -54,7 +52,9 @@ export function TranscriptionIntroDialog(props: { workspacesReady: boolean }) {
 
   const setUp = () => {
     dismiss();
-    navigate("/settings/recorder");
+    // Open the Recorder pane itself (not Settings) so the user lands where they
+    // record; the pane guides model download + permissions from there.
+    props.onOpenRecorder();
   };
 
   return (

--- a/apps/desktop/electron/audio/recorder-service.mjs
+++ b/apps/desktop/electron/audio/recorder-service.mjs
@@ -283,11 +283,10 @@ export class RecorderService {
   }
 
   /**
-   * Rough device tier for the "recommended for your device" hint. Premium
-   * (Parakeet) is the default recommendation on any capable machine: it is
-   * fast, multilingual, and comfortable on ~8 GB+. Weak/old machines fall back
-   * to the free Basic (Whisper small) model. We never auto-recommend the
-   * Maximum model (see `fastDevice`).
+   * Rough device tier for the "recommended for your device" hint. We recommend
+   * a FREE tier so a first-run user isn't nudged toward the gated Premium model
+   * they can't use yet: Basic (Whisper small) on a capable machine, Super small
+   * (Whisper tiny) on a weak/old one. Never the Premium or Maximum models.
    *
    * `fastDevice` is a stricter bar than `strong`: the Maximum (Whisper
    * large-v3) model is ~1.7 GB and slow on CPU, so it only makes sense on
@@ -305,7 +304,7 @@ export class RecorderService {
       logicalCores,
       appleSilicon,
       fastDevice,
-      recommendedModelId: strong ? "parakeet-tdt-0.6b-v3" : "whisper-small",
+      recommendedModelId: strong ? "whisper-small" : "whisper-tiny",
     };
   }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1,7 +1,8 @@
 import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
 import net from "node:net";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { createReadStream, existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { Readable } from "node:stream";
 import {
   chmod,
   cp,
@@ -16,9 +17,9 @@ import {
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, clipboard, desktopCapturer, dialog, globalShortcut, ipcMain, nativeImage, nativeTheme, net as electronNet, powerMonitor, powerSaveBlocker, protocol, session, shell, systemPreferences } from "electron";
+import { app, BrowserWindow, clipboard, desktopCapturer, dialog, globalShortcut, ipcMain, nativeImage, nativeTheme, powerMonitor, powerSaveBlocker, protocol, session, shell, systemPreferences } from "electron";
 import { configureFakeMediaForTests, installMediaPermissionHandlers } from "./media-permissions.mjs";
 import { appendLoopbackFeatureFlags, disableLoopbackAudio, enableLoopbackAudio, isLoopbackCaptureArmed } from "./audio/loopback.mjs";
 import { captureAuthStatus, openCapturePermissionSettings, requestCapturePermission } from "./audio/capture-permissions.mjs";
@@ -2698,7 +2699,36 @@ if (!app.requestSingleInstanceLock()) {
         const id = decodeURIComponent(url.pathname.replace(/^\/+/, "")) || decodeURIComponent(url.hostname);
         const filePath = recorderService().recordingAudioFilePath(id);
         if (!filePath) return new Response(null, { status: 404 });
-        return electronNet.fetch(pathToFileURL(filePath).toString(), { headers: request.headers });
+        // Serve with byte-range support so <audio> can seek. Without a 206 +
+        // Accept-Ranges the media element treats the source as non-seekable.
+        const size = statSync(filePath).size;
+        const baseHeaders = {
+          "Content-Type": "audio/webm",
+          "Accept-Ranges": "bytes",
+          "Cache-Control": "no-store",
+        };
+        const rangeMatch = /bytes=(\d*)-(\d*)/.exec(request.headers.get("Range") ?? "");
+        if (rangeMatch) {
+          let start = rangeMatch[1] ? Number.parseInt(rangeMatch[1], 10) : 0;
+          let end = rangeMatch[2] ? Number.parseInt(rangeMatch[2], 10) : size - 1;
+          if (!Number.isFinite(start) || start < 0) start = 0;
+          if (!Number.isFinite(end) || end >= size) end = size - 1;
+          if (start > end) {
+            return new Response(null, { status: 416, headers: { "Content-Range": `bytes */${size}` } });
+          }
+          return new Response(Readable.toWeb(createReadStream(filePath, { start, end })), {
+            status: 206,
+            headers: {
+              ...baseHeaders,
+              "Content-Range": `bytes ${start}-${end}/${size}`,
+              "Content-Length": String(end - start + 1),
+            },
+          });
+        }
+        return new Response(Readable.toWeb(createReadStream(filePath)), {
+          status: 200,
+          headers: { ...baseHeaders, "Content-Length": String(size) },
+        });
       } catch {
         return new Response(null, { status: 404 });
       }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2716,7 +2716,9 @@ if (!app.requestSingleInstanceLock()) {
           if (start > end) {
             return new Response(null, { status: 416, headers: { "Content-Range": `bytes */${size}` } });
           }
-          return new Response(Readable.toWeb(createReadStream(filePath, { start, end })), {
+          // Node's web ReadableStream is structurally a valid Response body but
+          // nominally differs from the DOM type tsc sees here — cast past it.
+          return new Response(/** @type {any} */ (Readable.toWeb(createReadStream(filePath, { start, end }))), {
             status: 206,
             headers: {
               ...baseHeaders,
@@ -2725,7 +2727,7 @@ if (!app.requestSingleInstanceLock()) {
             },
           });
         }
-        return new Response(Readable.toWeb(createReadStream(filePath)), {
+        return new Response(/** @type {any} */ (Readable.toWeb(createReadStream(filePath))), {
           status: 200,
           headers: { ...baseHeaders, "Content-Length": String(size) },
         });


### PR DESCRIPTION
A batch of recorder fixes on top of `dev`.

### Playback
- **One recording plays at a time** — starting a new one pauses the previous (row + modal share an active-audio ref).
- **Real duration in the modal player** — MediaRecorder webm has no header duration, so the scrubber pinned to the right; seek-past-end on load computes it.
- **Byte-range serving** so the scrubber can actually seek (`206` + `Accept-Ranges` in the `lw-recording://` handler).

### First-run setup
1. **Feature intro modal** opens the Recorder pane itself (not Settings).
2. **Default sources**: microphone + system audio (unsupported filtered per platform).
3. **Permissions up front** — proactively surface the OS permissions the raw recorder needs (mic / macOS system-audio recording) on entry, not only after a failed start.
4. **No auto-selected model** — picker shows "Choose a model", Record disabled until a model is selected AND installed, with a "download a model first" notice; the recommended hint points at a free tier (Basic / Super small), never gated Premium.
5. **"Dictate anywhere"** deep-links Settings › Recorder to the **Dictation** tab (`?tab=dictation`).
6. **Record button** gets a red record dot + red mic.

Verified: app typecheck · desktop tests 17/17 · i18n audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)