### PR TITLE
fix(recorder): play imported audio files of any format

### DIFF
--- a/apps/desktop/electron/audio-recorder.test.mjs
+++ b/apps/desktop/electron/audio-recorder.test.mjs
@@ -254,6 +254,37 @@ test("recorder service records, transcribes, finalizes files", async () => {
   await fsp.rm(workspaceDir, { recursive: true, force: true });
 });
 
+test("imported files resolve for playback under their original extension", async () => {
+  const userDataDir = await tempDir("lw-recorder-");
+  const service = new RecorderService({ userDataDir, forkWorker: () => new FakeWorker() });
+  await installFakeModel(service, "whisper-tiny");
+  await service.startTranscriber({ modelId: "whisper-tiny", language: "de" });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  // Import stores the original container (mp3), not audio.webm.
+  const meta = await service.importFileStart({
+    title: "Client meeting",
+    fileName: "client-meeting.mp3",
+    language: "de",
+    modelId: "whisper-tiny",
+  });
+  await service.importFileSource(meta.id, new TextEncoder().encode("mp3-bytes").buffer);
+  service.feedPcm(meta.id, new Float32Array(1600).buffer);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const done = await service.importFileFinish(meta.id, 1200);
+  assert.equal(done.status, "complete");
+
+  // The playback protocol must find the imported file even though it is not
+  // named audio.webm — this is the bug the play button hit for imports.
+  const playbackPath = service.recordingAudioFilePath(meta.id);
+  assert.ok(playbackPath, "imported file resolves for playback");
+  assert.ok(playbackPath.endsWith("client-meeting.mp3"));
+  assert.equal(service.recordingAudioFilePath("../etc/passwd"), null);
+
+  service.dispose();
+  await fsp.rm(userDataDir, { recursive: true, force: true });
+});
+
 test("device profile exposes the fast-device flag that gates the heaviest model", async () => {
   const userDataDir = await tempDir("lw-recorder-");
   const service = new RecorderService({ userDataDir, forkWorker: () => new FakeWorker() });

--- a/apps/desktop/electron/audio/recorder-service.mjs
+++ b/apps/desktop/electron/audio/recorder-service.mjs
@@ -870,12 +870,31 @@ export class RecorderService {
    * playback protocol. Returns null (rather than risking traversal) unless the
    * id is a single, safe path segment that resolves inside the recordings dir
    * and the file exists.
+   *
+   * Live recordings write `audio.webm`; imported files are stored verbatim
+   * under their original name + extension (e.g. `recording.mp3`), so the webm
+   * fast path misses them — fall back to the source file recorded in meta.json.
    */
   recordingAudioFilePath(recordingId) {
     const id = String(recordingId || "");
     if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) return null;
-    const audioPath = path.join(this.recordingsDir, id, "audio.webm");
-    if (!audioPath.startsWith(this.recordingsDir + path.sep)) return null;
+    const folder = path.join(this.recordingsDir, id);
+    if (!folder.startsWith(this.recordingsDir + path.sep)) return null;
+    const webmPath = path.join(folder, "audio.webm");
+    if (fs.existsSync(webmPath)) return webmPath;
+    // Imported audio keeps its original extension; the file name lives in
+    // meta.audioPath. Resolve only its basename inside the folder so a
+    // tampered meta can never point playback outside the recordings dir.
+    let audioName = "";
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(folder, "meta.json"), "utf8"));
+      if (meta?.audioPath) audioName = path.basename(String(meta.audioPath));
+    } catch {
+      return null;
+    }
+    if (!audioName || audioName === "meta.json") return null;
+    const audioPath = path.join(folder, audioName);
+    if (!audioPath.startsWith(folder + path.sep)) return null;
     return fs.existsSync(audioPath) ? audioPath : null;
   }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -63,6 +63,31 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
+// Live recordings are always webm, but imported files keep their original
+// container (mp3, m4a, wav, …). Serve each with a matching Content-Type so the
+// <audio> element can decode it — a webm type on an mp3 makes playback fail.
+const RECORDING_AUDIO_MIME_BY_EXT = {
+  ".webm": "audio/webm",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".mp4": "video/mp4",
+  ".aac": "audio/aac",
+  ".wav": "audio/wav",
+  ".flac": "audio/flac",
+  ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".opus": "audio/ogg",
+  ".caf": "audio/x-caf",
+  ".aif": "audio/aiff",
+  ".aiff": "audio/aiff",
+  ".mov": "video/quicktime",
+  ".wma": "audio/x-ms-wma",
+  ".3gp": "audio/3gpp",
+};
+function recordingAudioContentType(filePath) {
+  return RECORDING_AUDIO_MIME_BY_EXT[path.extname(filePath).toLowerCase()] ?? "application/octet-stream";
+}
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const pty = require(["node", "pty"].join("-"));
@@ -2703,7 +2728,7 @@ if (!app.requestSingleInstanceLock()) {
         // Accept-Ranges the media element treats the source as non-seekable.
         const size = statSync(filePath).size;
         const baseHeaders = {
-          "Content-Type": "audio/webm",
+          "Content-Type": recordingAudioContentType(filePath),
           "Accept-Ranges": "bytes",
           "Cache-Control": "no-store",
         };


### PR DESCRIPTION
## Summary
- Fix the recordings play button so it works for imported audio files, not just native webm recordings.

## Why
- The play button worked only for recordings the app captured itself (always `audio.webm`). Imported files can be any container (mp3, m4a, wav, …) and are stored verbatim under their original name/extension, so playback failed for them.
- Two root causes in the `lw-recording://` playback path:
  1. `recordingAudioFilePath` only ever looked for `audio.webm`, so it returned `null` → 404 for imported files stored as e.g. `client-meeting.mp3`.
  2. The protocol handler hardcoded `Content-Type: audio/webm`, the wrong MIME type for non-webm imports.

## Issue
- Closes #

## Scope
- `apps/desktop/electron/audio/recorder-service.mjs`: `recordingAudioFilePath` now falls back to the imported source filename recorded in `meta.json` when `audio.webm` is absent, resolving only the basename inside the recording folder so the existing path-traversal guard stays intact.
- `apps/desktop/electron/main.mjs`: the protocol handler derives `Content-Type` from the file extension (map covering webm/mp3/m4a/mp4/aac/wav/flac/ogg/opus/caf/aiff/mov/wma/3gp, defaulting to `application/octet-stream`) so the `<audio>` element can decode the actual container. Range/seeking behavior is unchanged.
- `apps/desktop/electron/audio-recorder.test.mjs`: adds a regression test covering import → playback resolution.

## Out of scope
- No changes to import decoding/transcription, the renderer player UI, or how live recordings are stored.

## Testing
### Ran
- `node --test electron/audio-recorder.test.mjs`

### Result
- pass/fail: pass (17/18)
- if fail, exact files/errors: the single failing test (`worker segments real audio with the real Silero VAD`) is pre-existing and unrelated — it asserts a Silero model devDependency is present on disk, which this sandbox does not have. `typecheck:electron` could not run here because `node_modules` is not installed in the sandbox.

## CI status
- pass: TBD (CI will run)
- code-related failures: none expected
- external/env/auth blockers: local typecheck blocked by missing `node_modules` in sandbox

## Manual verification
1. Import a non-webm audio file (e.g. an `.mp3`) via the Recorder pane.
2. Press the play button on its row — audio now plays and seeks.
3. Confirm a normal captured (`webm`) recording still plays as before.

## Evidence
- N/A (covered by automated regression test; desktop app not runnable in this environment)

## Risk
- Low. The change is confined to resolving the playback file path and its Content-Type; the traversal guard is preserved (only a basename inside the recording folder is used) and the webm fast path is unchanged.

## Rollback
- Revert this commit; playback returns to webm-only behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_012m3hFCWqK5NFUgcYkxyZmB)_