### PR TITLE
feat(providers): add Aki Cloud as a preconfigured provider

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -128,6 +128,14 @@ const BRANDED_CUSTOM_PROVIDERS: BrandedCustomProvider[] = [
     baseUrlPlaceholder: "https://<your-gateway>.apertus.ai/v1",
     description: "Connect your managed Apertus gateway — European open-source models, your own endpoint and key.",
   },
+  {
+    id: "aki",
+    name: "Aki Cloud",
+    apiType: "chat",
+    baseUrlPlaceholder: "https://api.aki.io/v1",
+    baseUrlDefault: "https://api.aki.io/v1",
+    description: "Connect Aki Cloud — EU-hosted, GDPR-compliant inference for open-source models. Add your API key and connect.",
+  },
 ];
 
 /**
@@ -198,6 +206,8 @@ const PROVIDER_LABELS: Record<string, string> = {
   openrouter: "OpenRouter",
   apertus: "Apertus AI",
   "apertus-ai": "Apertus AI",
+  aki: "Aki Cloud",
+  "aki-cloud": "Aki Cloud",
   ollama: "Ollama (local)",
   lmstudio: "LM Studio (local)",
   llamacpp: "llama.cpp (local)",


### PR DESCRIPTION
## Summary
- Add **Aki Cloud** (aki.io) as a preconfigured "branded" provider so it appears as a first-class entry in the provider list, alongside Apertus AI — no longer requiring users to hand-enter it as a fully custom provider.

## Why
- Aki Cloud already worked via the generic "Custom (OpenAI-compatible)" flow, but the ask was to ship it preconfigured like the other branded providers: a named row with a fixed id, correct API type, and a pre-filled endpoint, so connecting only requires an API key.

## Issue
- Closes #

## Scope
- `provider-auth-modal.tsx`: add an `aki` entry to `BRANDED_CUSTOM_PROVIDERS` (id `aki`, name "Aki Cloud", `apiType: "chat"` → `@ai-sdk/openai-compatible`, `/v1/chat/completions`). Aki serves a single public endpoint, so `baseUrlDefault` pre-fills `https://api.aki.io/v1` (per the type's guidance for fixed-endpoint providers).
- Register `aki` / `aki-cloud` display labels in `PROVIDER_LABELS`.

## Out of scope
- No custom SVG logo — like the existing Apertus entry, Aki falls back to the "AK" lettermark. Can add a branded icon later if a logo is provided.
- No server-side changes (branded providers are frontend-only; the user supplies their own key, stored in the engine auth store, never inline).

## Testing
### Ran
- `cd apps/app && npx tsc -p tsconfig.json --noEmit`
- `bun test tests/provider-local-templates.test.ts`

### Result
- pass/fail: **pass** — no type errors attributable to this change; provider tests 15 pass / 0 fail.
- if fail, exact files/errors: n/a. (Pre-existing environmental noise only: `@types/node` / `vite/client` type entry points and a `baseUrl` deprecation warning, both unrelated to this diff and caused by the sandbox's blocked electron/deps postinstall.)

## CI status
- pass: to be confirmed by CI
- code-related failures: none expected
- external/env/auth blockers: local `pnpm install` could not fetch the Electron binary (network policy 403); does not affect this UI-only change.

## Manual verification
1. Open the "Connect a provider" modal.
2. Confirm **Aki Cloud** appears as its own entry.
3. Select it → custom form opens pre-branded with the base URL pre-filled to `https://api.aki.io/v1`; enter an API key, fetch/enter models, and connect.

## Evidence
- N/A (small UI config change; no screenshot captured — app requires Electron which cannot launch in this sandbox)

## Risk
- Low. Additive, single-file change mirroring the existing Apertus precedent; no changes to the shared write path or auth handling.

## Rollback
- Revert this commit — removes the two `BRANDED_CUSTOM_PROVIDERS` / `PROVIDER_LABELS` entries with no data migration or side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018B8Mf8W23JU6QzWMvXxLFq)_