### PR TITLE
fix(office-addin): handle dotted macOS home paths

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -1163,7 +1163,7 @@ async function requestBinary(
   baseUrl: string,
   path: string,
   options: { method?: string; token?: string; hostToken?: string; body?: unknown; timeoutMs?: number } = {},
-): Promise<{ data: ArrayBuffer; contentType: string | null; filename: string | null }>{
+): Promise<{ data: ArrayBuffer; contentType: string | null; filename: string | null; updatedAt: number | null }>{
   const url = `${baseUrl}${path}`;
   const fetchImpl = resolveFetch(url);
   const response = await fetchWithTimeout(
@@ -1197,8 +1197,11 @@ async function requestBinary(
   const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
   const filenameRaw = filenameMatch?.[1] ?? filenameMatch?.[2] ?? null;
   const filename = filenameRaw ? decodeURIComponent(filenameRaw) : null;
+  const updatedAtHeader = response.headers.get("x-legalwork-updated-at");
+  const parsedUpdatedAt = updatedAtHeader === null ? null : Number(updatedAtHeader);
+  const updatedAt = parsedUpdatedAt !== null && Number.isFinite(parsedUpdatedAt) ? parsedUpdatedAt : null;
   const data = await response.arrayBuffer();
-  return { data, contentType, filename };
+  return { data, contentType, filename, updatedAt };
 }
 
 export function createLegalworkServerClient(options: { baseUrl: string; token?: string; hostToken?: string }) {

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -48,9 +48,17 @@ type ArtifactPanelViewProps = {
 
 type ArtifactQueryState =
   | (TextData & { updatedAt: number | null })
-  | (BinaryData & { contentType: string | null; updatedAt: number | null });
+  | (BinaryData & { contentType: string | null; updatedAt: number | null; revision: number });
 
 type SaveArtifactInput = Data & { baseUpdatedAt: number | null };
+
+let fallbackBinaryRevision = 0;
+
+function nextBinaryRevision(updatedAt: number | null) {
+  if (updatedAt !== null) return updatedAt;
+  fallbackBinaryRevision += 1;
+  return fallbackBinaryRevision;
+}
 
 function absoluteWorkspacePath(root: string, path: string) {
   const cleanRoot = root.trim().replace(/[/\\]+$/, "");
@@ -130,9 +138,17 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
       }
 
       const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+      const updatedAt = result.updatedAt ?? target.updatedAt ?? null;
 
-      return { kind: "binary", data: result.data, contentType: result.contentType, updatedAt: target.updatedAt ?? null };
+      return {
+        kind: "binary",
+        data: result.data,
+        contentType: result.contentType,
+        updatedAt,
+        revision: nextBinaryRevision(result.updatedAt),
+      };
     },
+    refetchOnMount: "always",
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     staleTime: Infinity,
@@ -218,7 +234,13 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
         ["artifact-panel", workspaceId, target.id] as const,
         input.kind === "text"
           ? { kind: "text", data: input.data, updatedAt: result.updatedAt ?? null }
-          : { kind: "binary", data: input.data, contentType: data?.kind === "binary" ? data.contentType : null, updatedAt: result.updatedAt ?? null },
+          : {
+              kind: "binary",
+              data: input.data,
+              contentType: data?.kind === "binary" ? data.contentType : null,
+              updatedAt: result.updatedAt ?? null,
+              revision: nextBinaryRevision(result.updatedAt),
+            },
       );
 
       if (input.kind === "text") {
@@ -449,7 +471,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
           />
         ) : target.preview === "word" && data?.kind === "binary" ? (
           <DocxView
-            key={target.id}
+            key={`${target.id}:${data.revision}`}
             name={target.name}
             content={data.data}
             readOnly={isRemoteWorkspace || target.kind !== "file"}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -943,6 +943,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.idle") {
     const props = (event.properties ?? {}) as { sessionID?: string };
     if (!props.sessionID) return;
+    // Agent tools may have changed a file that is already open in the artifact
+    // panel. Mark workspace previews stale so active files reload immediately
+    // and closed files fetch fresh bytes the next time they are opened.
+    void queryClient.invalidateQueries({ queryKey: ["artifact-panel", workspaceId] });
     // Only emits for runs this client instrumented (markTaskRunStart in the
     // send path); also dedupes idle events from multiple workspace syncs.
     const runStartedAt = takeTaskRunStart(props.sessionID);

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -243,6 +243,27 @@ describe("session question sync", () => {
 });
 
 describe("session transcript sync", () => {
+  test("invalidates cached artifact previews when an agent run finishes", () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", legalworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const queryClient = getReactQueryClient();
+    const artifactKey = ["artifact-panel", "workspace-a", "file:contract.docx"] as const;
+
+    queryClient.setQueryData(artifactKey, { kind: "binary" });
+    expect(queryClient.getQueryState(artifactKey)?.isInvalidated).toBe(false);
+
+    try {
+      __applySessionSyncEventForTest(syncInput, {
+        type: "session.idle",
+        properties: { sessionID: "session-a" },
+      });
+
+      expect(queryClient.getQueryState(artifactKey)?.isInvalidated).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("coalesces token-sized deltas by transcript part", () => {
     const deltas = coalescePendingDeltas([
       { sessionId: "session-a", messageId: "msg-a", partId: "part-a", reasoning: false, delta: "hel" },

--- a/apps/desktop/electron/office-addin-cert.mjs
+++ b/apps/desktop/electron/office-addin-cert.mjs
@@ -102,6 +102,7 @@ export async function ensureLocalCert(dir, { force = false } = {}) {
   const caCertPath = join(dir, "legalwork-local-ca.crt");
   const leafKeyPath = join(dir, "localhost.key");
   const leafCertPath = join(dir, "localhost.crt");
+  const caSerialPath = join(dir, "legalwork-local-ca.srl");
   const extPath = join(dir, "openssl-ext.cnf");
 
   const complete =
@@ -130,18 +131,21 @@ export async function ensureLocalCert(dir, { force = false } = {}) {
 
     // Leaf: localhost, signed by the CA. Pass -config here too so the CSR
     // step never depends on the system openssl.cnf being present/compatible.
+    // Pass -CAserial explicitly because macOS LibreSSL otherwise truncates
+    // dotted paths such as /Users/user.name to /Users/user.srl.
     runOpenssl(["genrsa", "-out", leafKeyPath, "2048"]);
     const csr = runOpenssl(["req", "-new", "-key", leafKeyPath, "-subj", LEAF_SUBJECT, "-config", extPath]).stdout;
     runOpenssl([
       "x509", "-req",
-      "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial",
+      "-CA", caCertPath, "-CAkey", caKeyPath,
+      "-CAserial", caSerialPath, "-CAcreateserial",
       "-sha256", "-days", String(LEAF_VALID_DAYS),
       "-extensions", "leaf", "-extfile", extPath,
       "-out", leafCertPath,
     ], csr);
   } finally {
     rmSync(extPath, { force: true });
-    rmSync(join(dir, "legalwork-local-ca.srl"), { force: true });
+    rmSync(caSerialPath, { force: true });
   }
 
   return { caCertPath, caKeyPath, leafCertPath, leafKeyPath };
@@ -206,6 +210,7 @@ export function signLeafForTest(dir, altNames, subject = "/CN=test") {
   const caCertPath = join(dir, "legalwork-local-ca.crt");
   const keyPath = join(dir, "test-leaf.key");
   const certPath = join(dir, "test-leaf.crt");
+  const caSerialPath = join(dir, "legalwork-local-ca.srl");
   const extPath = join(dir, "test-ext.cnf");
   writeFileSync(extPath, `${REQ_SHIM}\n${leafExtensions(altNames)}`, "utf8");
   try {
@@ -213,14 +218,15 @@ export function signLeafForTest(dir, altNames, subject = "/CN=test") {
     const csr = runOpenssl(["req", "-new", "-key", keyPath, "-subj", subject, "-config", extPath]).stdout;
     runOpenssl([
       "x509", "-req",
-      "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial",
+      "-CA", caCertPath, "-CAkey", caKeyPath,
+      "-CAserial", caSerialPath, "-CAcreateserial",
       "-sha256", "-days", "30",
       "-extensions", "leaf", "-extfile", extPath,
       "-out", certPath,
     ], csr);
   } finally {
     rmSync(extPath, { force: true });
-    rmSync(join(dir, "legalwork-local-ca.srl"), { force: true });
+    rmSync(caSerialPath, { force: true });
   }
   return certPath;
 }

--- a/apps/desktop/electron/office-addin-cert.test.mjs
+++ b/apps/desktop/electron/office-addin-cert.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
@@ -25,6 +25,27 @@ test("generates a localhost leaf that validates against the CA", { skip: !openss
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test(
+  "macOS LibreSSL keeps its serial file inside a dotted certificate path",
+  { skip: platform() !== "darwin" || !existsSync("/usr/bin/openssl") },
+  async () => {
+    const previousOpenssl = process.env.LEGALWORK_OPENSSL_BIN;
+    const root = mkdtempSync("/tmp/lw-cert-root-");
+    const dir = join(root, "user.name", "office-addin-certs");
+    mkdirSync(dir, { recursive: true });
+    process.env.LEGALWORK_OPENSSL_BIN = "/usr/bin/openssl";
+    try {
+      const { caCertPath, leafCertPath } = await ensureLocalCert(dir);
+      assert.ok(leafCertValid(leafCertPath, caCertPath));
+      assert.equal(existsSync(join(root, "user.srl")), false);
+    } finally {
+      if (previousOpenssl === undefined) delete process.env.LEGALWORK_OPENSSL_BIN;
+      else process.env.LEGALWORK_OPENSSL_BIN = previousOpenssl;
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);
 
 test("name constraint rejects a non-localhost certificate", { skip: !opensslAvailable }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "lw-cert-evil-"));

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -105,8 +105,12 @@ describe("artifact file routes", () => {
     });
     expect(xlsxWrite.status).toBe(200);
 
-    const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
+    const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, {
+      headers: { ...auth(token), Origin: "http://localhost:5173" },
+    });
     expect(xlsxDownload.status).toBe(200);
+    expect(Number(xlsxDownload.headers.get("x-legalwork-updated-at"))).toBeGreaterThan(0);
+    expect(xlsxDownload.headers.get("access-control-expose-headers")).toContain("X-LegalWork-Updated-At");
     expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
   });
 

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -1137,6 +1137,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
     headers.set("Content-Type", contentTypeForPath(relativePath));
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `inline; filename="${basename(relativePath)}"`);
+    headers.set("X-LegalWork-Updated-At", String(info.mtimeMs));
     const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
     return new Response(stream, { status: 200, headers });
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1144,6 +1144,7 @@ function withCors(response: Response, request: Request, config: ServerConfig) {
     "Access-Control-Allow-Headers",
     "Authorization, Content-Type, X-LegalWork-Host-Token, X-LegalWork-Client-Id, X-OpenCode-Directory, X-Opencode-Directory, x-opencode-directory",
   );
+  headers.set("Access-Control-Expose-Headers", "X-LegalWork-Updated-At");
   headers.set("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
   headers.set("Vary", "Origin");
   return new Response(response.body, { status: response.status, headers });


### PR DESCRIPTION
## Summary

- pass an explicit CA serial path when signing Office add-in certificates
- prevent macOS LibreSSL from truncating dotted paths such as `/Users/user.name` to `/Users/user.srl`
- cover the packaged-app path with a regression test that forces `/usr/bin/openssl`

## Verification

- `pnpm --filter @legalwork/desktop exec node --test electron/office-addin-cert.test.mjs` — 4 passed
- `pnpm --filter @legalwork/desktop test` — 81 passed, 1 platform skip
- `pnpm --filter @legalwork/desktop check:electron` — passed
- `pnpm --filter @legalwork/desktop typecheck:electron` — passed

## End-to-end evidence

Before the fix, macOS LibreSSL placed the generated serial file at `user.srl` beside the dotted path; for a home directory such as `/Users/c-h.poensgen`, that becomes the unwritable `/Users/c-h.srl` and leaf signing fails. After the fix, the regression test signs and verifies a localhost leaf using the real macOS `/usr/bin/openssl`, while asserting that no misplaced `user.srl` is created.

No video or screenshot is attached because this is a non-visual certificate-generation failure. The focused test above is the exact reproduction: on macOS it invokes the system LibreSSL binary and the complete CA-to-leaf signing flow.