### PR TITLE
feat(mcp): add Ruly to preconfigured integrations

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -453,6 +453,20 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     kind: "mcp",
   },
   {
+    get name() { return t("mcp.quick_connect_ruly_title"); },
+    serverName: "ruly",
+    get description() { return t("mcp.quick_connect_ruly_desc"); },
+    // Jurisdiction-specific court rules, local rules, and procedural statutes.
+    // One-click: OAuth 2.1 + PKCE with dynamic client registration; the desktop
+    // loopback redirect is permitted on any port, so no firm-admin step. Each
+    // user needs their own Ruly account with an MCP-enabled subscription (the
+    // server returns 403 not_entitled until it's activated).
+    url: "https://mcp.askruly.com/mcp",
+    type: "remote",
+    oauth: true,
+    kind: "mcp",
+  },
+  {
     get name() { return t("mcp.quick_connect_taxgraph_title"); },
     serverName: "taxgraph",
     get description() { return t("mcp.quick_connect_taxgraph_desc"); },

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -797,6 +797,8 @@ export default {
   "mcp.quick_connect_legalwork_ui_title": "LegalWork UI Control",
   "mcp.quick_connect_relativity_desc": "Query the firm's RelativityOne eDiscovery instance in natural language — manage matters, workspaces, and access. Enter your tenant hostname and the Client ID from Relativity Support; you act as a signed-in System Administrator.",
   "mcp.quick_connect_relativity_title": "Relativity",
+  "mcp.quick_connect_ruly_desc": "Search jurisdiction-specific court rules, local rules, and procedural statutes with grounded citations. One-click sign-in with your Ruly account; an active MCP subscription is required.",
+  "mcp.quick_connect_ruly_title": "Ruly",
   "mcp.quick_connect_sharepoint_desc": "Search and manage matter files across the firm's SharePoint sites and OneDrive. Enter your tenant ID; admin consent required.",
   "mcp.quick_connect_sharepoint_title": "Microsoft SharePoint",
   "mcp.quick_connect_taxgraph_desc": "Search a daily-updated German tax-law knowledge graph — statutes, BFH case law, and BMF guidance with citations.",


### PR DESCRIPTION
## Summary
- Add **Ruly** to the MCP quick-connect catalog (`MCP_QUICK_CONNECT` in `apps/app/src/app/constants.ts`) plus its `en` locale strings.

## Why
- Ruly exposes a jurisdiction-specific legal rule corpus (court rules, local rules, procedural statutes) over MCP. It's a standard MCP server using OAuth 2.1 + PKCE with dynamic client registration, so it connects one-click via the desktop loopback redirect (permitted on any port) with no firm-admin step — the same shape as the existing CourtListener / TaxGraph / Dropbox one-click entries.

## Issue
- Closes #

## Scope
- New catalog entry: `serverName: "ruly"`, `url: https://mcp.askruly.com/mcp`, `type: remote`, `oauth: true`, `kind: "mcp"`, placed with the other genuine one-click OAuth connectors.
- New `en.ts` strings `mcp.quick_connect_ruly_title` / `_desc` (alphabetically ordered; other locales fall back to English via the existing `t()` fallback chain).

## Out of scope
- Web/SaaS callback-host allowlisting (per Ruly's guide, that's an email-us step for hosted clients only; the desktop loopback flow needs no allowlisting).
- No icon added — Ruly has no Simple Icons slug, matching other icon-less catalog entries.

## Testing
### Ran
- `pnpm typecheck` (apps/app)
- `bun test tests/extension-items.test.ts`

### Result
- pass/fail: pass
- typecheck surfaces only a pre-existing `baseUrl` deprecation warning unrelated to this change; extension-items test passes (1 pass, 0 fail).

## CI status
- pass: to be confirmed by CI
- code-related failures: none expected
- external/env/auth blockers: `pnpm install` couldn't complete electron/better-sqlite3 postinstall in this sandbox (network-restricted); does not affect this data-only change.

## Manual verification
1. Open Settings → MCP / connectors catalog.
2. Confirm "Ruly" appears among the one-click OAuth connectors.
3. Click Connect → standard OAuth (PKCE + dynamic client registration) flow starts against `https://mcp.askruly.com/mcp`.

## Evidence
- N/A (catalog data change)

## Risk
- Low. Additive catalog + locale entry mirroring existing one-click OAuth connectors; no logic changes.

## Rollback
- Revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVr3EtMMEhz5n4gmgqGvdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVr3EtMMEhz5n4gmgqGvdp)_