### PR TITLE
fix(dictation): show readiness setup on settings page

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/dictation-readiness.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/dictation-readiness.tsx
@@ -1,0 +1,429 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Check, Keyboard, Loader2, ShieldCheck, X } from "lucide-react";
+
+import { audioSystemDictationPaste } from "@/app/lib/desktop";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { t } from "@/i18n";
+import { cn } from "@/lib/utils";
+import type {
+  AudioDictationPermissionKind,
+  AudioDictationReadiness,
+} from "@legalwork/types/audio";
+
+import { formatBytes } from "../../../../app/utils";
+import { tierName } from "../../recorder/model-tiers";
+import { SetupStep, recommendedTier } from "../../recorder/recorder-setup";
+import { useRecorderStore } from "../../recorder/recorder-store";
+
+/** How often the page re-probes the OS while something is still missing. */
+const READINESS_POLL_MS = 4000;
+
+type ReadinessStep = {
+  id: AudioDictationPermissionKind | "model";
+  done: boolean;
+};
+
+/**
+ * The steps this machine still needs, in the order a user should click
+ * through them. "unavailable" and "not-required" never block: the first is
+ * an environment without the native probe, the second a platform where the
+ * permission does not exist.
+ */
+function readinessSteps(
+  readiness: AudioDictationReadiness | null,
+  modelInstalled: boolean,
+): ReadinessStep[] {
+  if (!readiness) return [];
+  const steps: ReadinessStep[] = [
+    {
+      id: "microphone",
+      done: readiness.microphone === "granted" || readiness.microphone === "unknown",
+    },
+  ];
+  const permissionOk = (state: string) =>
+    state !== "denied" && state !== "broken" && state !== "not-determined";
+
+  if (readiness.platform === "darwin") {
+    steps.push(
+      { id: "inputMonitoring", done: permissionOk(readiness.inputMonitoring) },
+      { id: "accessibility", done: permissionOk(readiness.accessibility) },
+      { id: "automation", done: permissionOk(readiness.automation) },
+    );
+  }
+  steps.push({ id: "model", done: modelInstalled });
+  return steps;
+}
+
+/**
+ * Replaces the Dictate Anywhere settings with guided setup while a required
+ * permission or model is missing. This mirrors the Recorder's first-run gate:
+ * users fix prerequisites in context before seeing the feature controls.
+ */
+export function DictationReadinessGate(props: { children: ReactNode }) {
+  const store = useRecorderStore();
+  const readiness = store.dictationReadiness;
+  const [checking, setChecking] = useState(true);
+  const [requesting, setRequesting] = useState<AudioDictationPermissionKind | null>(null);
+  const [setupSkipped, setSetupSkipped] = useState(false);
+  /** Keep the completed checklist visible until the user continues. */
+  const [setupEngaged, setSetupEngaged] = useState(false);
+
+  const modelInstalled = store.bootstrap?.models.some((model) => model.state === "installed") ?? false;
+  const steps = useMemo(
+    () => readinessSteps(readiness, modelInstalled),
+    [readiness, modelInstalled],
+  );
+  const activeIndex = steps.findIndex((step) => !step.done);
+  const setupNeeded = readiness !== null && activeIndex !== -1;
+  const setupVisible = !setupSkipped && (setupNeeded || (setupEngaged && readiness !== null));
+
+  // Read live OS state before showing the normal page, then keep it current
+  // when the user returns from System Settings.
+  useEffect(() => {
+    let mounted = true;
+    void Promise.all([store.refreshDictationReadiness(), store.refreshBootstrap()]).finally(() => {
+      if (mounted) setChecking(false);
+    });
+    const onFocus = () => void store.refreshDictationReadiness();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      mounted = false;
+      window.removeEventListener("focus", onFocus);
+    };
+    // The recorder store is module-scoped and its actions are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!setupNeeded || setupSkipped) return;
+    setSetupEngaged(true);
+    const timer = window.setInterval(
+      () => void store.refreshDictationReadiness(),
+      READINESS_POLL_MS,
+    );
+    return () => window.clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setupNeeded, setupSkipped]);
+
+  const requestPermission = (kind: AudioDictationPermissionKind) => {
+    setRequesting(kind);
+    void store.requestDictationPermission(kind).finally(() => setRequesting(null));
+  };
+  const repairPermission = (kind: AudioDictationPermissionKind) => {
+    setRequesting(kind);
+    void store.repairDictationPermission(kind).finally(() => setRequesting(null));
+  };
+
+  if (checking) return null;
+  if (!setupVisible) return <>{props.children}</>;
+
+  const allDone = activeIndex === -1;
+  return (
+    <div className="mx-auto w-full max-w-xl py-6">
+      <div className="flex flex-col items-start">
+        <span
+          className={cn(
+            "flex size-11 items-center justify-center rounded-2xl transition-colors duration-300",
+            allDone ? "bg-success-soft text-success" : "bg-brand-soft text-brand",
+          )}
+        >
+          {allDone ? <Check className="size-5" /> : <Keyboard className="size-5" />}
+        </span>
+        <h1 className="mt-4 text-2xl font-medium tracking-[-0.02em] text-ink">
+          {allDone
+            ? t("recorder.dictation_readiness_done_title")
+            : t("recorder.dictation_readiness_title")}
+        </h1>
+        <p className="mt-1.5 max-w-md text-sm leading-relaxed text-subtext">
+          {allDone
+            ? t("recorder.dictation_readiness_done_subtitle")
+            : t("recorder.dictation_readiness_subtitle")}
+        </p>
+      </div>
+
+      <DictationReadinessSetup
+        readiness={readiness}
+        steps={steps}
+        activeIndex={activeIndex}
+        requesting={requesting}
+        onRequest={requestPermission}
+        onRepair={repairPermission}
+        onSkip={() => setSetupSkipped(true)}
+        onDone={() => setSetupEngaged(false)}
+      />
+    </div>
+  );
+}
+
+/**
+ * Click-through permission setup. Every step re-checks live: granting in
+ * System Settings ticks steps off on focus/poll without manual confirmation.
+ */
+function DictationReadinessSetup(props: {
+  readiness: AudioDictationReadiness;
+  steps: ReadinessStep[];
+  activeIndex: number;
+  requesting: AudioDictationPermissionKind | null;
+  onRequest: (kind: AudioDictationPermissionKind) => void;
+  onRepair: (kind: AudioDictationPermissionKind) => void;
+  onSkip: () => void;
+  onDone: () => void;
+}) {
+  const store = useRecorderStore();
+  const readiness = props.readiness;
+  const allDone = props.activeIndex === -1;
+  const mac = readiness.platform === "darwin";
+  const showDevHint = mac && readiness.packaged === false;
+  // tccutil-based repair resets entries for OUR bundle id; dev runs are
+  // attributed to the launching terminal/IDE and must not offer it.
+  const repairAvailable = mac && readiness.packaged === true;
+
+  const recommended = recommendedTier(store.bootstrap);
+  const recommendedModel = store.bootstrap?.models.find((model) => model.id === recommended.modelId);
+  const downloading = recommendedModel?.state === "downloading";
+  const totalBytes = recommendedModel?.totalBytes || recommendedModel?.approxSizeBytes || 0;
+  const downloadedBytes = recommendedModel?.downloadedBytes ?? 0;
+  const pct = totalBytes > 0 ? Math.round((downloadedBytes / totalBytes) * 100) : 0;
+
+  // End-to-end paste self-test: runs the real clipboard, Accessibility
+  // keystroke, and System Events pipeline into this page's own input.
+  const [pasteTest, setPasteTest] = useState<"idle" | "running" | "ok" | "failed">("idle");
+  const [pasteError, setPasteError] = useState<string | null>(null);
+  const pasteInputRef = useRef<HTMLInputElement | null>(null);
+
+  const runPasteTest = () => {
+    const input = pasteInputRef.current;
+    if (!input) return;
+    input.value = "";
+    input.focus();
+    setPasteTest("running");
+    setPasteError(null);
+    void audioSystemDictationPaste(t("recorder.dictation_paste_test_sample"))
+      .then((result) => {
+        if (result.error) {
+          setPasteTest("failed");
+          setPasteError(result.error);
+          void store.refreshDictationReadiness();
+          return;
+        }
+        window.setTimeout(() => {
+          setPasteTest(input.value.trim().length > 0 ? "ok" : "failed");
+        }, 350);
+      })
+      .catch(() => setPasteTest("failed"));
+  };
+
+  const permissionStep = (
+    step: ReadinessStep,
+    index: number,
+    kind: AudioDictationPermissionKind,
+    view: {
+      title: string;
+      body: string;
+      blockedHint: string | null;
+      cta: string;
+      /** Stale or declined grant: offer the tccutil reset + fresh prompt. */
+      repairable?: boolean;
+    },
+  ) => {
+    const repair = view.repairable === true && repairAvailable && kind !== "microphone";
+    return (
+      <SetupStep
+        key={step.id}
+        index={index}
+        done={step.done}
+        active={index === props.activeIndex}
+        title={view.title}
+        doneLabel={t("recorder.perm_status_granted")}
+      >
+        <p className="text-sm text-subtext">{view.blockedHint ?? view.body}</p>
+        {showDevHint ? (
+          <p className="mt-1.5 text-xs text-tertiary">{t("recorder.perm_dev_hint")}</p>
+        ) : null}
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+          <Button
+            size="sm"
+            disabled={props.requesting !== null}
+            onClick={() => (repair ? props.onRepair(kind) : props.onRequest(kind))}
+          >
+            {props.requesting === kind ? (
+              <Loader2 data-icon="inline-start" className="animate-spin" />
+            ) : null}
+            {repair ? t("recorder.dictation_repair_cta") : view.cta}
+          </Button>
+          {repair ? (
+            <button
+              type="button"
+              className="text-xs text-subtext underline-offset-2 hover:text-ink hover:underline"
+              disabled={props.requesting !== null}
+              onClick={() => props.onRequest(kind)}
+            >
+              {t("recorder.perm_open_settings")}
+            </button>
+          ) : null}
+        </div>
+        {props.requesting === kind ? (
+          <p className="mt-2.5 flex items-center gap-1.5 text-xs text-subtext animate-in fade-in-0">
+            <Loader2 className="size-3 animate-spin text-brand" />
+            {t("recorder.dictation_step_waiting_prompt")}
+          </p>
+        ) : null}
+      </SetupStep>
+    );
+  };
+
+  return (
+    <>
+      <div className="mt-7 divide-y divide-subtle overflow-hidden rounded-2xl border border-subtle bg-surface shadow-xs">
+        {props.steps.map((step, index) => {
+          if (step.id === "microphone") {
+            return permissionStep(step, index, "microphone", {
+              title: t("recorder.setup_mic_title"),
+              body: t("recorder.setup_mic_body"),
+              blockedHint:
+                readiness.microphone === "denied" || readiness.microphone === "restricted"
+                  ? t("recorder.perm_microphone_instructions")
+                  : null,
+              cta:
+                readiness.microphone === "not-determined"
+                  ? t("recorder.setup_mic_cta")
+                  : t("recorder.perm_open_settings"),
+            });
+          }
+          if (step.id === "inputMonitoring") {
+            const state = readiness.inputMonitoring;
+            return permissionStep(step, index, "inputMonitoring", {
+              title: t("recorder.dictation_step_monitor_title"),
+              body: t("recorder.dictation_step_monitor_body"),
+              blockedHint:
+                state === "broken"
+                  ? t("recorder.dictation_step_monitor_broken")
+                  : state === "denied"
+                    ? t("recorder.dictation_step_monitor_denied")
+                    : null,
+              cta:
+                state === "not-determined"
+                  ? t("recorder.perm_allow")
+                  : t("recorder.perm_open_settings"),
+              repairable: state === "broken" || state === "denied",
+            });
+          }
+          if (step.id === "accessibility") {
+            return permissionStep(step, index, "accessibility", {
+              title: t("recorder.dictation_step_a11y_title"),
+              body: t("recorder.dictation_step_a11y_body"),
+              blockedHint: null,
+              cta: t("recorder.perm_open_settings"),
+              repairable: readiness.accessibility === "denied",
+            });
+          }
+          if (step.id === "automation") {
+            return permissionStep(step, index, "automation", {
+              title: t("recorder.dictation_step_automation_title"),
+              body: t("recorder.dictation_step_automation_body"),
+              blockedHint:
+                readiness.automation === "denied"
+                  ? t("recorder.dictation_step_automation_denied")
+                  : null,
+              cta:
+                readiness.automation === "not-determined"
+                  ? t("recorder.perm_allow")
+                  : t("recorder.perm_open_settings"),
+              repairable: readiness.automation === "denied",
+            });
+          }
+          return (
+            <SetupStep
+              key={step.id}
+              index={index}
+              done={step.done}
+              active={index === props.activeIndex}
+              title={t("recorder.setup_model_title")}
+              doneLabel={t("recorder.model_installed")}
+            >
+              <p className="text-sm text-subtext">{t("recorder.setup_model_body")}</p>
+              <div className="mt-3 flex items-center gap-3">
+                {downloading ? (
+                  <>
+                    <Progress value={pct} className="h-1.5 flex-1" />
+                    <span className="text-2xs tabular-nums text-subtext">
+                      {formatBytes(downloadedBytes)} / {formatBytes(totalBytes)}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={t("recorder.model_cancel")}
+                      onClick={() => void store.cancelModelDownload(recommended.modelId)}
+                    >
+                      <X />
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      store.setModelId(recommended.modelId);
+                      void store.downloadModel(recommended.modelId);
+                    }}
+                  >
+                    {t("recorder.model_download")} {tierName(recommended.key)}
+                  </Button>
+                )}
+              </div>
+              {recommendedModel?.state === "error" && recommendedModel.error ? (
+                <div className="mt-1 text-xs text-danger">{recommendedModel.error}</div>
+              ) : null}
+            </SetupStep>
+          );
+        })}
+      </div>
+
+      {allDone ? (
+        <div className="mt-4 rounded-xl border border-subtle bg-surface px-4 py-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              ref={pasteInputRef}
+              className="h-9 min-w-0 flex-1 rounded-md border border-subtle bg-sunken px-3 text-sm text-ink outline-none focus:border-brand"
+              placeholder={t("recorder.dictation_paste_test_placeholder")}
+            />
+            <Button size="sm" variant="outline" disabled={pasteTest === "running"} onClick={runPasteTest}>
+              {pasteTest === "running" ? (
+                <Loader2 data-icon="inline-start" className="animate-spin" />
+              ) : null}
+              {t("recorder.dictation_paste_test_cta")}
+            </Button>
+          </div>
+          {pasteTest === "ok" ? (
+            <p className="mt-2 flex items-center gap-1.5 text-xs text-success animate-in fade-in-0">
+              <Check className="size-3" />
+              {t("recorder.dictation_paste_test_ok")}
+            </p>
+          ) : pasteTest === "failed" ? (
+            <p className="mt-2 text-xs text-danger">
+              {pasteError ?? t("recorder.dictation_paste_test_failed")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-5 flex items-center justify-between gap-4">
+        <p className="flex items-center gap-1.5 text-xs text-subtext">
+          <ShieldCheck className="size-3.5 shrink-0 text-success" />
+          {t("recorder.perm_recheck_hint")}
+        </p>
+        {allDone ? (
+          <Button onClick={props.onDone}>
+            <Check data-icon="inline-start" />
+            {t("recorder.setup_done_cta")}
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm" className="shrink-0 text-subtext" onClick={props.onSkip}>
+            {t("recorder.setup_skip_all")}
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/pages/dictation-setup-dialog.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/dictation-setup-dialog.tsx
@@ -1,8 +1,7 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
-import { AudioLines, Check, Keyboard, Loader2, MousePointerClick, ShieldCheck, X } from "lucide-react";
+import { useEffect, useState, type KeyboardEvent } from "react";
+import { AudioLines, Keyboard, MousePointerClick } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -10,59 +9,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Progress } from "@/components/ui/progress";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import type {
-  AudioDictationPermissionKind,
-  AudioDictationReadiness,
-  AudioSystemDictationPlatform,
-} from "@legalwork/types/audio";
+import type { AudioSystemDictationPlatform } from "@legalwork/types/audio";
 import { t } from "@/i18n";
 
-import { audioSystemDictationPaste } from "@/app/lib/desktop";
-
-import { formatBytes } from "../../../../app/utils";
 import { formatDictationShortcut } from "../../recorder/dictation-shortcut";
-import { SetupStep, recommendedTier } from "../../recorder/recorder-setup";
-import { tierName } from "../../recorder/model-tiers";
 import { useRecorderStore } from "../../recorder/recorder-store";
-
-/** How often the wizard re-probes the OS while something is still missing. */
-const READINESS_POLL_MS = 4000;
-
-type ReadinessStepId = AudioDictationPermissionKind | "model";
-
-type ReadinessStep = { id: ReadinessStepId; done: boolean };
-
-/**
- * The steps this machine still needs, in the order a user should click
- * through them. "unavailable" and "not-required" never block: the first is
- * an environment without the native probe, the second a platform where the
- * permission does not exist.
- */
-function readinessSteps(
-  readiness: AudioDictationReadiness | null,
-  modelInstalled: boolean,
-): ReadinessStep[] {
-  if (!readiness) return [];
-  const mac = readiness.platform === "darwin";
-  const permissionOk = (state: string) => state !== "denied" && state !== "broken" && state !== "not-determined";
-  return [
-    {
-      id: "microphone" as const,
-      done: readiness.microphone === "granted" || readiness.microphone === "unknown",
-    },
-    ...(mac
-      ? [
-          { id: "inputMonitoring" as const, done: permissionOk(readiness.inputMonitoring) },
-          { id: "accessibility" as const, done: permissionOk(readiness.accessibility) },
-          { id: "automation" as const, done: permissionOk(readiness.automation) },
-        ]
-      : []),
-    { id: "model" as const, done: modelInstalled },
-  ];
-}
 
 function acceleratorFromEvent(
   event: KeyboardEvent<HTMLButtonElement>,
@@ -106,22 +59,8 @@ export function DictationSetupDialog(props: {
 }) {
   const store = useRecorderStore();
   const dictation = store.systemDictation;
-  const readiness = store.dictationReadiness;
   const [saving, setSaving] = useState(false);
-  const [requesting, setRequesting] = useState<AudioDictationPermissionKind | null>(null);
-  const [setupSkipped, setSetupSkipped] = useState(false);
-  /** The wizard was shown this open; keeps the done screen up for its CTA. */
-  const [wizardEngaged, setWizardEngaged] = useState(false);
   const capturing = dictation?.shortcutCaptureActive === true;
-
-  const modelInstalled = store.bootstrap?.models.some((model) => model.state === "installed") ?? false;
-  const steps = useMemo(
-    () => readinessSteps(readiness, modelInstalled),
-    [readiness, modelInstalled],
-  );
-  const activeIndex = steps.findIndex((step) => !step.done);
-  const setupNeeded = readiness !== null && activeIndex !== -1;
-  const wizardVisible = !setupSkipped && (setupNeeded || (wizardEngaged && readiness !== null));
 
   const stopCapture = async () => {
     await store.setSystemDictationShortcutCapture(false);
@@ -134,45 +73,6 @@ export function DictationSetupDialog(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.open]);
 
-  // Probe the OS every time the dialog opens: permissions rot behind the
-  // app's back (updates invalidate macOS grants, users decline one-time
-  // prompts), so the wizard has to re-derive what is missing, never trust a
-  // stored "was fine once". Re-probe on focus (returning from System
-  // Settings) and on a slow poll while something is still missing.
-  useEffect(() => {
-    if (!props.open) return;
-    setSetupSkipped(false);
-    setWizardEngaged(false);
-    void store.refreshDictationReadiness();
-    void store.refreshBootstrap();
-    const onFocus = () => void store.refreshDictationReadiness();
-    window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
-    // Probing follows the dialog boundary, not store identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.open]);
-
-  useEffect(() => {
-    if (!props.open || !setupNeeded || setupSkipped) return;
-    setWizardEngaged(true);
-    const timer = window.setInterval(
-      () => void store.refreshDictationReadiness(),
-      READINESS_POLL_MS,
-    );
-    return () => window.clearInterval(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.open, setupNeeded, setupSkipped]);
-
-  const requestPermission = (kind: AudioDictationPermissionKind) => {
-    setRequesting(kind);
-    void store.requestDictationPermission(kind).finally(() => setRequesting(null));
-  };
-
-  const repairPermission = (kind: AudioDictationPermissionKind) => {
-    setRequesting(kind);
-    void store.repairDictationPermission(kind).finally(() => setRequesting(null));
-  };
-
   return (
     <Dialog
       open={props.open}
@@ -183,35 +83,12 @@ export function DictationSetupDialog(props: {
     >
       <DialogContent className="max-h-[calc(100vh-2rem)] max-w-[760px] gap-0 overflow-y-auto rounded-xl p-0 sm:max-w-[760px]">
         <DialogHeader className="items-center px-8 pb-6 pt-8 text-center">
-          <DialogTitle className="text-2xl">
-            {wizardVisible && !setupNeeded
-              ? t("recorder.dictation_readiness_done_title")
-              : wizardVisible
-                ? t("recorder.dictation_readiness_title")
-                : t("recorder.dictation_setup_title")}
-          </DialogTitle>
+          <DialogTitle className="text-2xl">{t("recorder.dictation_setup_title")}</DialogTitle>
           <DialogDescription className="text-base">
-            {wizardVisible && !setupNeeded
-              ? t("recorder.dictation_readiness_done_subtitle")
-              : wizardVisible
-                ? t("recorder.dictation_readiness_subtitle")
-                : t("recorder.dictation_setup_description")}
+            {t("recorder.dictation_setup_description")}
           </DialogDescription>
         </DialogHeader>
 
-        {wizardVisible ? (
-          <ReadinessWizard
-            readiness={readiness}
-            steps={steps}
-            activeIndex={activeIndex}
-            requesting={requesting}
-            onRequest={requestPermission}
-            onRepair={repairPermission}
-            onSkip={() => setSetupSkipped(true)}
-            onDone={() => setWizardEngaged(false)}
-          />
-        ) : (
-          <>
         <section className="border-y border-subtle px-8 py-6">
           <div className="text-xs font-semibold uppercase text-subtext">
             {t("recorder.dictation_hotkey_label")}
@@ -325,290 +202,7 @@ export function DictationSetupDialog(props: {
             placeholder={t("recorder.dictation_test_placeholder")}
           />
         </section>
-          </>
-        )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-/**
- * Click-through permission setup, mirroring the Recorder first-run flow.
- * Every step re-checks live: granting in System Settings ticks steps off on
- * focus/poll without any manual confirm.
- */
-function ReadinessWizard(props: {
-  readiness: AudioDictationReadiness | null;
-  steps: ReadinessStep[];
-  activeIndex: number;
-  requesting: AudioDictationPermissionKind | null;
-  onRequest: (kind: AudioDictationPermissionKind) => void;
-  onRepair: (kind: AudioDictationPermissionKind) => void;
-  onSkip: () => void;
-  onDone: () => void;
-}) {
-  const store = useRecorderStore();
-  const readiness = props.readiness;
-  const allDone = props.activeIndex === -1;
-  const mac = readiness?.platform === "darwin";
-  const showDevHint = mac && readiness?.packaged === false;
-  // tccutil-based repair resets entries for OUR bundle id; dev runs are
-  // attributed to the launching terminal/IDE and must not offer it.
-  const repairAvailable = mac && readiness?.packaged === true;
-
-  const recommended = recommendedTier(store.bootstrap);
-  const recommendedModel = store.bootstrap?.models.find((model) => model.id === recommended.modelId);
-  const downloading = recommendedModel?.state === "downloading";
-  const totalBytes = recommendedModel?.totalBytes || recommendedModel?.approxSizeBytes || 0;
-  const downloadedBytes = recommendedModel?.downloadedBytes ?? 0;
-  const pct = totalBytes > 0 ? Math.round((downloadedBytes / totalBytes) * 100) : 0;
-
-  // End-to-end paste self-test: runs the REAL pipeline (clipboard, the
-  // Accessibility-gated keystroke, System Events) into this dialog's own
-  // input, so "everything green" is proven by execution, not by reading
-  // permission state. A failure re-probes readiness to resurface the step
-  // that actually broke.
-  const [pasteTest, setPasteTest] = useState<"idle" | "running" | "ok" | "failed">("idle");
-  const [pasteError, setPasteError] = useState<string | null>(null);
-  const pasteInputRef = useRef<HTMLInputElement | null>(null);
-
-  const runPasteTest = () => {
-    const input = pasteInputRef.current;
-    if (!input) return;
-    input.value = "";
-    input.focus();
-    setPasteTest("running");
-    setPasteError(null);
-    void audioSystemDictationPaste(t("recorder.dictation_paste_test_sample"))
-      .then((result) => {
-        if (result.error) {
-          setPasteTest("failed");
-          setPasteError(result.error);
-          void store.refreshDictationReadiness();
-          return;
-        }
-        // The keystroke already landed (paste resolves after its restore
-        // delay); the input's content is the end-to-end proof.
-        window.setTimeout(() => {
-          setPasteTest(input.value.trim().length > 0 ? "ok" : "failed");
-        }, 350);
-      })
-      .catch(() => setPasteTest("failed"));
-  };
-
-  const permissionStep = (
-    step: ReadinessStep,
-    index: number,
-    kind: AudioDictationPermissionKind,
-    view: {
-      title: string;
-      body: string;
-      blockedHint: string | null;
-      cta: string;
-      /** Stale or declined grant: offer the tccutil reset + fresh prompt. */
-      repairable?: boolean;
-    },
-  ) => {
-    const repair = view.repairable === true && repairAvailable && kind !== "microphone";
-    return (
-      <SetupStep
-        key={step.id}
-        index={index}
-        done={step.done}
-        active={index === props.activeIndex}
-        title={view.title}
-        doneLabel={t("recorder.perm_status_granted")}
-      >
-        <p className="text-sm text-subtext">{view.blockedHint ?? view.body}</p>
-        {showDevHint ? (
-          <p className="mt-1.5 text-xs text-tertiary">{t("recorder.perm_dev_hint")}</p>
-        ) : null}
-        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
-          <Button
-            size="sm"
-            disabled={props.requesting !== null}
-            onClick={() => (repair ? props.onRepair(kind) : props.onRequest(kind))}
-          >
-            {props.requesting === kind ? (
-              <Loader2 data-icon="inline-start" className="animate-spin" />
-            ) : null}
-            {repair ? t("recorder.dictation_repair_cta") : view.cta}
-          </Button>
-          {repair ? (
-            <button
-              type="button"
-              className="text-xs text-subtext underline-offset-2 hover:text-ink hover:underline"
-              disabled={props.requesting !== null}
-              onClick={() => props.onRequest(kind)}
-            >
-              {t("recorder.perm_open_settings")}
-            </button>
-          ) : null}
-        </div>
-        {props.requesting === kind ? (
-          <p className="mt-2.5 flex items-center gap-1.5 text-xs text-subtext animate-in fade-in-0">
-            <Loader2 className="size-3 animate-spin text-brand" />
-            {t("recorder.dictation_step_waiting_prompt")}
-          </p>
-        ) : null}
-      </SetupStep>
-    );
-  };
-
-  return (
-    <div className="px-8 pb-8">
-      <div className="divide-y divide-subtle overflow-hidden rounded-2xl border border-subtle bg-surface shadow-xs">
-        {props.steps.map((step, index) => {
-          if (step.id === "microphone") {
-            return permissionStep(step, index, "microphone", {
-              title: t("recorder.setup_mic_title"),
-              body: t("recorder.setup_mic_body"),
-              blockedHint:
-                readiness?.microphone === "denied" || readiness?.microphone === "restricted"
-                  ? t("recorder.perm_microphone_instructions")
-                  : null,
-              cta:
-                readiness?.microphone === "not-determined"
-                  ? t("recorder.setup_mic_cta")
-                  : t("recorder.perm_open_settings"),
-            });
-          }
-          if (step.id === "inputMonitoring") {
-            const state = readiness?.inputMonitoring;
-            return permissionStep(step, index, "inputMonitoring", {
-              title: t("recorder.dictation_step_monitor_title"),
-              body: t("recorder.dictation_step_monitor_body"),
-              blockedHint:
-                state === "broken"
-                  ? t("recorder.dictation_step_monitor_broken")
-                  : state === "denied"
-                    ? t("recorder.dictation_step_monitor_denied")
-                    : null,
-              cta:
-                state === "not-determined"
-                  ? t("recorder.perm_allow")
-                  : t("recorder.perm_open_settings"),
-              // A grant that looks on but is dead, or one declined earlier,
-              // is fixed by wiping our stale entries and prompting fresh.
-              repairable: state === "broken" || state === "denied",
-            });
-          }
-          if (step.id === "accessibility") {
-            return permissionStep(step, index, "accessibility", {
-              title: t("recorder.dictation_step_a11y_title"),
-              body: t("recorder.dictation_step_a11y_body"),
-              blockedHint: null,
-              cta: t("recorder.perm_open_settings"),
-              // "denied" cannot distinguish never-granted from a stale row
-              // bound to an older build; the reset covers both.
-              repairable: readiness?.accessibility === "denied",
-            });
-          }
-          if (step.id === "automation") {
-            return permissionStep(step, index, "automation", {
-              title: t("recorder.dictation_step_automation_title"),
-              body: t("recorder.dictation_step_automation_body"),
-              blockedHint:
-                readiness?.automation === "denied"
-                  ? t("recorder.dictation_step_automation_denied")
-                  : null,
-              cta:
-                readiness?.automation === "not-determined"
-                  ? t("recorder.perm_allow")
-                  : t("recorder.perm_open_settings"),
-              repairable: readiness?.automation === "denied",
-            });
-          }
-          return (
-            <SetupStep
-              key={step.id}
-              index={index}
-              done={step.done}
-              active={index === props.activeIndex}
-              title={t("recorder.setup_model_title")}
-              doneLabel={t("recorder.model_installed")}
-            >
-              <p className="text-sm text-subtext">{t("recorder.setup_model_body")}</p>
-              <div className="mt-3 flex items-center gap-3">
-                {downloading ? (
-                  <>
-                    <Progress value={pct} className="h-1.5 flex-1" />
-                    <span className="text-2xs tabular-nums text-subtext">
-                      {formatBytes(downloadedBytes)} / {formatBytes(totalBytes)}
-                    </span>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      aria-label={t("recorder.model_cancel")}
-                      onClick={() => void store.cancelModelDownload(recommended.modelId)}
-                    >
-                      <X />
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      store.setModelId(recommended.modelId);
-                      void store.downloadModel(recommended.modelId);
-                    }}
-                  >
-                    {t("recorder.model_download")} {tierName(recommended.key)}
-                  </Button>
-                )}
-              </div>
-              {recommendedModel?.state === "error" && recommendedModel.error ? (
-                <div className="mt-1 text-xs text-danger">{recommendedModel.error}</div>
-              ) : null}
-            </SetupStep>
-          );
-        })}
-      </div>
-
-      {allDone ? (
-        <div className="mt-4 rounded-xl border border-subtle bg-surface px-4 py-3">
-          <div className="flex flex-wrap items-center gap-3">
-            <input
-              ref={pasteInputRef}
-              className="h-9 min-w-0 flex-1 rounded-md border border-subtle bg-sunken px-3 text-sm text-ink outline-none focus:border-brand"
-              placeholder={t("recorder.dictation_paste_test_placeholder")}
-            />
-            <Button size="sm" variant="outline" disabled={pasteTest === "running"} onClick={runPasteTest}>
-              {pasteTest === "running" ? (
-                <Loader2 data-icon="inline-start" className="animate-spin" />
-              ) : null}
-              {t("recorder.dictation_paste_test_cta")}
-            </Button>
-          </div>
-          {pasteTest === "ok" ? (
-            <p className="mt-2 flex items-center gap-1.5 text-xs text-success animate-in fade-in-0">
-              <Check className="size-3" />
-              {t("recorder.dictation_paste_test_ok")}
-            </p>
-          ) : pasteTest === "failed" ? (
-            <p className="mt-2 text-xs text-danger">
-              {pasteError ?? t("recorder.dictation_paste_test_failed")}
-            </p>
-          ) : null}
-        </div>
-      ) : null}
-
-      <div className="mt-5 flex items-center justify-between gap-4">
-        <p className="flex items-center gap-1.5 text-xs text-subtext">
-          <ShieldCheck className="size-3.5 shrink-0 text-success" />
-          {t("recorder.perm_recheck_hint")}
-        </p>
-        {allDone ? (
-          <Button onClick={props.onDone}>
-            <Check data-icon="inline-start" />
-            {t("recorder.setup_done_cta")}
-          </Button>
-        ) : (
-          <Button variant="ghost" size="sm" className="shrink-0 text-subtext" onClick={props.onSkip}>
-            {t("recorder.setup_skip_all")}
-          </Button>
-        )}
-      </div>
-    </div>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/recorder-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/recorder-view.tsx
@@ -31,6 +31,7 @@ import { ModelManagerList } from "../../recorder/model-manager";
 import { formatDictationShortcut } from "../../recorder/dictation-shortcut";
 import { useRecorderStore } from "../../recorder/recorder-store";
 import { HubTabs } from "../segmented-tabs";
+import { DictationReadinessGate } from "./dictation-readiness";
 import { DictationSetupDialog } from "./dictation-setup-dialog";
 
 export function RecorderSettingsView() {
@@ -128,7 +129,8 @@ export function RecorderSettingsView() {
           </LayoutSectionItem>
         </>
       ) : (
-        <LayoutSectionItem>
+        <DictationReadinessGate>
+          <LayoutSectionItem>
         <LayoutSectionItemHeader>
           <div>
             <LayoutSectionItemTitle>{t("recorder.dictation_title")}</LayoutSectionItemTitle>
@@ -251,7 +253,8 @@ export function RecorderSettingsView() {
             </span>
           </div>
         </div>
-        </LayoutSectionItem>
+          </LayoutSectionItem>
+        </DictationReadinessGate>
       )}
     </LayoutStack>
   );


### PR DESCRIPTION
## Summary

- replace the Dictate Anywhere settings content with the readiness checklist when a permission or model is missing
- restore the Configure modal to hotkey, mode, and dictation testing only
- preserve live permission polling, stale-grant repair, model setup, and paste verification

## Tests

- `pnpm --filter @legalwork/app typecheck` — passed
- `pnpm --filter @legalwork/app test` — 192 passed, 0 failed

## End-to-end evidence

No video or screenshot captured: this state depends on native Electron/macOS permissions and is not available in the browser test harness.

Reviewer steps:

1. Use a desktop build with at least one Dictate Anywhere requirement missing.
2. Open Settings → Recorder → Dictate Anywhere.
3. Confirm the readiness checklist replaces the normal Dictate Anywhere content.
4. Grant the missing requirements and continue; confirm the normal settings content appears.
5. Open Configure and confirm it contains only hotkey, mode, and dictation testing controls.