### PR TITLE
fix(mcp): recover Notion OAuth from stale DCR client_id mismatch

### DIFF
--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -39,6 +39,23 @@ function isDynamicClientRegistrationError(message: string | undefined): boolean 
   return normalized.includes("dynamic client registration") && normalized.includes("does not support");
 }
 
+// Providers that use Dynamic Client Registration (e.g. Notion's hosted MCP)
+// mint a fresh client_id on every registration. When a stale/orphaned
+// registration lingers from an earlier attempt, the token exchange fails with
+// "OAuth completion failed: Client ID mismatch" (or an "invalid_client" from
+// the provider). Detect that class of failure so we can drop the stale
+// registration and retry with a clean one.
+function isClientRegistrationMismatchError(message: string | undefined): boolean {
+  const normalized = message?.toLowerCase() ?? "";
+  if (!normalized) return false;
+  return (
+    (normalized.includes("client id") && normalized.includes("mismatch")) ||
+    (normalized.includes("client_id") && normalized.includes("mismatch")) ||
+    normalized.includes("invalid_client") ||
+    normalized.includes("invalid client")
+  );
+}
+
 export type McpAuthModalProps = {
   open: boolean;
   onClose: () => void;
@@ -167,6 +184,37 @@ export function McpAuthModal(props: McpAuthModalProps) {
   const resolveSlug = (name: string) =>
     validateMcpServerName(name).toLowerCase().replace(/[^a-z0-9]+/g, "-");
 
+  // Drop any stored OAuth registration/tokens for this server. Best-effort:
+  // used to recover from a stale Dynamic Client Registration that would
+  // otherwise fail the token exchange with a "Client ID mismatch".
+  const clearStoredAuth = async (slug: string, directory: string) => {
+    if (!props.client) return;
+    try {
+      await props.client.mcp.auth.remove({ directory, name: slug });
+    } catch {
+      // Clearing is a recovery step, not a hard requirement — ignore failures.
+    }
+  };
+
+  // Run the engine's one-shot authenticate. If the provider rejects the token
+  // exchange because of a stale DCR client_id ("Client ID mismatch"), clear the
+  // orphaned registration once and retry a clean registration + authorize.
+  const runLocalAuthenticate = async (
+    slug: string,
+    directory: string,
+    allowMismatchRetry: boolean,
+  ): Promise<McpStatusEntry> => {
+    const result = await props.client!.mcp.auth.authenticate({ name: slug, directory });
+    const status = unwrap(result) as McpStatusEntry;
+
+    if (allowMismatchRetry && status.status === "failed" && isClientRegistrationMismatchError(status.error)) {
+      await clearStoredAuth(slug, directory);
+      return runLocalAuthenticate(slug, directory, false);
+    }
+
+    return status;
+  };
+
   const waitForMcpAvailability = async (slug: string) => {
     const startedAt = Date.now();
     while (Date.now() - startedAt < MCP_AUTH_DISCOVERY_TIMEOUT_MS) {
@@ -254,11 +302,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       }
 
       if (!props.isRemoteWorkspace) {
-        const result = await props.client.mcp.auth.authenticate({
-          name: slug,
-          directory,
-        });
-        const status = unwrap(result) as McpStatusEntry;
+        const status = await runLocalAuthenticate(slug, directory, true);
 
         if (status.status === "connected") {
           setAlreadyConnected(true);
@@ -560,6 +604,12 @@ export function McpAuthModal(props: McpAuthModalProps) {
       } else if (status.status === "disabled") {
         setError(t("mcp.auth.server_disabled"));
       } else if (status.status === "failed") {
+        // A stale DCR client_id ("Client ID mismatch") won't recover by
+        // re-submitting the same code. Drop the orphaned registration so the
+        // next Retry starts a clean registration + authorize.
+        if (isClientRegistrationMismatchError(status.error)) {
+          await clearStoredAuth(slug, directory);
+        }
         setError(status.error ?? t("mcp.auth.oauth_failed"));
       } else {
         setError(t("mcp.auth.authorization_still_required"));


### PR DESCRIPTION
## Summary
- When connecting Notion, after approving in the browser the app failed with `OAuth completion failed: Client ID mismatch`. This detects that failure class in the MCP auth modal, drops the stale/orphaned client registration, and retries a clean registration + authorize.

## Why
- Notion's hosted MCP (`https://mcp.notion.com/mcp`) uses **Dynamic Client Registration** (`oauth: true`, no fixed client ID — `apps/app/src/app/constants.ts`) and mints a **fresh `client_id` on every registration**. When a stale registration lingers from an earlier attempt, the engine does the browser `authorize` step under one `client_id` and the `token` exchange under another, so the provider rejects the exchange right after approval. The `Client ID mismatch` string is emitted by the opencode engine sidecar (`anomalyco/opencode`), not this repo, so the repo-side remedy is to recover from it. Matches known bugs opencode#28741 and claude-code#65752.

## Issue
- Closes #

## Scope
- `apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx`
  - `isClientRegistrationMismatchError()` — detect `client id mismatch` / `invalid_client`.
  - `clearStoredAuth()` — drop the orphaned registration via `client.mcp.auth.remove` (same API `store.ts` uses for logout).
  - Local flow: transparently clear stored auth and retry `authenticate` **once**.
  - Remote/manual flow: clear stored auth on mismatch so the existing **Retry** re-registers cleanly instead of re-submitting a code bound to a dead `client_id`.

## Out of scope
- Skipping DCR entirely by giving Notion a pre-registered OAuth client ID (needs a real Notion credential).
- The upstream root-cause fix in `anomalyco/opencode` (use the originating `client_id` for the token exchange).

## Testing
### Ran
- `npx tsc -p tsconfig.json --noEmit`

### Result
- pass/fail: **could not run** — dependencies are not installed in this environment (`no node_modules`); `tsc` reports only environmental errors (`Cannot find type definition file for 'node'`, `vite/client`), none in the changed file.
- if fail, exact files/errors: N/A (no errors in `mcp-auth-modal.tsx`)

## CI status
- pass:
- code-related failures:
- external/env/auth blockers: local typecheck blocked by missing `node_modules`

## Manual verification
1. Add the Notion connector and start OAuth; approve in the browser.
2. If the engine returns `Client ID mismatch`, confirm the app clears the stale registration and completes on the automatic (local) or manual **Retry** attempt.
3. Confirm an already-connected server and a normal first-time success are unaffected (retry only fires on the mismatch failure).

## Evidence
- N/A

## Risk
- Low. New behavior is gated on the specific mismatch error; the retry is bounded to a single re-attempt. The clear-and-retry only runs when the server is not already connected. Changes mirror existing client-API precedents in `store.ts`.

## Rollback
- Revert this commit; no migrations, config, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1eJbrXcCYpdyNNwvdzjoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1eJbrXcCYpdyNNwvdzjoi)_