### PR TITLE
fix(recorder): open Plus upsell from locked models

### DIFF
--- a/apps/app/src/app/lib/eigenwelt-budget.ts
+++ b/apps/app/src/app/lib/eigenwelt-budget.ts
@@ -33,8 +33,8 @@ export const EIGENWELT_BUDGET_MAX_RETRY_ATTEMPTS = 3;
 
 export const EIGENWELT_BUDGET_EXCEEDED_TITLE = "Your seat's daily usage has been used up";
 export const EIGENWELT_BUDGET_EXCEEDED_BODY =
-  "Upgrade to premium for higher limits, or come back tomorrow.";
-export const EIGENWELT_BUDGET_UPGRADE_LABEL = "Upgrade to premium";
+  "Upgrade to Pro for higher limits, or come back tomorrow.";
+export const EIGENWELT_BUDGET_UPGRADE_LABEL = "Upgrade to Pro";
 
 /**
  * Text of the synthetic terminal error message injected into the transcript

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -671,7 +671,7 @@ function FreeLimitReachedMessage() {
 /**
  * Terminal card for an Eigenwelt budget stop (the app aborts the run after
  * the allowed retries — see app/lib/eigenwelt-budget). Flat, lined border;
- * the one action that actually resolves the state is upgrading to premium.
+ * the one action that actually resolves the state is upgrading to Pro.
  */
 function BudgetExceededMessage() {
   return (

--- a/apps/app/src/react-app/domains/recorder/model-manager.tsx
+++ b/apps/app/src/react-app/domains/recorder/model-manager.tsx
@@ -110,7 +110,7 @@ function ModelRow(props: { model: AudioModelState; recommended: boolean; selecte
             {formatBytes(model.installedSizeBytes ?? model.approxSizeBytes)}
           </span>
           {locked ? (
-            <Button variant="outline" size="sm" onClick={() => setUpgradeOpen(true)}>
+            <Button variant="outline" size="sm" onClick={select}>
               <Lock data-icon="inline-start" />
               {premiumLocked ? t("recorder.tier_premium_locked") : t("recorder.tier_device_badge")}
             </Button>

--- a/apps/app/tests/eigenwelt-budget.test.ts
+++ b/apps/app/tests/eigenwelt-budget.test.ts
@@ -69,7 +69,8 @@ describe("retry banner action", () => {
     const action = eigenweltBudgetRetryAction();
     expect(action.link).toBe("https://platform.eigenweltlabs.com/billing");
     expect(action.provider).toBe("eigenwelt");
-    expect(action.label.length).toBeGreaterThan(0);
+    expect(action.label).toBe("Upgrade to Pro");
+    expect(action.message).toBe("Upgrade to Pro for higher limits, or come back tomorrow.");
   });
 
   test("uses the connected platform's billing URL when provided", () => {


### PR DESCRIPTION
## Summary

- route locked recorder-model button clicks through the existing gate-aware selector
- open the Plus upsell for subscription-locked models
- preserve the hardware warning for device-locked models
- call the paid usage tier Pro in the usage-limit message and CTA

## Why

The visible locked button still called the old local dialog state setter after premium gating moved to the shared Plus upsell. Premium rows no longer render that local dialog, so clicking Plus produced no visible result.

The paid usage-limit upsell also called the second subscription tier “premium”; its product name is Pro.

## Verification

- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter @legalwork/app test` — 189 passed, 0 failed
- `git diff --check`

A UI recording was not captured because the in-app browser runtime was unavailable in this session. Manual verification: open Settings → Recorder while signed out or on a free plan, click Plus on Premium, and confirm the Eigenwelt sign-in/Plus upgrade modal opens. The dev app is running with hot reload for local verification.