### PR TITLE
feat(app): add DingDuff default connector to the MCP quick-connect catalog

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -453,6 +453,20 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     kind: "mcp",
   },
   {
+    get name() { return t("mcp.quick_connect_dingduff_title"); },
+    serverName: "dingduff",
+    get description() { return t("mcp.quick_connect_dingduff_desc"); },
+    // Attorney-built legal research server (github.com/DingDuff/dingduff-public):
+    // court opinions, federal/state statutes and rules, and PACER dockets via
+    // plain-English search. One-click: standard MCP OAuth — a sign-in window
+    // opens on dingduff.com and returns automatically. Each user needs their
+    // own DingDuff account (free while in beta; licensed attorneys per ToS).
+    url: "https://app.dingduff.com/mcp",
+    type: "remote",
+    oauth: true,
+    kind: "mcp",
+  },
+  {
     get name() { return t("mcp.quick_connect_ruly_title"); },
     serverName: "ruly",
     get description() { return t("mcp.quick_connect_ruly_desc"); },

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -771,6 +771,8 @@ export default {
   "mcp.quick_connect_box_title": "Box",
   "mcp.quick_connect_courtlistener_desc": "Search and cite free US case law, dockets, PACER filings, and judge data from Free Law Project.",
   "mcp.quick_connect_courtlistener_title": "CourtListener",
+  "mcp.quick_connect_dingduff_desc": "Plain-English legal research from DingDuff — millions of court opinions, federal and state statutes and rules, and PACER filings. One-click sign-in with your DingDuff account.",
+  "mcp.quick_connect_dingduff_title": "DingDuff",
   "mcp.quick_connect_dropbox_desc": "Search, read, and manage matter files in the firm's Dropbox. One-click sign-in with your Dropbox account.",
   "mcp.quick_connect_dropbox_title": "Dropbox",
   "mcp.quick_connect_egnyte_desc": "Search and summarize documents in the firm's Egnyte repository, governed by existing Egnyte permissions.",


### PR DESCRIPTION
DingDuff (github.com/DingDuff/dingduff-public) is an attorney-built legal
research MCP server covering court opinions, federal/state statutes and
rules, and PACER dockets. It connects one-click via standard MCP OAuth
(sign-in on dingduff.com), so the entry follows the CourtListener/Ruly/
TaxGraph pattern: oauth: true with no token or client-credential form.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J26sbuxUj247vb8unRw5Eu