### PR TITLE
fix(usage): make limit upsells plan-aware

### DIFF
--- a/apps/app/src/app/lib/eigenwelt-budget.ts
+++ b/apps/app/src/app/lib/eigenwelt-budget.ts
@@ -35,6 +35,30 @@ export const EIGENWELT_BUDGET_EXCEEDED_TITLE = "Your seat's daily usage has been
 export const EIGENWELT_BUDGET_EXCEEDED_BODY =
   "Upgrade to Pro for higher limits, or come back tomorrow.";
 export const EIGENWELT_BUDGET_UPGRADE_LABEL = "Upgrade to Pro";
+export const EIGENWELT_PRO_LIMIT_TITLE = "Daily usage limit reached";
+export const EIGENWELT_PRO_LIMIT_BODY = "You've used today's Pro allowance. Come back tomorrow.";
+
+export type EigenweltBudgetPlan = "plus" | "pro" | null;
+
+/** Plan-aware terminal-card copy. Pro is already the highest usage tier. */
+export function eigenweltBudgetLimitDisplay(plan: EigenweltBudgetPlan): {
+  title: string;
+  body: string;
+  upgradeLabel: string | null;
+} {
+  if (plan === "pro") {
+    return {
+      title: EIGENWELT_PRO_LIMIT_TITLE,
+      body: EIGENWELT_PRO_LIMIT_BODY,
+      upgradeLabel: null,
+    };
+  }
+  return {
+    title: EIGENWELT_BUDGET_EXCEEDED_TITLE,
+    body: EIGENWELT_BUDGET_EXCEEDED_BODY,
+    upgradeLabel: EIGENWELT_BUDGET_UPGRADE_LABEL,
+  };
+}
 
 /**
  * Text of the synthetic terminal error message injected into the transcript

--- a/apps/app/src/app/lib/eigenwelt-free-budget.ts
+++ b/apps/app/src/app/lib/eigenwelt-free-budget.ts
@@ -25,8 +25,8 @@
 
 export const EIGENWELT_FREE_PROVIDER_ID = "eigenwelt-free";
 
-/** Upgrade/contact page, opened externally via `openDesktopUrl`. */
-export const EIGENWELT_FREE_UPGRADE_URL = "https://eigenweltlabs.com/contact";
+/** Self-serve platform billing page, opened externally via `openDesktopUrl`. */
+export const EIGENWELT_FREE_UPGRADE_URL = "https://platform.eigenweltlabs.com/billing";
 
 /** Stop the engine's retry loop after this many budget-exceeded attempts. */
 export const EIGENWELT_FREE_BUDGET_MAX_RETRY_ATTEMPTS = 3;

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -29,10 +29,9 @@ import {
   isEigenweltFreeLimitErrorText,
 } from "@/app/lib/eigenwelt-free-budget"
 import {
-  EIGENWELT_BUDGET_EXCEEDED_BODY,
-  EIGENWELT_BUDGET_EXCEEDED_TITLE,
-  EIGENWELT_BUDGET_UPGRADE_LABEL,
+  eigenweltBudgetLimitDisplay,
   isEigenweltBudgetExceededErrorText,
+  type EigenweltBudgetPlan,
 } from "@/app/lib/eigenwelt-budget"
 import { eigenweltBillingUrl } from "@/react-app/domains/connections/eigenwelt-entitlements"
 import { eigenweltPremiumPlatformUrl } from "@/react-app/domains/recorder/model-tiers"
@@ -212,6 +211,7 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 const isEmptyMessage = (message: UIMessage): boolean => message.parts.length === 0
 
 type RetryStatus = Extract<SessionStatus, { type: "retry" }>
+const EigenweltBudgetPlanContext = React.createContext<EigenweltBudgetPlan>(null)
 
 function isSessionErrorMessage(message: UIMessage) {
   return message.id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX)
@@ -617,11 +617,12 @@ interface ErrorMessageProps {
 }
 
 function ErrorMessage({ error }: ErrorMessageProps) {
+  const eigenweltPlan = React.useContext(EigenweltBudgetPlanContext)
   if (isEigenweltFreeLimitErrorText(error)) {
     return <FreeLimitReachedMessage />
   }
   if (isEigenweltBudgetExceededErrorText(error)) {
-    return <BudgetExceededMessage />
+    return <BudgetExceededMessage plan={eigenweltPlan} />
   }
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
@@ -670,10 +671,11 @@ function FreeLimitReachedMessage() {
 
 /**
  * Terminal card for an Eigenwelt budget stop (the app aborts the run after
- * the allowed retries — see app/lib/eigenwelt-budget). Flat, lined border;
- * the one action that actually resolves the state is upgrading to Pro.
+ * the allowed retries — see app/lib/eigenwelt-budget). Plus can upgrade to
+ * Pro; Pro sees the reached limit without another upsell.
  */
-function BudgetExceededMessage() {
+function BudgetExceededMessage({ plan }: { plan: EigenweltBudgetPlan }) {
+  const display = eigenweltBudgetLimitDisplay(plan)
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="flex w-full min-w-0 flex-col gap-2 rounded-lg border border-dls-border bg-dls-surface px-4 py-3">
@@ -681,20 +683,22 @@ function BudgetExceededMessage() {
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-700" />
           <div className="min-w-0 space-y-1">
             <p className="text-sm font-medium text-foreground">
-              {EIGENWELT_BUDGET_EXCEEDED_TITLE}
+              {display.title}
             </p>
-            <p className="text-sm text-muted-foreground">{EIGENWELT_BUDGET_EXCEEDED_BODY}</p>
+            <p className="text-sm text-muted-foreground">{display.body}</p>
           </div>
         </div>
-        <div className="ml-6">
-          <Button
-            size="sm"
-            className="h-7 text-xs"
-            onClick={() => void openDesktopUrl(eigenweltBillingUrl(eigenweltPremiumPlatformUrl()))}
-          >
-            {EIGENWELT_BUDGET_UPGRADE_LABEL}
-          </Button>
-        </div>
+        {display.upgradeLabel ? (
+          <div className="ml-6">
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => void openDesktopUrl(eigenweltBillingUrl(eigenweltPremiumPlatformUrl()))}
+            >
+              {display.upgradeLabel}
+            </Button>
+          </div>
+        ) : null}
       </div>
     </Message>
   )
@@ -895,12 +899,13 @@ function MessageGroup({
 }
 
 interface MessageListProps {
+  eigenweltPlan?: EigenweltBudgetPlan
   messages: UIMessage[]
   status: ThreadStatus
   retryStatus?: RetryStatus | null
 }
 
-export function MessageList({ messages, status, retryStatus }: MessageListProps) {
+export function MessageList({ eigenweltPlan = null, messages, status, retryStatus }: MessageListProps) {
   const isStreaming = status === "streaming" || status === "retrying"
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
@@ -910,6 +915,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
     : null
 
   return (
+    <EigenweltBudgetPlanContext.Provider value={eigenweltPlan}>
     <div className={cn("flex flex-col gap-2 @container/message-list")}>
       {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
 
@@ -947,5 +953,6 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
       {retryStatus ? <RetryMessage status={retryStatus} /> : null}
       {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
     </div>
+    </EigenweltBudgetPlanContext.Provider>
   )
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -17,12 +17,16 @@ import {
 } from "@/app/lib/eigenwelt-free-budget";
 import {
   EIGENWELT_BUDGET_EXCEEDED_ERROR_TEXT,
+  eigenweltBudgetLimitDisplay,
   eigenweltBudgetRetryAction,
   isEigenweltBudgetError,
   markEigenweltBudgetStop,
   shouldStopEigenweltBudgetRetry,
 } from "@/app/lib/eigenwelt-budget";
-import { eigenweltBillingUrl } from "@/react-app/domains/connections/eigenwelt-entitlements";
+import {
+  eigenweltBillingUrl,
+  useEigenweltEntitlements,
+} from "@/react-app/domains/connections/eigenwelt-entitlements";
 import { eigenweltPremiumPlatformUrl } from "@/react-app/domains/recorder/model-tiers";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
@@ -443,6 +447,12 @@ function mergeDrafts(drafts: ComposerDraft[]): ComposerDraft | null {
 export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
   const { config: shellConfig } = useShellConfig();
+  const eigenweltEntitlementsQuery = useEigenweltEntitlements({
+    client: props.client,
+    workspaceId: props.workspaceId,
+    enabled: props.selectedModel.providerID === "eigenwelt",
+  });
+  const eigenweltPlan = eigenweltEntitlementsQuery.data?.entitlements?.plan ?? null;
   const showThinking = local.prefs.showThinking;
   const sessionActivityStatus = useSessionActivityStore(
     (state) => state.statusesByWorkspaceId[props.workspaceId]?.[props.sessionId] ?? "idle",
@@ -743,15 +753,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
     isEigenweltBudgetError(props.selectedModel.providerID, liveStatus.message);
   const retryStatusForDisplay = useMemo(() => {
     if (liveStatus.type !== "retry") return null;
+    if (paidBudgetRetryActive && eigenweltPlan === "pro") {
+      return {
+        ...liveStatus,
+        message: eigenweltBudgetLimitDisplay(eigenweltPlan).title,
+        action: undefined,
+      };
+    }
     if (liveStatus.action) return liveStatus;
     if (freeBudgetRetryActive) return { ...liveStatus, action: eigenweltFreeBudgetRetryAction() };
-    if (paidBudgetRetryActive)
+    if (paidBudgetRetryActive) {
       return {
         ...liveStatus,
         action: eigenweltBudgetRetryAction(eigenweltBillingUrl(eigenweltPremiumPlatformUrl())),
       };
+    }
     return liveStatus;
-  }, [freeBudgetRetryActive, paidBudgetRetryActive, liveStatus]);
+  }, [eigenweltPlan, freeBudgetRetryActive, paidBudgetRetryActive, liveStatus]);
   useEffect(() => {
     // A fresh attempt (busy) re-arms the guard so a later prompt that hits
     // the limit / budget wall again is stopped again.
@@ -1549,6 +1567,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       onEditUserMessage={handleEditUserMessage}
                     >
                       <MessageList
+                        eigenweltPlan={eigenweltPlan}
                         messages={renderedMessages}
                         status={status}
                         retryStatus={retryStatusForDisplay}

--- a/apps/app/tests/eigenwelt-budget.test.ts
+++ b/apps/app/tests/eigenwelt-budget.test.ts
@@ -4,6 +4,7 @@ import {
   EIGENWELT_BUDGET_EXCEEDED_ERROR_TEXT,
   EIGENWELT_BUDGET_MAX_RETRY_ATTEMPTS,
   consumeEigenweltBudgetStop,
+  eigenweltBudgetLimitDisplay,
   eigenweltBudgetRetryAction,
   isEigenweltBudgetError,
   isEigenweltBudgetExceededErrorText,
@@ -76,6 +77,24 @@ describe("retry banner action", () => {
   test("uses the connected platform's billing URL when provided", () => {
     const action = eigenweltBudgetRetryAction("https://acme.example.com/billing");
     expect(action.link).toBe("https://acme.example.com/billing");
+  });
+});
+
+describe("plan-aware limit display", () => {
+  test("offers Plus users an upgrade to Pro", () => {
+    expect(eigenweltBudgetLimitDisplay("plus")).toEqual({
+      title: "Your seat's daily usage has been used up",
+      body: "Upgrade to Pro for higher limits, or come back tomorrow.",
+      upgradeLabel: "Upgrade to Pro",
+    });
+  });
+
+  test("shows Pro users the reached limit without an upgrade", () => {
+    expect(eigenweltBudgetLimitDisplay("pro")).toEqual({
+      title: "Daily usage limit reached",
+      body: "You've used today's Pro allowance. Come back tomorrow.",
+      upgradeLabel: null,
+    });
   });
 });
 

--- a/apps/app/tests/eigenwelt-free-budget.test.ts
+++ b/apps/app/tests/eigenwelt-free-budget.test.ts
@@ -66,9 +66,9 @@ describe("terminal error text", () => {
 });
 
 describe("retry banner action", () => {
-  test("points at the upgrade/contact page", () => {
+  test("points at the self-serve platform billing page", () => {
     const action = eigenweltFreeBudgetRetryAction();
-    expect(action.link).toBe("https://eigenweltlabs.com/contact");
+    expect(action.link).toBe("https://platform.eigenweltlabs.com/billing");
     expect(action.provider).toBe("eigenwelt-free");
     expect(action.title).toBe("Out of free usage?");
     expect(action.label).toBe("Upgrade");


### PR DESCRIPTION
## Summary
- send the free-model Upgrade action to Eigenwelt platform billing
- retain Upgrade to Pro for Plus users who exhaust daily usage
- show Pro users a limit-reached state with no unavailable upgrade action
- use live entitlement data for retry and terminal states

## Verification
- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter @legalwork/app test` — 191 passed, 0 failed
- `git diff --check`