### PR TITLE
fix: honor selected Word model and stabilize dictation HUD

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -912,6 +912,11 @@ export function SessionRoute() {
             sessionID: targetSessionId,
             command: draft.command.name,
             arguments: draft.command.arguments,
+            model: local.prefs.defaultModel
+              ? `${local.prefs.defaultModel.providerID}/${local.prefs.defaultModel.modelID}`
+              : undefined,
+            agent: selectedAgent ?? undefined,
+            variant: modelVariantValue ?? undefined,
           });
           if (result.error) {
             throw new Error(serializeSDKError(result.error));

--- a/apps/desktop/electron/audio/dictation-hud.mjs
+++ b/apps/desktop/electron/audio/dictation-hud.mjs
@@ -1,29 +1,23 @@
 import { BrowserWindow, screen } from "electron";
 
-const WIDTH = 260;
-const HEIGHT = 58;
-
-const LABELS = {
-  listening: "Listening - press shortcut to finish",
-  transcribing: "Transcribing on this device",
-  error: "Dictation needs attention",
-};
+const SIZE = 24;
 
 export class DictationHud {
   constructor() {
     /** @type {BrowserWindow | null} */
     this.window = null;
     this.hideTimer = null;
+    this.updateVersion = 0;
   }
 
   async ensureWindow() {
     if (this.window && !this.window.isDestroyed()) return this.window;
     const area = screen.getPrimaryDisplay().workArea;
     const window = new BrowserWindow({
-      width: WIDTH,
-      height: HEIGHT,
-      x: Math.round(area.x + (area.width - WIDTH) / 2),
-      y: area.y + area.height - HEIGHT - 32,
+      width: SIZE,
+      height: SIZE,
+      x: Math.round(area.x + (area.width - SIZE) / 2),
+      y: area.y + area.height - SIZE - 18,
       // A non-activating NSPanel: the HUD must never take key status from
       // the app that is about to receive the paste.
       ...(process.platform === "darwin" ? { type: "panel" } : {}),
@@ -37,7 +31,7 @@ export class DictationHud {
       focusable: false,
       skipTaskbar: true,
       alwaysOnTop: true,
-      hasShadow: true,
+      hasShadow: false,
       show: false,
       webPreferences: {
         contextIsolation: true,
@@ -61,12 +55,11 @@ export class DictationHud {
 <html><head><meta charset="utf-8"><style>
 html,body{width:100%;height:100%;margin:0;background:transparent;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:0}
 body{display:flex;align-items:center;justify-content:center}
-main{width:calc(100% - 12px);height:46px;box-sizing:border-box;display:flex;align-items:center;gap:11px;padding:0 14px;border:1px solid rgba(255,255,255,.16);border-radius:8px;background:rgba(20,20,22,.94);color:#f4f4f5;box-shadow:0 8px 28px rgba(0,0,0,.32)}
-#dot{width:10px;height:10px;flex:none;border-radius:50%;background:#36a269;box-shadow:0 0 0 4px rgba(54,162,105,.16)}
-#dot.listening{animation:pulse 1.15s ease-in-out infinite}#dot.transcribing{background:#d49b31;box-shadow:0 0 0 4px rgba(212,155,49,.16)}#dot.error{background:#df5b55;box-shadow:0 0 0 4px rgba(223,91,85,.16)}
-#label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13px;font-weight:600}
+main{width:18px;height:18px;box-sizing:border-box;display:flex;align-items:center;justify-content:center;border:1px solid rgba(255,255,255,.18);border-radius:50%;background:rgba(20,20,22,.9);box-shadow:0 3px 10px rgba(0,0,0,.25)}
+#dot{width:6px;height:6px;border-radius:50%;background:#36a269}
+#dot.listening{animation:pulse 1.15s ease-in-out infinite}#dot.transcribing{background:#d49b31}#dot.error{background:#df5b55}
 @keyframes pulse{50%{opacity:.42}}
-</style></head><body><main><span id="dot"></span><span id="label"></span></main></body></html>`)}`);
+</style></head><body><main><span id="dot"></span></main></body></html>`)}`);
     window.on("closed", () => {
       if (this.window === window) this.window = null;
     });
@@ -74,7 +67,8 @@ main{width:calc(100% - 12px);height:46px;box-sizing:border-box;display:flex;alig
     return window;
   }
 
-  async setState(state, message = "") {
+  async setState(state, _message = "") {
+    const updateVersion = ++this.updateVersion;
     if (this.hideTimer) clearTimeout(this.hideTimer);
     this.hideTimer = null;
     if (state === "idle") {
@@ -82,19 +76,21 @@ main{width:calc(100% - 12px);height:46px;box-sizing:border-box;display:flex;alig
       return;
     }
     const window = await this.ensureWindow();
-    const label = message.trim() || LABELS[state] || "System-wide dictation";
+    if (updateVersion !== this.updateVersion || window.isDestroyed()) return;
     await window.webContents.executeJavaScript(
-      `document.getElementById("dot").className=${JSON.stringify(state)};document.getElementById("label").textContent=${JSON.stringify(label)};`,
+      `document.getElementById("dot").className=${JSON.stringify(state)};`,
     );
+    if (updateVersion !== this.updateVersion || window.isDestroyed()) return;
     window.showInactive();
     if (state === "error") {
       this.hideTimer = setTimeout(() => {
-        if (!window.isDestroyed()) window.hide();
+        if (updateVersion === this.updateVersion && !window.isDestroyed()) window.hide();
       }, 5_000);
     }
   }
 
   destroy() {
+    this.updateVersion += 1;
     if (this.hideTimer) clearTimeout(this.hideTimer);
     if (this.window && !this.window.isDestroyed()) this.window.destroy();
     this.window = null;


### PR DESCRIPTION
## Summary

- Forward the selected provider/model, agent, and variant for slash-command and skill turns in the shared session route used by the Office add-in. This prevents OpenCode from silently using its free default.
- Replace the 260 x 58 dictation status bar with a 24 x 24 centered status dot.
- Ignore stale asynchronous HUD updates so a completed dictation cannot be shown again after the idle state already hid it.

## Verification

- pnpm --filter @legalwork/app typecheck — passed
- pnpm --filter @legalwork/app test — 192 passed
- pnpm --filter @legalwork/app build:word-addin — passed
- pnpm --filter @legalwork/desktop typecheck:electron — passed
- pnpm --filter @legalwork/desktop test — 81 passed, 1 platform-specific skip
- git diff --check — passed

## End-to-end evidence

No screen recording is attached. A faithful capture requires a signed-in Office desktop host plus the Electron app with macOS Microphone, Accessibility, and Input Monitoring permissions; this verification run was terminal-based.

Reviewer reproduction:

1. Open the Word add-in, choose a paid Eigenwelt model, then run a slash command or skill. Confirm the resulting assistant turn metadata uses the selected provider/model rather than eigenwelt-free.
2. On a fresh desktop launch, enable Dictate Anywhere and immediately start and finish a short dictation while the HUD is first being created. Confirm only the small centered dot appears and that it hides after completion.
3. Repeat with a longer dictation. Confirm the dot stays visible while listening, changes while transcribing, and disappears at idle.