### PR TITLE
feat(word-addin): untracked-edit fallback + Office build diagnostics on old Word (no WordApi 1.4)

### DIFF
--- a/apps/app/src/word-addin/office-run-code.ts
+++ b/apps/app/src/word-addin/office-run-code.ts
@@ -12,8 +12,10 @@
  *
  * In Word, change tracking is forced on around the batch so document
  * mutations stay reviewable redlines, mirroring the typed word_* tools.
+ * Hosts without WordApi 1.4 cannot control tracking; the batch still runs
+ * and the result carries trackedChanges: false plus a warning to relay.
  */
-import { isWordApiSupported, wordApiDiagnostic, wordRun } from "./office";
+import { isWordApiSupported, untrackedEditWarning, wordRun } from "./office";
 import { excelRun } from "./excel-api";
 import { powerPointRun } from "./powerpoint-api";
 
@@ -128,14 +130,16 @@ export async function runOfficeCode(host: RunHost, args: Record<string, unknown>
   const execute = (context: unknown): Promise<unknown> =>
     snippet(context, apis.Office, apis.Word, apis.Excel, apis.PowerPoint, consoleProxy);
 
+  const wordTracking = host === "word" ? isWordApiSupported("1.4") : false;
+
   try {
     let result: unknown;
     if (host === "word") {
       result = await wordRun(async (context) => {
-        if (!isWordApiSupported("1.4")) {
-          throw new Error(
-            `This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). word_run_code is disabled for safety. ${wordApiDiagnostic()}`,
-          );
+        if (!wordTracking) {
+          const value = await execute(context);
+          await context.sync();
+          return value;
         }
         // Mirror withTrackedChanges in word-document-tools: every mutation
         // the snippet makes must land as a reviewable redline.
@@ -174,7 +178,9 @@ export async function runOfficeCode(host: RunHost, args: Record<string, unknown>
     return {
       result: serializeResult(result),
       ...(logs.length ? { logs } : {}),
-      ...(host === "word" ? { trackedChanges: true } : {}),
+      ...(host === "word"
+        ? { trackedChanges: wordTracking, ...(wordTracking ? {} : { warning: untrackedEditWarning() }) }
+        : {}),
     };
   } catch (error) {
     throw describeOfficeError(error);

--- a/apps/app/src/word-addin/office-run-code.ts
+++ b/apps/app/src/word-addin/office-run-code.ts
@@ -13,7 +13,7 @@
  * In Word, change tracking is forced on around the batch so document
  * mutations stay reviewable redlines, mirroring the typed word_* tools.
  */
-import { isWordApiSupported, wordRun } from "./office";
+import { isWordApiSupported, wordApiDiagnostic, wordRun } from "./office";
 import { excelRun } from "./excel-api";
 import { powerPointRun } from "./powerpoint-api";
 
@@ -134,7 +134,7 @@ export async function runOfficeCode(host: RunHost, args: Record<string, unknown>
       result = await wordRun(async (context) => {
         if (!isWordApiSupported("1.4")) {
           throw new Error(
-            "This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). word_run_code is disabled for safety.",
+            `This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). word_run_code is disabled for safety. ${wordApiDiagnostic()}`,
           );
         }
         // Mirror withTrackedChanges in word-document-tools: every mutation

--- a/apps/app/src/word-addin/office.ts
+++ b/apps/app/src/word-addin/office.ts
@@ -194,6 +194,19 @@ export function wordApiDiagnostic(): string {
   return `Detected Office ${build} on ${platform}; highest supported WordApi is ${highest ?? "unknown"}.`;
 }
 
+/**
+ * Warning attached to every edit made on a host without WordApi 1.4: the
+ * mutation went through, but tracking could not be forced (or even read),
+ * so unless the user has Track Changes on themselves the edit is untracked.
+ */
+export function untrackedEditWarning(): string {
+  return (
+    "Edit applied WITHOUT tracked changes: this Word version does not let add-ins control change tracking " +
+    "(requires WordApi 1.4). Tell the user exactly what you changed so they can review it (undo via Ctrl/Cmd+Z), " +
+    `and mention that updating Word/Microsoft 365 enables native redlines. ${wordApiDiagnostic()}`
+  );
+}
+
 /** URL/path of the open document, when the host exposes it. */
 export function getDocumentUrl(): string | null {
   const url = officeGlobals().office?.context?.document?.url;

--- a/apps/app/src/word-addin/office.ts
+++ b/apps/app/src/word-addin/office.ts
@@ -42,6 +42,7 @@ export type WordRange = {
   text: string;
   load: (properties: string) => void;
   insertText: (text: string, insertLocation: string) => WordRange;
+  insertOoxml: (ooxml: string, insertLocation: string) => WordRange;
   insertComment: (commentText: string) => unknown;
   delete: () => void;
   paragraphs: WordParagraphCollection;
@@ -62,6 +63,7 @@ export type WordBody = {
   text: string;
   load: (properties: string) => void;
   insertText: (text: string, insertLocation: string) => WordRange;
+  insertOoxml: (ooxml: string, insertLocation: string) => WordRange;
   search: (searchText: string, options?: WordSearchOptions) => WordRangeCollection;
 };
 
@@ -195,15 +197,17 @@ export function wordApiDiagnostic(): string {
 }
 
 /**
- * Warning attached to every edit made on a host without WordApi 1.4: the
- * mutation went through, but tracking could not be forced (or even read),
- * so unless the user has Track Changes on themselves the edit is untracked.
+ * Warning attached to an edit that went through untracked: the host cannot
+ * control change tracking (no WordApi 1.4) and the edit could not be
+ * expressed as revision markup either, so unless the user has Track Changes
+ * on themselves the edit is invisible as a change.
  */
 export function untrackedEditWarning(): string {
   return (
     "Edit applied WITHOUT tracked changes: this Word version does not let add-ins control change tracking " +
-    "(requires WordApi 1.4). Tell the user exactly what you changed so they can review it (undo via Ctrl/Cmd+Z), " +
-    `and mention that updating Word/Microsoft 365 enables native redlines. ${wordApiDiagnostic()}`
+    "(requires WordApi 1.4), and this edit could not be synthesized as revision markup. Tell the user exactly " +
+    "what you changed so they can review it (undo via Ctrl/Cmd+Z), and mention that updating Word/Microsoft 365 " +
+    `enables native redlines. ${wordApiDiagnostic()}`
   );
 }
 

--- a/apps/app/src/word-addin/office.ts
+++ b/apps/app/src/word-addin/office.ts
@@ -22,6 +22,7 @@ type OfficeNamespace = {
   onReady: (callback?: (info: OfficeHostInfo) => void) => Promise<OfficeHostInfo> | void;
   context?: {
     requirements?: { isSetSupported?: (name: string, version?: string) => boolean };
+    diagnostics?: { host?: unknown; platform?: unknown; version?: unknown };
     document?: OfficeDocumentContext;
     ui?: { openBrowserWindow?: (url: string) => void };
   };
@@ -168,6 +169,29 @@ export function isOfficeApiSupported(setName: string, version: string): boolean 
 /** Check a Word requirement set, e.g. isWordApiSupported("1.4") for tracking/comments. */
 export function isWordApiSupported(version: string): boolean {
   return isOfficeApiSupported("WordApi", version);
+}
+
+/** Highest WordApi requirement set the host reports (sets are cumulative), or null. */
+export function highestWordApiVersion(): string | null {
+  let highest: string | null = null;
+  for (let minor = 1; minor <= 9; minor++) {
+    const version = `1.${minor}`;
+    if (isWordApiSupported(version)) highest = version;
+  }
+  return highest;
+}
+
+/**
+ * One-line host description for unsupported-API errors, so support can see
+ * the customer's actual Office build and API level straight from the
+ * agent transcript instead of asking them for it.
+ */
+export function wordApiDiagnostic(): string {
+  const diagnostics = officeGlobals().office?.context?.diagnostics;
+  const build = typeof diagnostics?.version === "string" && diagnostics.version ? diagnostics.version : "unknown build";
+  const platform = diagnostics?.platform != null ? String(diagnostics.platform) : "unknown platform";
+  const highest = highestWordApiVersion();
+  return `Detected Office ${build} on ${platform}; highest supported WordApi is ${highest ?? "unknown"}.`;
 }
 
 /** URL/path of the open document, when the host exposes it. */

--- a/apps/app/src/word-addin/word-document-tools.ts
+++ b/apps/app/src/word-addin/word-document-tools.ts
@@ -14,6 +14,7 @@
 import {
   getDocumentUrl,
   isWordApiSupported,
+  wordApiDiagnostic,
   readSelectionText,
   wordRun,
   type WordRange,
@@ -83,7 +84,7 @@ function pickAnchorRange(ranges: WordRange[], occurrence: number | undefined, an
 async function withTrackedChanges(context: WordRunContext, mutate: () => void): Promise<void> {
   if (!isWordApiSupported("1.4")) {
     throw new Error(
-      "This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). Document edits are disabled for safety — the user can update Word/Microsoft 365 to enable them.",
+      `This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). Document edits are disabled for safety — the user can update Word/Microsoft 365 to enable them. ${wordApiDiagnostic()}`,
     );
   }
   const document = context.document;
@@ -121,6 +122,7 @@ async function readDocument(args: Record<string, unknown>): Promise<unknown> {
       truncated: text.length > maxChars,
       changeTrackingMode: trackingSupported ? context.document.changeTrackingMode : "unsupported",
       editingSupported: trackingSupported,
+      ...(trackingSupported ? {} : { editingDisabledReason: `WordApi 1.4 not available. ${wordApiDiagnostic()}` }),
       text: text.slice(0, maxChars),
     };
   });
@@ -219,7 +221,9 @@ async function addComment(args: Record<string, unknown>): Promise<unknown> {
   const comment = stringArg(args, "comment")?.trim();
   if (!comment) throw new Error("comment is required.");
   if (!isWordApiSupported("1.4")) {
-    throw new Error("This Word version does not support inserting comments from add-ins (requires WordApi 1.4).");
+    throw new Error(
+      `This Word version does not support inserting comments from add-ins (requires WordApi 1.4). ${wordApiDiagnostic()}`,
+    );
   }
 
   return wordRun(async (context) => {

--- a/apps/app/src/word-addin/word-document-tools.ts
+++ b/apps/app/src/word-addin/word-document-tools.ts
@@ -6,11 +6,13 @@
  *   document; character offsets would drift while the user types.
  * - Every mutation runs with Word change tracking forced to TrackAll, so
  *   agent edits are always reviewable redlines. If the host Word version
- *   cannot control tracking (WordApi < 1.4), edits still apply but the
- *   result flags trackedChange: false with a warning the agent must relay
- *   -- the user gets told exactly what changed instead of a refusal.
- *   Comments and tracking control genuinely do not exist below 1.4 and
- *   keep failing with a diagnostic.
+ *   cannot control tracking (WordApi < 1.4), the redline is synthesized
+ *   instead: the edit is inserted as OOXML w:ins/w:del revision markup
+ *   (insertOoxml, WordApi 1.1), which Word treats as a normal tracked
+ *   change attributed to REVISION_AUTHOR. Only if the host rejects that
+ *   package does the edit apply untracked, flagged trackedChange: false
+ *   with a warning the agent must relay. Comments genuinely do not exist
+ *   below 1.4 and keep failing with a diagnostic.
  * - Handlers throw Error with a model-readable message; the relay client
  *   converts that into { ok: false, error } for the tool result.
  */
@@ -83,16 +85,11 @@ function pickAnchorRange(ranges: WordRange[], occurrence: number | undefined, an
 
 /**
  * Run a mutation with change tracking forced on, restoring the user's
- * previous tracking mode afterwards (revisions persist once made). On hosts
- * without WordApi 1.4 tracking cannot be controlled or read; the mutation
- * still runs and the caller surfaces tracked: false to the agent.
+ * previous tracking mode afterwards (revisions persist once made).
+ * Requires WordApi 1.4; callers below that go through applyTracked's
+ * revision-markup path instead.
  */
-async function withTrackedChanges(context: WordRunContext, mutate: () => void): Promise<{ tracked: boolean }> {
-  if (!isWordApiSupported("1.4")) {
-    mutate();
-    await context.sync();
-    return { tracked: false };
-  }
+async function withTrackedChanges(context: WordRunContext, mutate: () => void): Promise<void> {
   const document = context.document;
   document.load("changeTrackingMode");
   await context.sync();
@@ -111,7 +108,89 @@ async function withTrackedChanges(context: WordRunContext, mutate: () => void): 
       await context.sync();
     }
   }
-  return { tracked: true };
+}
+
+/** Author shown on synthesized revisions in Word's Review ribbon. */
+export const REVISION_AUTHOR = "LegalWork";
+
+let revisionIdCounter = 0;
+
+function xmlEscape(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/** A single run; newlines become w:br (anchors are single-paragraph by contract). */
+function revisionRun(text: string, kind: "ins" | "del"): string {
+  const tag = kind === "del" ? "w:delText" : "w:t";
+  const content = text
+    .split(/\r\n|\r|\n/)
+    .map((line) => `<${tag} xml:space="preserve">${xmlEscape(line)}</${tag}>`)
+    .join("<w:br/>");
+  return `<w:r>${content}</w:r>`;
+}
+
+/**
+ * Flat-OPC package holding one paragraph of w:ins/w:del revision runs.
+ * Range.insertOoxml (WordApi 1.1) splices a single-paragraph package into
+ * the target paragraph inline, and Word treats the markup as real tracked
+ * changes: they show up in the Review ribbon, attributable and
+ * accept/rejectable, no WordApi 1.4 needed.
+ */
+export function revisionOoxml(parts: Array<{ kind: "ins" | "del"; text: string }>): string {
+  const date = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const revisions = parts
+    .filter((part) => part.text.length > 0)
+    .map(
+      (part) =>
+        `<w:${part.kind} w:id="${++revisionIdCounter}" w:author="${REVISION_AUTHOR}" w:date="${date}">` +
+        `${revisionRun(part.text, part.kind)}</w:${part.kind}>`,
+    )
+    .join("");
+  return (
+    `<pkg:package xmlns:pkg="http://schemas.microsoft.com/office/2006/xmlPackage">` +
+    `<pkg:part pkg:name="/_rels/.rels" pkg:contentType="application/vnd.openxmlformats-package.relationships+xml">` +
+    `<pkg:xmlData>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="/word/document.xml"/>` +
+    `</Relationships>` +
+    `</pkg:xmlData>` +
+    `</pkg:part>` +
+    `<pkg:part pkg:name="/word/document.xml" pkg:contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml">` +
+    `<pkg:xmlData>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+    `<w:body><w:p>${revisions}</w:p></w:body>` +
+    `</w:document>` +
+    `</pkg:xmlData>` +
+    `</pkg:part>` +
+    `</pkg:package>`
+  );
+}
+
+type EditOutcome = { trackedChange: boolean; method?: "revision-markup"; warning?: string };
+
+/**
+ * The tracked-edit ladder: native tracking (WordApi 1.4) -> synthesized
+ * w:ins/w:del revision markup -> plain untracked edit as last resort,
+ * flagged with a warning the agent relays to the user.
+ */
+async function applyTracked(
+  context: WordRunContext,
+  mutate: () => void,
+  insertRevision: () => void,
+): Promise<EditOutcome> {
+  if (isWordApiSupported("1.4")) {
+    await withTrackedChanges(context, mutate);
+    return { trackedChange: true };
+  }
+  try {
+    insertRevision();
+    await context.sync();
+    return { trackedChange: true, method: "revision-markup" };
+  } catch {
+    mutate();
+    await context.sync();
+    return { trackedChange: false, warning: untrackedEditWarning() };
+  }
 }
 
 async function readDocument(args: Record<string, unknown>): Promise<unknown> {
@@ -134,8 +213,8 @@ async function readDocument(args: Record<string, unknown>): Promise<unknown> {
         ? {}
         : {
             warning:
-              "Edits on this Word version are applied WITHOUT tracked changes and comments are unavailable " +
-              `(requires WordApi 1.4). ${wordApiDiagnostic()}`,
+              "This Word version lacks WordApi 1.4: edits become redlines via synthesized revision markup " +
+              `(author "${REVISION_AUTHOR}"), and comments are unavailable. ${wordApiDiagnostic()}`,
           }),
       text: text.slice(0, maxChars),
     };
@@ -186,17 +265,27 @@ async function replaceText(args: Record<string, unknown>): Promise<unknown> {
   return wordRun(async (context) => {
     const ranges = await findAnchorRanges(context, anchor);
     const { range, index } = pickAnchorRange(ranges, occurrence, anchor);
-    const { tracked } = await withTrackedChanges(context, () => {
-      if (replacement === "") {
-        range.delete();
-      } else {
-        range.insertText(replacement, "Replace");
-      }
-    });
+    const outcome = await applyTracked(
+      context,
+      () => {
+        if (replacement === "") {
+          range.delete();
+        } else {
+          range.insertText(replacement, "Replace");
+        }
+      },
+      () =>
+        range.insertOoxml(
+          revisionOoxml([
+            { kind: "del", text: range.text || anchor },
+            { kind: "ins", text: replacement },
+          ]),
+          "Replace",
+        ),
+    );
     return {
       applied: true,
-      trackedChange: tracked,
-      ...(tracked ? {} : { warning: untrackedEditWarning() }),
+      ...outcome,
       action: replacement === "" ? "deleted" : "replaced",
       matches: ranges.length,
       occurrence: index + 1,
@@ -211,23 +300,28 @@ async function insertText(args: Record<string, unknown>): Promise<unknown> {
 
   return wordRun(async (context) => {
     if (location === "document_start" || location === "document_end") {
-      const { tracked } = await withTrackedChanges(context, () => {
-        context.document.body.insertText(text, location === "document_start" ? "Start" : "End");
-      });
-      return { applied: true, trackedChange: tracked, ...(tracked ? {} : { warning: untrackedEditWarning() }), location };
+      const wordLocation = location === "document_start" ? "Start" : "End";
+      const outcome = await applyTracked(
+        context,
+        () => context.document.body.insertText(text, wordLocation),
+        () => context.document.body.insertOoxml(revisionOoxml([{ kind: "ins", text }]), wordLocation),
+      );
+      return { applied: true, ...outcome, location };
     }
 
     if (location === "before_anchor" || location === "after_anchor") {
       const anchor = requireAnchor(args);
       const ranges = await findAnchorRanges(context, anchor);
       const { range, index } = pickAnchorRange(ranges, numberArg(args, "occurrence"), anchor);
-      const { tracked } = await withTrackedChanges(context, () => {
-        range.insertText(text, location === "before_anchor" ? "Before" : "After");
-      });
+      const wordLocation = location === "before_anchor" ? "Before" : "After";
+      const outcome = await applyTracked(
+        context,
+        () => range.insertText(text, wordLocation),
+        () => range.insertOoxml(revisionOoxml([{ kind: "ins", text }]), wordLocation),
+      );
       return {
         applied: true,
-        trackedChange: tracked,
-        ...(tracked ? {} : { warning: untrackedEditWarning() }),
+        ...outcome,
         location,
         matches: ranges.length,
         occurrence: index + 1,

--- a/apps/app/src/word-addin/word-document-tools.ts
+++ b/apps/app/src/word-addin/word-document-tools.ts
@@ -6,14 +6,18 @@
  *   document; character offsets would drift while the user types.
  * - Every mutation runs with Word change tracking forced to TrackAll, so
  *   agent edits are always reviewable redlines. If the host Word version
- *   cannot control tracking (WordApi < 1.4), edits are refused entirely --
- *   silent modifications are never acceptable for legal documents.
+ *   cannot control tracking (WordApi < 1.4), edits still apply but the
+ *   result flags trackedChange: false with a warning the agent must relay
+ *   -- the user gets told exactly what changed instead of a refusal.
+ *   Comments and tracking control genuinely do not exist below 1.4 and
+ *   keep failing with a diagnostic.
  * - Handlers throw Error with a model-readable message; the relay client
  *   converts that into { ok: false, error } for the tool result.
  */
 import {
   getDocumentUrl,
   isWordApiSupported,
+  untrackedEditWarning,
   wordApiDiagnostic,
   readSelectionText,
   wordRun,
@@ -79,13 +83,15 @@ function pickAnchorRange(ranges: WordRange[], occurrence: number | undefined, an
 
 /**
  * Run a mutation with change tracking forced on, restoring the user's
- * previous tracking mode afterwards (revisions persist once made).
+ * previous tracking mode afterwards (revisions persist once made). On hosts
+ * without WordApi 1.4 tracking cannot be controlled or read; the mutation
+ * still runs and the caller surfaces tracked: false to the agent.
  */
-async function withTrackedChanges(context: WordRunContext, mutate: () => void): Promise<void> {
+async function withTrackedChanges(context: WordRunContext, mutate: () => void): Promise<{ tracked: boolean }> {
   if (!isWordApiSupported("1.4")) {
-    throw new Error(
-      `This Word version does not support controlling tracked changes from add-ins (requires WordApi 1.4). Document edits are disabled for safety — the user can update Word/Microsoft 365 to enable them. ${wordApiDiagnostic()}`,
-    );
+    mutate();
+    await context.sync();
+    return { tracked: false };
   }
   const document = context.document;
   document.load("changeTrackingMode");
@@ -105,6 +111,7 @@ async function withTrackedChanges(context: WordRunContext, mutate: () => void): 
       await context.sync();
     }
   }
+  return { tracked: true };
 }
 
 async function readDocument(args: Record<string, unknown>): Promise<unknown> {
@@ -121,8 +128,15 @@ async function readDocument(args: Record<string, unknown>): Promise<unknown> {
       totalChars: text.length,
       truncated: text.length > maxChars,
       changeTrackingMode: trackingSupported ? context.document.changeTrackingMode : "unsupported",
-      editingSupported: trackingSupported,
-      ...(trackingSupported ? {} : { editingDisabledReason: `WordApi 1.4 not available. ${wordApiDiagnostic()}` }),
+      editingSupported: true,
+      trackedEditingSupported: trackingSupported,
+      ...(trackingSupported
+        ? {}
+        : {
+            warning:
+              "Edits on this Word version are applied WITHOUT tracked changes and comments are unavailable " +
+              `(requires WordApi 1.4). ${wordApiDiagnostic()}`,
+          }),
       text: text.slice(0, maxChars),
     };
   });
@@ -172,7 +186,7 @@ async function replaceText(args: Record<string, unknown>): Promise<unknown> {
   return wordRun(async (context) => {
     const ranges = await findAnchorRanges(context, anchor);
     const { range, index } = pickAnchorRange(ranges, occurrence, anchor);
-    await withTrackedChanges(context, () => {
+    const { tracked } = await withTrackedChanges(context, () => {
       if (replacement === "") {
         range.delete();
       } else {
@@ -181,7 +195,8 @@ async function replaceText(args: Record<string, unknown>): Promise<unknown> {
     });
     return {
       applied: true,
-      trackedChange: true,
+      trackedChange: tracked,
+      ...(tracked ? {} : { warning: untrackedEditWarning() }),
       action: replacement === "" ? "deleted" : "replaced",
       matches: ranges.length,
       occurrence: index + 1,
@@ -196,20 +211,27 @@ async function insertText(args: Record<string, unknown>): Promise<unknown> {
 
   return wordRun(async (context) => {
     if (location === "document_start" || location === "document_end") {
-      await withTrackedChanges(context, () => {
+      const { tracked } = await withTrackedChanges(context, () => {
         context.document.body.insertText(text, location === "document_start" ? "Start" : "End");
       });
-      return { applied: true, trackedChange: true, location };
+      return { applied: true, trackedChange: tracked, ...(tracked ? {} : { warning: untrackedEditWarning() }), location };
     }
 
     if (location === "before_anchor" || location === "after_anchor") {
       const anchor = requireAnchor(args);
       const ranges = await findAnchorRanges(context, anchor);
       const { range, index } = pickAnchorRange(ranges, numberArg(args, "occurrence"), anchor);
-      await withTrackedChanges(context, () => {
+      const { tracked } = await withTrackedChanges(context, () => {
         range.insertText(text, location === "before_anchor" ? "Before" : "After");
       });
-      return { applied: true, trackedChange: true, location, matches: ranges.length, occurrence: index + 1 };
+      return {
+        applied: true,
+        trackedChange: tracked,
+        ...(tracked ? {} : { warning: untrackedEditWarning() }),
+        location,
+        matches: ranges.length,
+        occurrence: index + 1,
+      };
     }
 
     throw new Error("location must be one of document_start, document_end, before_anchor, after_anchor.");
@@ -222,7 +244,8 @@ async function addComment(args: Record<string, unknown>): Promise<unknown> {
   if (!comment) throw new Error("comment is required.");
   if (!isWordApiSupported("1.4")) {
     throw new Error(
-      `This Word version does not support inserting comments from add-ins (requires WordApi 1.4). ${wordApiDiagnostic()}`,
+      "Comments are unavailable on this Word version (requires WordApi 1.4) — put the rationale in the chat reply " +
+        `instead. ${wordApiDiagnostic()}`,
     );
   }
 

--- a/apps/app/tests/word-revision-ooxml.test.ts
+++ b/apps/app/tests/word-revision-ooxml.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { REVISION_AUTHOR, revisionOoxml } from "../src/word-addin/word-document-tools";
+
+/**
+ * The w:ins/w:del fallback for Word hosts without WordApi 1.4: the package
+ * must be a valid single-paragraph Flat OPC document whose revision runs
+ * Word accepts as real tracked changes.
+ */
+describe("revisionOoxml", () => {
+  test("replace = deletion of the old text plus insertion of the new text", () => {
+    const pkg = revisionOoxml([
+      { kind: "del", text: "old clause" },
+      { kind: "ins", text: "new clause" },
+    ]);
+    expect(pkg).toContain(`<w:delText xml:space="preserve">old clause</w:delText>`);
+    expect(pkg).toContain(`<w:t xml:space="preserve">new clause</w:t>`);
+    expect(pkg.indexOf("<w:del ")).toBeLessThan(pkg.indexOf("<w:ins "));
+    expect(pkg).toContain(`w:author="${REVISION_AUTHOR}"`);
+    expect(pkg).toMatch(/w:date="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"/);
+  });
+
+  test("empty parts are dropped, so a pure deletion has no w:ins", () => {
+    const pkg = revisionOoxml([
+      { kind: "del", text: "gone" },
+      { kind: "ins", text: "" },
+    ]);
+    expect(pkg).toContain("<w:del ");
+    expect(pkg).not.toContain("<w:ins ");
+  });
+
+  test("XML metacharacters in document text are escaped", () => {
+    const pkg = revisionOoxml([{ kind: "ins", text: `a < b & "c" > d` }]);
+    expect(pkg).toContain("a &lt; b &amp; &quot;c&quot; &gt; d");
+    expect(pkg).not.toContain(`a < b`);
+  });
+
+  test("newlines in inserted text become w:br line breaks", () => {
+    const pkg = revisionOoxml([{ kind: "ins", text: "line one\nline two" }]);
+    expect(pkg).toContain(
+      `<w:t xml:space="preserve">line one</w:t><w:br/><w:t xml:space="preserve">line two</w:t>`,
+    );
+  });
+
+  test("package is a single-paragraph Flat OPC document", () => {
+    const pkg = revisionOoxml([{ kind: "ins", text: "x" }]);
+    expect(pkg.startsWith(`<pkg:package `)).toBe(true);
+    expect(pkg).toContain(`pkg:name="/word/document.xml"`);
+    expect(pkg.match(/<w:p>/g)).toHaveLength(1);
+    expect(pkg).toContain("<w:body><w:p>");
+  });
+
+  test("revision ids are unique across calls", () => {
+    const first = revisionOoxml([{ kind: "ins", text: "a" }]);
+    const second = revisionOoxml([{ kind: "ins", text: "b" }]);
+    const id = (pkg: string) => pkg.match(/w:id="(\d+)"/)?.[1];
+    expect(id(first)).toBeDefined();
+    expect(id(second)).toBeDefined();
+    expect(id(first)).not.toBe(id(second));
+  });
+});

--- a/apps/server/src/opencode-plugins/legalwork-word-tools.ts
+++ b/apps/server/src/opencode-plugins/legalwork-word-tools.ts
@@ -14,13 +14,17 @@ import {
  * pane executes via Office.js (see office-plugin-shared.ts for the path).
  *
  * All mutating tools force Word's change tracking on, so every agent edit
- * shows up as a native tracked change the user can accept or reject.
+ * shows up as a native tracked change the user can accept or reject. On
+ * outdated Word versions that cannot control tracking (no WordApi 1.4),
+ * edits still apply but come back flagged trackedChange: false with a
+ * warning the agent must relay; comments are unavailable there.
  */
 
 const WORD_TOOL_RULES = `Rules for word_* tools:
 - Call word_read_document before editing so anchors are exact.
 - Anchors are short snippets (under 200 characters) copied VERBATIM from the document — including punctuation and casing. Prefer distinctive phrases; if an anchor matches several places, the tool reports the count and you must pass "occurrence".
-- Every edit is applied as a tracked change (redline). Never claim you changed text silently; the user reviews and accepts each change in Word.
+- Every edit is normally applied as a tracked change (redline). Never claim you changed text silently; the user reviews and accepts each change in Word.
+- On outdated Word versions (no WordApi 1.4) edit results say trackedChange: false with a warning: the edit WAS applied, just without tracked changes. Do not refuse to edit and do not claim the tools are unavailable — make the edits, then tell the user exactly what changed (they can undo with Ctrl/Cmd+Z) and that updating Word/Microsoft 365 restores native redlines. word_add_comment is unavailable there; put the rationale in the chat instead.
 - After substantive edits, add a short word_add_comment on the edited text explaining the reasoning, like a careful colleague would.
 - word_run_code executes raw Office.js for anything the typed tools cannot do (formatting, styles, tables, headers/footers, sections). Prefer the typed tools when they fit; keep snippets small and return a compact summary.
 - If a tool answers "No Office pane is connected", tell the user to open the LegalWork pane in Word and retry.`;
@@ -185,7 +189,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_replace_text: {
       description:
-        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text.",
+        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text. On Word versions without WordApi 1.4 the edit still applies but untracked — the result flags trackedChange: false and you must tell the user what changed.",
       args: replaceArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = replaceArgs.parse(rawArgs);
@@ -194,7 +198,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_insert_text: {
       description:
-        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text.",
+        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text. On Word versions without WordApi 1.4 the insert still applies but untracked — the result flags trackedChange: false and you must tell the user what changed.",
       args: insertArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = insertArgs.parse(rawArgs);
@@ -206,7 +210,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_add_comment: {
       description:
-        "Attach a Word comment to exact text in the document, e.g. to explain the rationale for a tracked change you just made.",
+        "Attach a Word comment to exact text in the document, e.g. to explain the rationale for a tracked change you just made. Unavailable on Word versions without WordApi 1.4 — put the rationale in the chat reply instead.",
       args: commentArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = commentArgs.parse(rawArgs);
@@ -215,7 +219,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_run_code: {
       description:
-        "Escape hatch: run Office.js (Word JavaScript API) code against the open document for anything the typed word_* tools cannot do — character formatting (bold, fonts, colors, highlights), paragraph styles (headings, quotes), tables, headers/footers, sections, lists, page setup. Change tracking is forced on, so document edits appear as reviewable redlines. Errors return the Office.js debugInfo so you can fix the snippet and retry. Prefer the typed tools when they fit.",
+        "Escape hatch: run Office.js (Word JavaScript API) code against the open document for anything the typed word_* tools cannot do — character formatting (bold, fonts, colors, highlights), paragraph styles (headings, quotes), tables, headers/footers, sections, lists, page setup. Change tracking is forced on when the Word version supports it, so document edits appear as reviewable redlines; otherwise the result flags trackedChanges: false and you must tell the user what changed. Errors return the Office.js debugInfo so you can fix the snippet and retry. Prefer the typed tools when they fit.",
       args: runCodeArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = runCodeArgs.parse(rawArgs);

--- a/apps/server/src/opencode-plugins/legalwork-word-tools.ts
+++ b/apps/server/src/opencode-plugins/legalwork-word-tools.ts
@@ -16,8 +16,10 @@ import {
  * All mutating tools force Word's change tracking on, so every agent edit
  * shows up as a native tracked change the user can accept or reject. On
  * outdated Word versions that cannot control tracking (no WordApi 1.4),
- * edits still apply but come back flagged trackedChange: false with a
- * warning the agent must relay; comments are unavailable there.
+ * typed edits are synthesized as OOXML revision markup (still real,
+ * accept/rejectable redlines); only if that fails does an edit apply
+ * untracked, flagged trackedChange: false with a warning the agent must
+ * relay. Comments are unavailable there.
  */
 
 const WORD_TOOL_RULES = `Rules for word_* tools:
@@ -188,7 +190,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_replace_text: {
       description:
-        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text. On Word versions without WordApi 1.4 the edit applies untracked and the result says so.",
+        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text.",
       args: replaceArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = replaceArgs.parse(rawArgs);
@@ -197,7 +199,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_insert_text: {
       description:
-        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text. On Word versions without WordApi 1.4 the insert applies untracked and the result says so.",
+        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text.",
       args: insertArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = insertArgs.parse(rawArgs);

--- a/apps/server/src/opencode-plugins/legalwork-word-tools.ts
+++ b/apps/server/src/opencode-plugins/legalwork-word-tools.ts
@@ -23,8 +23,7 @@ import {
 const WORD_TOOL_RULES = `Rules for word_* tools:
 - Call word_read_document before editing so anchors are exact.
 - Anchors are short snippets (under 200 characters) copied VERBATIM from the document — including punctuation and casing. Prefer distinctive phrases; if an anchor matches several places, the tool reports the count and you must pass "occurrence".
-- Every edit is normally applied as a tracked change (redline). Never claim you changed text silently; the user reviews and accepts each change in Word.
-- On outdated Word versions (no WordApi 1.4) edit results say trackedChange: false with a warning: the edit WAS applied, just without tracked changes. Do not refuse to edit and do not claim the tools are unavailable — make the edits, then tell the user exactly what changed (they can undo with Ctrl/Cmd+Z) and that updating Word/Microsoft 365 restores native redlines. word_add_comment is unavailable there; put the rationale in the chat instead.
+- Every edit is normally applied as a tracked change (redline). Never claim you changed text silently; the user reviews and accepts each change in Word. If an edit result carries trackedChange: false with a warning, follow that warning.
 - After substantive edits, add a short word_add_comment on the edited text explaining the reasoning, like a careful colleague would.
 - word_run_code executes raw Office.js for anything the typed tools cannot do (formatting, styles, tables, headers/footers, sections). Prefer the typed tools when they fit; keep snippets small and return a compact summary.
 - If a tool answers "No Office pane is connected", tell the user to open the LegalWork pane in Word and retry.`;
@@ -189,7 +188,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_replace_text: {
       description:
-        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text. On Word versions without WordApi 1.4 the edit still applies but untracked — the result flags trackedChange: false and you must tell the user what changed.",
+        "Replace exact text in the Word document as a tracked change (redline). The anchor must be copied verbatim from the document. If the anchor matches multiple places, the tool reports the count and you must pass occurrence. An empty replacement deletes the text. On Word versions without WordApi 1.4 the edit applies untracked and the result says so.",
       args: replaceArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = replaceArgs.parse(rawArgs);
@@ -198,7 +197,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_insert_text: {
       description:
-        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text. On Word versions without WordApi 1.4 the insert still applies but untracked — the result flags trackedChange: false and you must tell the user what changed.",
+        "Insert text into the Word document as a tracked change — at the start/end of the document, or before/after an exact anchor text. On Word versions without WordApi 1.4 the insert applies untracked and the result says so.",
       args: insertArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = insertArgs.parse(rawArgs);
@@ -219,7 +218,7 @@ export const LegalWorkWordTools = async (pluginInput?: { directory?: string }) =
     },
     word_run_code: {
       description:
-        "Escape hatch: run Office.js (Word JavaScript API) code against the open document for anything the typed word_* tools cannot do — character formatting (bold, fonts, colors, highlights), paragraph styles (headings, quotes), tables, headers/footers, sections, lists, page setup. Change tracking is forced on when the Word version supports it, so document edits appear as reviewable redlines; otherwise the result flags trackedChanges: false and you must tell the user what changed. Errors return the Office.js debugInfo so you can fix the snippet and retry. Prefer the typed tools when they fit.",
+        "Escape hatch: run Office.js (Word JavaScript API) code against the open document for anything the typed word_* tools cannot do — character formatting (bold, fonts, colors, highlights), paragraph styles (headings, quotes), tables, headers/footers, sections, lists, page setup. Change tracking is forced on when the Word version supports it, so document edits appear as reviewable redlines; otherwise the result flags trackedChanges: false. Errors return the Office.js debugInfo so you can fix the snippet and retry. Prefer the typed tools when they fit.",
       args: runCodeArgs.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const args = runCodeArgs.parse(rawArgs);

--- a/docs/word-addin.md
+++ b/docs/word-addin.md
@@ -183,12 +183,16 @@ through Office.js and posts the result back. Edits are anchor-based (exact
 text snippets, not offsets) and run with Word change tracking forced to
 `TrackAll`, so every agent edit is a native redline the user accepts or
 rejects in Word. On Word versions without WordApi 1.4 (change-tracking
-control), edits still apply but come back flagged `trackedChange: false`
-with a warning (including the detected Office build) that instructs the
-agent to spell out exactly what changed and to suggest updating Word;
-comments are unavailable there and fail with the same diagnostic. When no
-pane is connected the tools return a clear error and the agent tells the
-user to open the pane.
+control), typed edits are synthesized as OOXML `w:ins`/`w:del` revision
+markup via `insertOoxml` (WordApi 1.1) — still real, accept/rejectable
+redlines, attributed to author "LegalWork". Only if the host rejects that
+package does the edit apply untracked, flagged `trackedChange: false` with
+a warning (including the detected Office build) that instructs the agent
+to spell out exactly what changed and to suggest updating Word. Comments
+and `word_run_code` tracking are unavailable below 1.4: comments fail with
+a diagnostic, and `word_run_code` results flag `trackedChanges: false`.
+When no pane is connected the tools return a clear error and the agent
+tells the user to open the pane.
 
 ## Security notes
 

--- a/docs/word-addin.md
+++ b/docs/word-addin.md
@@ -183,9 +183,12 @@ through Office.js and posts the result back. Edits are anchor-based (exact
 text snippets, not offsets) and run with Word change tracking forced to
 `TrackAll`, so every agent edit is a native redline the user accepts or
 rejects in Word. On Word versions without WordApi 1.4 (change-tracking
-control), edits are refused rather than applied silently. When no pane is
-connected the tools return a clear error and the agent tells the user to
-open the pane.
+control), edits still apply but come back flagged `trackedChange: false`
+with a warning (including the detected Office build) that instructs the
+agent to spell out exactly what changed and to suggest updating Word;
+comments are unavailable there and fail with the same diagnostic. When no
+pane is connected the tools return a clear error and the agent tells the
+user to open the pane.
 
 ## Security notes
 


### PR DESCRIPTION
## Summary
- **Synthesized redlines below WordApi 1.4:** the typed edit tools (`word_replace_text`, `word_insert_text`) now build a single-paragraph Flat OPC package with `w:ins`/`w:del` revision runs (author "LegalWork") and splice it in via `insertOoxml` (WordApi 1.1). Word treats that markup as *real* tracked changes — visible in the Review ribbon, accept/rejectable — so the redline contract holds even on hosts that cannot control change tracking. Tested by `apps/app/tests/word-revision-ooxml.test.ts`.
- **Edit ladder:** native forced `TrackAll` (WordApi 1.4) → synthesized revision markup (result reports `method: "revision-markup"`) → plain untracked edit *only* if the host rejects the package, flagged `trackedChange: false` with a warning instructing the agent to spell out exactly what changed (undo via Ctrl/Cmd+Z) and suggest updating Word. Previously the add-in refused all edits below 1.4, so the agent told users the tools were broken.
- **Guidance rides on the fallback, not the system prompt:** system rules and tool descriptions stay neutral; the disclose-to-the-user instruction only appears in tool results when a fallback actually triggered — no nagging on modern Word, agent knows exactly what it did in the moment.
- **Diagnostics:** `wordApiDiagnostic()` / `highestWordApiVersion()` in `office.ts` (backed by `Office.context.diagnostics`) append the detected Office build, platform, and highest supported WordApi set to every warning/error; `word_read_document` reports `trackedEditingSupported: false` plus the same diagnostic — so support can read the customer's situation straight from the agent transcript.
- Still 1.4-gated (no API below that): `word_add_comment` (error now says to put the rationale in the chat) and tracking for `word_run_code` (arbitrary code can't be synthesized; result flags `trackedChanges: false`).
- `docs/word-addin.md` updated to match.

## Why
- A customer on an outdated Word hit the WordApi 1.4 gate and their agent reported it couldn't edit at all — even though only tracked-changes control and comments were missing. The agent should keep producing reviewable redlines where possible, degrade transparently where not, and the transcript should tell support whether the fix is a Microsoft 365 update or a perpetual-license (2019/2021) upgrade.

## Issue
- Linear: [EIG-73 — Word API version fallback and capability detection](https://linear.app/eigenweltlabs/issue/EIG-73/word-api-version-fallback-and-capability-detection)

## Scope
- `apps/app/src/word-addin/office.ts`: `diagnostics` typing, `insertOoxml` typings, `highestWordApiVersion()`, `wordApiDiagnostic()`, `untrackedEditWarning()`
- `apps/app/src/word-addin/word-document-tools.ts`: `revisionOoxml()` builder (Flat OPC, `w:ins`/`w:del`), `applyTracked()` ladder, results carry `trackedChange`/`method`/`warning`; `word_read_document` gains `trackedEditingSupported` + warning; comment error reworded
- `apps/app/src/word-addin/office-run-code.ts`: `word_run_code` runs untracked below 1.4, result flags `trackedChanges: false` + warning
- `apps/app/tests/word-revision-ooxml.test.ts`: new unit tests for the OOXML builder (escaping, del+ins ordering, pure deletion, line breaks, Flat OPC shape, unique revision ids)
- `apps/server/src/opencode-plugins/legalwork-word-tools.ts`: neutral wording; fallback noted factually
- `docs/word-addin.md`

## Out of scope
- Synthesized comments below WordApi 1.4 (would require merging a comments part via Flat OPC — unreliable)
- Pane→server capability reporting (e.g. conditional system-prompt note for affected hosts) — possible follow-up under EIG-73
- Any change to behavior on WordApi 1.4+ hosts — tracking is still forced to `TrackAll` there

## Testing
### Ran
- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter @legalwork/app build:word-addin`
- `bun test tests/word-revision-ooxml.test.ts` (apps/app)
- `bun test src/opencode-plugins/legalwork-word-tools.test.ts` (apps/server)

### Result
- pass/fail: pass (all)

## CI status
- pass: pending (draft, opened from remote session)
- code-related failures: none known
- external/env/auth blockers: none

## Manual verification
1. Open the pane in a Word build without WordApi 1.4 (e.g. Word 2019/2021 perpetual).
2. Ask the agent to replace text → the change appears as a normal tracked change by author "LegalWork" in the Review ribbon; accept and reject both work; the tool result shows `trackedChange: true, method: "revision-markup"`.
3. Same for inserts (start/end/before/after anchor); a replace shows old text struck through followed by the insertion.
4. `word_add_comment` fails with the comments-unavailable message; `word_read_document` returns `trackedEditingSupported: false` + warning with the detected Office build.
5. On a current Microsoft 365 build everything behaves exactly as before (forced `TrackAll`, `trackedChange: true`, no `method`/`warning` fields, no extra prompt text).

## Evidence
- N/A so far — the revision-markup path needs a manual check on a real pre-1.4 Word build (see Manual verification); unit tests cover the generated OOXML.

## Risk
- Medium: the revision-markup path inserts hand-built OOXML; a malformed or host-rejected package falls through to a disclosed untracked edit rather than failing the tool. Inserted runs take paragraph default formatting rather than inheriting the neighboring run's direct formatting (native-tracking path unaffected). Unchanged behavior on any host with WordApi 1.4.

## Rollback
- Revert the four commits (`c2e3fdd`, `76ae3b8`, `85eb9ec`, `eb25bc8`); no data or config migration involved.