### PR TITLE
fix: repair stray .opencode file breaking workspaces, isolate engine DB, make error toasts dismissable

### DIFF
--- a/apps/app/src/components/ui/sonner.tsx
+++ b/apps/app/src/components/ui/sonner.tsx
@@ -208,7 +208,14 @@ function showToast(type: ToastType, message: React.ReactNode, options?: ToastOpt
       />
     ),
     {
-      id: options?.id,
+      // Never pass an explicit `id: undefined`: sonner's custom() builds
+      // `{ jsx: jsx(generatedId), id: generatedId, ...data }`, so a literal
+      // undefined id in `data` clobbers the generated one and create() then
+      // mints a DIFFERENT id for the stored toast. The X button (and any
+      // toast.dismiss(returnedId)) would target the id the JSX captured,
+      // match nothing, and the toast becomes undismissable — invisible for
+      // auto-closing toasts, permanent for `duration: Infinity` error toasts.
+      ...(options?.id !== undefined ? { id: options.id } : {}),
       duration: options?.duration,
       description: undefined,
       action: undefined,

--- a/apps/app/tests/sonner-toast-dismiss.test.ts
+++ b/apps/app/tests/sonner-toast-dismiss.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { toast as sonnerToast } from "sonner";
+
+import { toast } from "../src/components/ui/sonner";
+
+// sonner's Observer notifies subscribers via requestAnimationFrame, which bun's
+// test runtime doesn't provide. The assertions below only rely on synchronous
+// Observer state (toasts + dismissedToasts), but dismiss() still calls rAF.
+if (typeof globalThis.requestAnimationFrame === "undefined") {
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+    setTimeout(() => callback(0), 0) as unknown as number) as typeof requestAnimationFrame;
+}
+
+describe("sonner toast wrapper", () => {
+  test("the stored toast carries the id the wrapper returns (X button can dismiss it)", () => {
+    // Regression: passing a literal `id: undefined` through to sonner's
+    // custom() clobbered the generated id (`{jsx: jsx(id), id, ...data}`), so
+    // the stored toast got a different id than the one the ToastCard's X
+    // button dismisses. Error toasts with duration: Infinity then could never
+    // be closed (issue #62, "clicking the X icon does nothing").
+    const returned = toast.error("OpenCode unavailable", {
+      description: "engine down",
+      action: { label: "Retry", onClick: () => {} },
+      duration: Infinity,
+    });
+
+    const active = sonnerToast.getToasts();
+    expect(active.some((entry) => entry.id === returned)).toBe(true);
+
+    sonnerToast.dismiss(returned);
+    expect(sonnerToast.getToasts().some((entry) => entry.id === returned)).toBe(false);
+  });
+
+  test("an explicit toast id is preserved", () => {
+    const returned = toast("summary", { id: "legalwork-notification-alert" });
+    expect(returned).toBe("legalwork-notification-alert");
+    expect(sonnerToast.getToasts().some((entry) => entry.id === returned)).toBe(true);
+    sonnerToast.dismiss(returned);
+    expect(sonnerToast.getToasts().some((entry) => entry.id === returned)).toBe(false);
+  });
+});

--- a/apps/desktop/electron/opencode-state-dir.mjs
+++ b/apps/desktop/electron/opencode-state-dir.mjs
@@ -1,0 +1,66 @@
+import { existsSync } from "node:fs";
+import { lstat, mkdir, rename } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Guarantee `<workspace>/.opencode` is a usable directory before the engine
+ * boots.
+ *
+ * The engine creates that directory during instance bootstrap. `mkdir`
+ * tolerates an existing *directory* but throws EEXIST when the name is taken
+ * by a *file*, and the engine does not catch it — instance bootstrap aborts
+ * and then every route for that workspace answers 500 `UnknownError`, which
+ * the app shows as "Failed to load providers" and "OpenCode is unavailable for
+ * this workspace" (issue #62). The engine also caches the failed instance, so
+ * the repair has to happen before it spawns.
+ *
+ * The stray entry is renamed aside, never deleted — it is user data we did not
+ * write, and its contents are the only clue to how it got there.
+ *
+ * Mirrors apps/server/src/opencode-state-dir.ts (separate package, no shared
+ * module) — keep the two in sync.
+ */
+export async function ensureOpencodeStateDir(workspaceRoot, now = Date.now()) {
+  const statePath = path.join(workspaceRoot, ".opencode");
+  let movedTo = null;
+
+  // lstat, not stat: a symlink to a file (or to nothing) breaks the engine's
+  // mkdir the same way, and following it would misreport that.
+  let entry = null;
+  try {
+    entry = await lstat(statePath);
+  } catch {
+    entry = null;
+  }
+
+  if (entry && !entry.isDirectory()) {
+    const base = `${statePath}.invalid-${now}`;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const candidate = attempt === 0 ? base : `${base}-${attempt}`;
+      if (existsSync(candidate)) continue;
+      movedTo = candidate;
+      break;
+    }
+    if (!movedTo) {
+      throw new Error(`Unable to reserve a backup path for ${statePath}`);
+    }
+    try {
+      await rename(statePath, movedTo);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${statePath} must be a folder, but a file is in its place and it could not be moved aside (${reason}). ` +
+          `Rename or remove that file, then restart LegalWork.`,
+      );
+    }
+  }
+
+  try {
+    await mkdir(statePath, { recursive: true });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not create the folder ${statePath} (${reason}).`);
+  }
+
+  return { path: statePath, movedTo };
+}

--- a/apps/desktop/electron/opencode-state-dir.test.mjs
+++ b/apps/desktop/electron/opencode-state-dir.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { ensureOpencodeStateDir } from "./opencode-state-dir.mjs";
+
+async function workspace() {
+  return mkdtemp(path.join(tmpdir(), "legalwork-state-dir-"));
+}
+
+test("creates .opencode when it is missing", async () => {
+  const root = await workspace();
+  const result = await ensureOpencodeStateDir(root);
+
+  assert.equal(result.path, path.join(root, ".opencode"));
+  assert.equal(result.movedTo, null);
+  assert.equal((await lstat(result.path)).isDirectory(), true);
+});
+
+test("leaves an existing .opencode directory and its contents alone", async () => {
+  const root = await workspace();
+  await mkdir(path.join(root, ".opencode"), { recursive: true });
+  await writeFile(path.join(root, ".opencode", "legalwork.json"), '{"keep":true}\n', "utf8");
+
+  const result = await ensureOpencodeStateDir(root);
+
+  assert.equal(result.movedTo, null);
+  assert.equal(await readFile(path.join(root, ".opencode", "legalwork.json"), "utf8"), '{"keep":true}\n');
+});
+
+// The issue #62 shape: the engine's instance bootstrap runs mkdir(.opencode),
+// which throws EEXIST on a file, aborting bootstrap so every route for that
+// workspace answers 500.
+test("moves a stray .opencode FILE aside and creates the directory", async () => {
+  const root = await workspace();
+  await writeFile(path.join(root, ".opencode"), "stray\n", "utf8");
+
+  const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+  assert.equal(result.movedTo, path.join(root, ".opencode.invalid-1700000000000"));
+  assert.equal((await lstat(result.path)).isDirectory(), true);
+  // Never destroy user data we did not write.
+  assert.equal(await readFile(result.movedTo, "utf8"), "stray\n");
+});
+
+test("moves a .opencode symlink aside (it breaks the engine the same way)", async () => {
+  const root = await workspace();
+  await writeFile(path.join(root, "target.txt"), "x\n", "utf8");
+  await symlink(path.join(root, "target.txt"), path.join(root, ".opencode"));
+
+  const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+  assert.equal(result.movedTo, path.join(root, ".opencode.invalid-1700000000000"));
+  assert.equal((await lstat(result.path)).isDirectory(), true);
+});
+
+test("does not overwrite an existing backup from a previous repair", async () => {
+  const root = await workspace();
+  await writeFile(path.join(root, ".opencode"), "second\n", "utf8");
+  await writeFile(path.join(root, ".opencode.invalid-1700000000000"), "first\n", "utf8");
+
+  const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+  assert.equal(result.movedTo, path.join(root, ".opencode.invalid-1700000000000-1"));
+  assert.equal(await readFile(path.join(root, ".opencode.invalid-1700000000000"), "utf8"), "first\n");
+  assert.equal(await readFile(result.movedTo, "utf8"), "second\n");
+});
+
+test("is idempotent across repeated runs", async () => {
+  const root = await workspace();
+  await writeFile(path.join(root, ".opencode"), "stray\n", "utf8");
+
+  await ensureOpencodeStateDir(root, 1700000000000);
+  const second = await ensureOpencodeStateDir(root, 1700000000001);
+
+  assert.equal(second.movedTo, null);
+  assert.equal((await lstat(second.path)).isDirectory(), true);
+});

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { pathToFileURL } from "node:url";
 
 import { createOfficeAddinManager } from "./office-addin-manager.mjs";
+import { ensureOpencodeStateDir } from "./opencode-state-dir.mjs";
 
 const __runtimeDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -258,6 +259,7 @@ async function fileExists(targetPath) {
     return false;
   }
 }
+
 
 async function readJsonFile(targetPath, fallback) {
   try {
@@ -1211,6 +1213,18 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function ensureOpencodeConfig(projectDir) {
+    // First, and regardless of which config wins below: the engine needs
+    // .opencode to be a directory or its instance bootstrap dies, taking every
+    // route for this workspace with it (issue #62). This must run before the
+    // early return — a workspace with a root-level config would otherwise skip
+    // the check entirely and still fail to start.
+    const stateDir = await ensureOpencodeStateDir(projectDir);
+    if (stateDir.movedTo) {
+      console.warn(
+        `[runtime] ${stateDir.path} was a file, not a folder; moved it to ${stateDir.movedTo} so OpenCode can start.`,
+      );
+    }
+
     // Seed the project config in the hidden .opencode/ directory (the engine
     // reads it from there too) so the user's workspace folder stays free of
     // files they didn't create. A config the user already keeps at the

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { legalworkWorkspaceDisplayName, selectLegalworkWorkspaceForConnection } from "./remote-workspace.mjs";
+import { ensureOpencodeStateDir } from "./opencode-state-dir.mjs";
 import { exportWorkspaceConfig, importWorkspaceConfig } from "./workspace-archive.mjs";
 
 const EMPTY_WORKSPACE_LIST = Object.freeze({
@@ -485,7 +486,9 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
 
   async function writeWorkspaceLegalworkConfig(workspacePath, config) {
     const legalworkPath = path.join(workspacePath, ".opencode", "legalwork.json");
-    await mkdir(path.dirname(legalworkPath), { recursive: true });
+    // A stray file named .opencode makes this mkdir throw EEXIST (and breaks
+    // the engine the same way) — repair it rather than failing the write.
+    await ensureOpencodeStateDir(workspacePath);
     await writeFile(legalworkPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
     return execResult(true, `Wrote ${legalworkPath}`);
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,7 @@
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
     "build:audiotap": "node ./scripts/build-audiotap.mjs",
     "build:key-monitor": "node ./scripts/build-key-monitor.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs",
+    "test": "node --test electron/runtime.test.mjs electron/opencode-state-dir.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs",
     "office:sideload": "node ./scripts/office-addin-sideload.mjs"
   },
   "dependencies": {

--- a/apps/server/src/benchmarks.e2e.test.ts
+++ b/apps/server/src/benchmarks.e2e.test.ts
@@ -13,6 +13,10 @@ const roots: string[] = [];
 const ENV_KEYS = [
   "LEGALWORK_BENCHMARKS_DB",
   "LEGALWORK_BENCHMARKS_DIR",
+  // startLegalworkServer() sets this too; without it here the afterEach never
+  // restores it and every later test file inherits a runtime-DB path pointing
+  // into this suite's (already deleted) temp root.
+  "LEGALWORK_RUNTIME_DB",
   "LEGALWORK_GITHUB_API_BASE",
   "LEGALWORK_GITHUB_RAW_BASE",
   "LEGALWORK_BENCHMARK_POLL_MS",

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -7,6 +7,7 @@ import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./manag
 import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { keepLegalworkRuntimeConfigFileFresh, writeLegalworkRuntimeConfigFile } from "./legalwork-runtime-config.js";
+import { prepareManagedOpencodeEngineDb } from "./managed-opencode-db.js";
 import { refreshEigenweltFreeManifest } from "./eigenwelt-free.js";
 import { refreshEigenweltProviderModels } from "./eigenwelt-auth.js";
 import pkg from "../package.json" with { type: "json" };
@@ -53,6 +54,11 @@ if (!config.opencodeBaseUrl && process.env.LEGALWORK_MANAGE_OPENCODE === "1") {
     void refreshEigenweltProviderModels(config, workspace.id);
     const managedOpencodeCwd = process.env.LEGALWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
+    // Private engine DB (see managed-opencode-db.ts): keep the managed engine
+    // off OpenCode's global opencode.db so a separately installed OpenCode
+    // can never migrate the engine's schema out from under it (issue #62).
+    const managedDb = await prepareManagedOpencodeEngineDb(config);
+    if (managedDb) process.env.OPENCODE_DB = managedDb.path;
     managedOpencode = await createManagedOpencodeServer({
       bin: process.env.LEGALWORK_OPENCODE_BIN,
       cwd: managedOpencodeCwd,
@@ -63,6 +69,7 @@ if (!config.opencodeBaseUrl && process.env.LEGALWORK_MANAGE_OPENCODE === "1") {
         LEGALWORK_SERVER_URL: serverUrl,
         LEGALWORK_SERVER_TOKEN: config.token,
         OPENCODE_CONFIG: runtimeConfigPath,
+        ...(managedDb ? { OPENCODE_DB: managedDb.path } : {}),
       },
     });
     config.opencodeBaseUrl = managedOpencode.url;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -11,6 +11,7 @@ import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeE
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { keepLegalworkRuntimeConfigFileFresh, writeLegalworkRuntimeConfigFile } from "./legalwork-runtime-config.js";
+import { prepareManagedOpencodeEngineDb } from "./managed-opencode-db.js";
 import { readCachedEigenweltFreeManifest, refreshEigenweltFreeManifest } from "./eigenwelt-free.js";
 import { refreshEigenweltPaidManifest } from "./eigenwelt-paid-manifest.js";
 import type { ServeResult } from "./serve-node.js";
@@ -103,6 +104,15 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         || workspace.path;
       await mkdir(cwd, { recursive: true });
 
+      // Private engine DB: never share OpenCode's global opencode.db with a
+      // separately installed OpenCode — a newer install migrates it to a
+      // schema the pinned sidecar can't open, which kills provider listing,
+      // MCP connect, and session create (issue #62). Also exported to
+      // process.env so server-side direct DB access (opencode-db.ts) targets
+      // the same file the engine writes.
+      const managedDb = await prepareManagedOpencodeEngineDb(config);
+      if (managedDb) process.env.OPENCODE_DB = managedDb.path;
+
       managedOpencode = await createManagedOpencodeServer({
         bin: options.opencodeBin || process.env.LEGALWORK_OPENCODE_BIN,
         cwd,
@@ -114,6 +124,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
           LEGALWORK_SERVER_TOKEN: config.token,
           OPENCODE_CONFIG: runtimeConfigPath,
           OPENCODE_MODELS_URL: opencodeModelsUrl,
+          ...(managedDb ? { OPENCODE_DB: managedDb.path } : {}),
         },
       });
 

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -48,9 +48,12 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   config.pickDirectory = options.pickDirectory ?? null;
   config.recorder = options.recorder ?? null;
   const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${config.port}`;
+  // No trailing slash: the engine appends "/api.json" to this value, so a
+  // trailing slash produces the malformed "https://…com//api.json" seen in
+  // user-reported engine logs.
   const opencodeModelsUrl = process.env.LEGALWORK_DEV_MODE === "1"
     ? "http://localhost:8791/models"
-    : "https://models.eigenweltlabs.com/";
+    : "https://models.eigenweltlabs.com";
 
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
   let managedOpencode: ManagedOpencodeServer | null = null;

--- a/apps/server/src/managed-opencode-db.test.ts
+++ b/apps/server/src/managed-opencode-db.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -42,12 +42,24 @@ function testConfig(): ServerConfig {
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "legalwork-managed-db-"));
-  for (const key of ["OPENCODE_DB", "LEGALWORK_DEV_MODE", "XDG_DATA_HOME", "LEGALWORK_DATA_DIR"]) {
+  for (const key of [
+    "OPENCODE_DB",
+    "LEGALWORK_DEV_MODE",
+    "XDG_DATA_HOME",
+    "LEGALWORK_DATA_DIR",
+    "LEGALWORK_RUNTIME_DB",
+  ]) {
     savedEnv[key] = process.env[key];
     delete process.env[key];
   }
   // Point the shared-DB discovery at an isolated location.
   process.env.XDG_DATA_HOME = join(root, "xdg-data");
+  // runtimeStorageDir() prefers LEGALWORK_RUNTIME_DB over the config path, and
+  // sibling suites set it, so pin it inside this test's temp root. Without
+  // this the private DB lands in whatever directory leaked in — shared across
+  // these tests — and a DB written by one test makes the next one take the
+  // "private DB already exists" early return.
+  process.env.LEGALWORK_RUNTIME_DB = join(root, "config", "runtime.sqlite");
 });
 
 afterEach(() => {
@@ -64,8 +76,6 @@ function sharedDbPath(): string {
 }
 
 function ensureSharedDbDir(): void {
-  // mkdir -p for the shared dir
-  const { mkdirSync } = require("node:fs") as typeof import("node:fs");
   mkdirSync(join(root, "xdg-data", "opencode"), { recursive: true });
 }
 

--- a/apps/server/src/managed-opencode-db.test.ts
+++ b/apps/server/src/managed-opencode-db.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Database } from "bun:sqlite";
+
+import {
+  MANAGED_ENGINE_DB_FILENAME,
+  PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP,
+  classifySharedOpencodeDb,
+  prepareManagedOpencodeEngineDb,
+} from "./managed-opencode-db.js";
+import type { ServerConfig } from "./types.js";
+
+let root: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+function createDb(path: string, setup: (db: Database) => void): void {
+  const db = new Database(path, { create: true });
+  try {
+    setup(db);
+  } finally {
+    db.close();
+  }
+}
+
+function createEngineStyleDb(path: string, migrationIds: string[]): void {
+  createDb(path, (db) => {
+    db.exec("CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER)");
+    db.exec("CREATE TABLE session (id TEXT PRIMARY KEY, data TEXT)");
+    const insert = db.query("INSERT INTO migration (id, time_completed) VALUES (?, ?)");
+    for (const id of migrationIds) insert.run(id, Date.now());
+    db.query("INSERT INTO session (id, data) VALUES (?, ?)").run("ses_test", "{}");
+  });
+}
+
+function testConfig(): ServerConfig {
+  // Only configPath is consulted (runtimeStorageDir derives from it).
+  return { configPath: join(root, "config", "server.json") } as unknown as ServerConfig;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "legalwork-managed-db-"));
+  for (const key of ["OPENCODE_DB", "LEGALWORK_DEV_MODE", "XDG_DATA_HOME", "LEGALWORK_DATA_DIR"]) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // Point the shared-DB discovery at an isolated location.
+  process.env.XDG_DATA_HOME = join(root, "xdg-data");
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+function sharedDbPath(): string {
+  const dir = join(root, "xdg-data", "opencode");
+  return join(dir, "opencode.db");
+}
+
+function ensureSharedDbDir(): void {
+  // mkdir -p for the shared dir
+  const { mkdirSync } = require("node:fs") as typeof import("node:fs");
+  mkdirSync(join(root, "xdg-data", "opencode"), { recursive: true });
+}
+
+describe("classifySharedOpencodeDb", () => {
+  test("accepts a DB whose migrations are all known to the pinned engine", async () => {
+    ensureSharedDbDir();
+    createEngineStyleDb(sharedDbPath(), [
+      "20260127222353_familiar_lady_ursula",
+      `${PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP}_simplify_session_input`,
+    ]);
+    expect(await classifySharedOpencodeDb(sharedDbPath())).toBe("compatible");
+  });
+
+  test("rejects a DB migrated by a newer OpenCode", async () => {
+    ensureSharedDbDir();
+    createEngineStyleDb(sharedDbPath(), [
+      `${PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP}_simplify_session_input`,
+      "20990101000000_from_the_future",
+    ]);
+    expect(await classifySharedOpencodeDb(sharedDbPath())).toBe("foreign");
+  });
+
+  test("rejects a non-empty DB with neither migration nor session table", async () => {
+    ensureSharedDbDir();
+    createDb(sharedDbPath(), (db) => {
+      db.exec("CREATE TABLE something_else (id TEXT)");
+    });
+    expect(await classifySharedOpencodeDb(sharedDbPath())).toBe("foreign");
+  });
+
+  test("reports a missing file as unreadable", async () => {
+    expect(await classifySharedOpencodeDb(join(root, "does-not-exist.db"))).toBe("unreadable");
+  });
+});
+
+describe("prepareManagedOpencodeEngineDb", () => {
+  test("seeds the private DB from a compatible shared DB (sessions survive)", async () => {
+    ensureSharedDbDir();
+    createEngineStyleDb(sharedDbPath(), [`${PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP}_simplify_session_input`]);
+
+    const result = await prepareManagedOpencodeEngineDb(testConfig());
+    expect(result).not.toBeNull();
+    expect(result?.path.endsWith(MANAGED_ENGINE_DB_FILENAME)).toBe(true);
+    expect(result?.seededFrom).toBe(sharedDbPath());
+    expect(existsSync(result!.path)).toBe(true);
+
+    const copy = new Database(result!.path, { readonly: true });
+    try {
+      const row = copy.query("SELECT id FROM session").get() as { id?: string };
+      expect(row?.id).toBe("ses_test");
+    } finally {
+      copy.close();
+    }
+  });
+
+  test("does NOT adopt a foreign (newer) shared DB — engine starts fresh", async () => {
+    ensureSharedDbDir();
+    createEngineStyleDb(sharedDbPath(), ["20990101000000_from_the_future"]);
+
+    const result = await prepareManagedOpencodeEngineDb(testConfig());
+    expect(result).not.toBeNull();
+    expect(result?.seededFrom).toBeNull();
+    expect(result?.sharedDbCompatibility).toBe("foreign");
+    // No copy was made; the engine will create the file itself.
+    expect(existsSync(result!.path)).toBe(false);
+  });
+
+  test("returns the existing private DB without touching the shared one", async () => {
+    const first = await prepareManagedOpencodeEngineDb(testConfig());
+    expect(first).not.toBeNull();
+    createDb(first!.path, (db) => db.exec("CREATE TABLE marker (id TEXT)"));
+
+    // A foreign shared DB appearing later must not displace the private DB.
+    ensureSharedDbDir();
+    createEngineStyleDb(sharedDbPath(), ["20990101000000_from_the_future"]);
+
+    const second = await prepareManagedOpencodeEngineDb(testConfig());
+    expect(second?.path).toBe(first!.path);
+    expect(second?.seededFrom).toBeNull();
+    expect(second?.sharedDbCompatibility).toBeNull();
+    const db = new Database(first!.path, { readonly: true });
+    try {
+      expect(db.query("SELECT name FROM sqlite_master WHERE name = 'marker'").get()).toBeTruthy();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("respects an explicit OPENCODE_DB override", async () => {
+    process.env.OPENCODE_DB = join(root, "custom.db");
+    expect(await prepareManagedOpencodeEngineDb(testConfig())).toBeNull();
+  });
+
+  test("stays out of the way in dev mode", async () => {
+    process.env.LEGALWORK_DEV_MODE = "1";
+    expect(await prepareManagedOpencodeEngineDb(testConfig())).toBeNull();
+  });
+});

--- a/apps/server/src/managed-opencode-db.ts
+++ b/apps/server/src/managed-opencode-db.ts
@@ -1,0 +1,179 @@
+/**
+ * Private SQLite database for the managed OpenCode engine.
+ *
+ * By default OpenCode keeps ONE global database (XDG data dir, e.g.
+ * ~/.local/share/opencode/opencode.db — the same dotted path on Windows), so
+ * a LegalWork-managed engine shares it with any OpenCode the user installed
+ * separately. That standalone install is free to run a different release
+ * (the auto-updating desktop app, a canary, an old CLI) and migrate the
+ * shared DB to a schema the pinned sidecar engine has never seen. The pinned
+ * engine then fails on that foreign schema — either at startup ("Database is
+ * not empty and has no session table" -> the engine never comes up, every
+ * task reports "OpenCode is unavailable for this workspace") or lazily on
+ * each request (500 UnknownError "Unexpected server error" on provider
+ * listing, MCP connect, session create). See issue #62.
+ *
+ * The fix: give the managed engine its own DB file under LegalWork's runtime
+ * storage dir, passed via OPENCODE_DB (an absolute path there is used as-is
+ * by the engine). To keep existing users' sessions, the private DB is seeded
+ * once from the shared DB — but only when the shared DB is compatible with
+ * the pinned engine (its migrations are all known to it); a foreign or
+ * unreadable shared DB is left alone and the engine starts fresh.
+ */
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ServerConfig } from "./types.js";
+import { findExistingOpencodeDbPath } from "./opencode-db.js";
+import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
+
+export const MANAGED_ENGINE_DB_FILENAME = "opencode-engine.db";
+
+/**
+ * Timestamp prefix of the newest migration bundled in the pinned engine
+ * (constants.json opencodeVersion). A shared DB containing any migration
+ * NEWER than this was written by a newer OpenCode and must not be adopted.
+ * Update together with constants.json opencodeVersion (list the bundled
+ * migrations by running `strings <opencode binary> | grep -oE
+ * '20[0-9]{12}_[a-z0-9_]+'`).
+ */
+export const PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP = "20260622202450"; // opencode v1.17.18
+
+export type SharedOpencodeDbCompatibility = "compatible" | "foreign" | "unreadable";
+
+// Minimal read surface over bun:sqlite (bun runtime) or node:sqlite (Node /
+// Electron). Same dual-driver approach as runtime-opencode-config-store.ts —
+// better-sqlite3 is not loadable under bun.
+type SqliteReader = {
+  all: (sql: string) => Array<Record<string, unknown>>;
+  run: (sql: string, params: string[]) => void;
+  close: () => void;
+};
+
+async function openSqliteReadonly(path: string): Promise<SqliteReader> {
+  if (typeof process.versions.bun === "string") {
+    const { Database } = await import("bun:sqlite");
+    const db = new Database(path, { readonly: true });
+    return {
+      all: (sql) => db.query(sql).all() as Array<Record<string, unknown>>,
+      run: (sql, params) => {
+        db.query(sql).run(...params);
+      },
+      close: () => db.close(),
+    };
+  }
+  const { DatabaseSync } = await import("node:sqlite");
+  const db = new DatabaseSync(path, { readOnly: true });
+  return {
+    all: (sql) => db.prepare(sql).all() as Array<Record<string, unknown>>,
+    run: (sql, params) => {
+      db.prepare(sql).run(...params);
+    },
+    close: () => db.close(),
+  };
+}
+
+/**
+ * Can the pinned engine safely open this DB? "compatible" means every
+ * migration recorded in it is at or below the pinned engine's newest bundled
+ * migration (or the DB predates the migration table entirely), so the engine
+ * can migrate it forward. Anything newer or structurally unexpected is
+ * "foreign".
+ */
+export async function classifySharedOpencodeDb(
+  path: string,
+  newestLocalMigrationTimestamp: string = PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP,
+): Promise<SharedOpencodeDbCompatibility> {
+  if (!existsSync(path)) return "unreadable";
+  let db: SqliteReader | null = null;
+  try {
+    db = await openSqliteReadonly(path);
+    const tables = new Set(
+      db.all("SELECT name FROM sqlite_master WHERE type = 'table'").map((row) => String(row.name ?? "")),
+    );
+    // A brand-new/empty DB is fine — the engine initializes it from scratch.
+    if (tables.size === 0) return "compatible";
+    if (tables.has("migration")) {
+      for (const row of db.all("SELECT id FROM migration")) {
+        const id = String(row.id ?? "");
+        const timestamp = /^(\d{14})/.exec(id)?.[1];
+        if (!timestamp || timestamp > newestLocalMigrationTimestamp) return "foreign";
+      }
+      return "compatible";
+    }
+    // Pre-migration-table era DBs are upgraded in place by the engine, but it
+    // refuses a non-empty DB without a session table ("Database is not empty
+    // and has no session table").
+    return tables.has("session") ? "compatible" : "foreign";
+  } catch {
+    return "unreadable";
+  } finally {
+    db?.close();
+  }
+}
+
+async function seedPrivateDbFromShared(sharedPath: string, privatePath: string): Promise<boolean> {
+  let db: SqliteReader | null = null;
+  try {
+    // VACUUM INTO takes a consistent snapshot (WAL included) even while the
+    // user's own OpenCode has the shared DB open, and writes a compact copy.
+    db = await openSqliteReadonly(sharedPath);
+    db.run("VACUUM INTO ?", [privatePath]);
+    return true;
+  } catch {
+    // Never leave a partial copy behind — the engine would try to open it.
+    try {
+      rmSync(privatePath, { force: true });
+    } catch {
+      // ignore
+    }
+    return false;
+  } finally {
+    db?.close();
+  }
+}
+
+export type ManagedEngineDb = {
+  /** Absolute path to pass to the engine as OPENCODE_DB. */
+  path: string;
+  /** Shared DB the private one was seeded from on this call, if any. */
+  seededFrom: string | null;
+  /** Why the shared DB was (not) adopted; null when the private DB already existed or no shared DB exists. */
+  sharedDbCompatibility: SharedOpencodeDbCompatibility | null;
+};
+
+/**
+ * Resolve (and on first use seed) the managed engine's private database.
+ * Returns null when the caller should leave OPENCODE_DB handling untouched:
+ * an explicit OPENCODE_DB override is set, dev mode already isolates the
+ * whole OpenCode home, or preparation failed unexpectedly (status quo is
+ * safer than blocking engine startup).
+ */
+export async function prepareManagedOpencodeEngineDb(config: ServerConfig): Promise<ManagedEngineDb | null> {
+  try {
+    if (process.env.OPENCODE_DB?.trim()) return null;
+    if (process.env.LEGALWORK_DEV_MODE === "1") return null;
+
+    const storageDir = runtimeStorageDir(config);
+    mkdirSync(storageDir, { recursive: true });
+    const privatePath = join(storageDir, MANAGED_ENGINE_DB_FILENAME);
+    if (existsSync(privatePath)) {
+      return { path: privatePath, seededFrom: null, sharedDbCompatibility: null };
+    }
+
+    const sharedPath = findExistingOpencodeDbPath();
+    if (!sharedPath) {
+      return { path: privatePath, seededFrom: null, sharedDbCompatibility: null };
+    }
+
+    const compatibility = await classifySharedOpencodeDb(sharedPath);
+    const seeded = compatibility === "compatible" && (await seedPrivateDbFromShared(sharedPath, privatePath));
+    return {
+      path: privatePath,
+      seededFrom: seeded ? sharedPath : null,
+      sharedDbCompatibility: compatibility,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -94,6 +94,11 @@ export function resolveOpencodeDbPath(): string {
   return candidates[0] ?? join(homedir(), ".local", "share", "opencode", preferredDbNames()[0] ?? "opencode.db");
 }
 
+/** First existing OpenCode DB on this machine, or null when none exists yet. */
+export function findExistingOpencodeDbPath(): string | null {
+  return candidateOpencodeDbPaths().find((candidate) => existsSync(candidate)) ?? null;
+}
+
 function findOpencodeSessionDbPath(sessionId: string, inputPath?: string): string | null {
   const candidates = (inputPath ? [inputPath] : candidateOpencodeDbPaths()).filter((candidate) => existsSync(candidate));
   for (const dbPath of candidates) {

--- a/apps/server/src/opencode-state-dir.test.ts
+++ b/apps/server/src/opencode-state-dir.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureOpencodeStateDir } from "./opencode-state-dir.js";
+import { exists } from "./utils.js";
+
+async function workspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "legalwork-state-dir-"));
+}
+
+describe("ensureOpencodeStateDir", () => {
+  test("creates .opencode when it is missing", async () => {
+    const root = await workspace();
+    const result = await ensureOpencodeStateDir(root);
+
+    expect(result.path).toBe(join(root, ".opencode"));
+    expect(result.movedTo).toBeNull();
+    expect((await lstat(result.path)).isDirectory()).toBe(true);
+  });
+
+  test("leaves an existing .opencode directory and its contents alone", async () => {
+    const root = await workspace();
+    await mkdir(join(root, ".opencode"), { recursive: true });
+    await writeFile(join(root, ".opencode", "legalwork.json"), '{"keep":true}\n', "utf8");
+
+    const result = await ensureOpencodeStateDir(root);
+
+    expect(result.movedTo).toBeNull();
+    expect(await readFile(join(root, ".opencode", "legalwork.json"), "utf8")).toBe('{"keep":true}\n');
+  });
+
+  test("moves a stray .opencode FILE aside and creates the directory", async () => {
+    // The issue #62 shape: the engine's instance bootstrap does mkdir(.opencode),
+    // which throws EEXIST on a file and 500s every route for the workspace.
+    const root = await workspace();
+    await writeFile(join(root, ".opencode"), "stray\n", "utf8");
+
+    const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+    expect(result.movedTo).toBe(join(root, ".opencode.invalid-1700000000000"));
+    expect((await lstat(result.path)).isDirectory()).toBe(true);
+    // Never destroy user data we did not write.
+    expect(await readFile(result.movedTo!, "utf8")).toBe("stray\n");
+  });
+
+  test("moves a .opencode symlink aside (it breaks the engine the same way)", async () => {
+    const root = await workspace();
+    await writeFile(join(root, "target.txt"), "x\n", "utf8");
+    await symlink(join(root, "target.txt"), join(root, ".opencode"));
+
+    const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+    expect(result.movedTo).toBe(join(root, ".opencode.invalid-1700000000000"));
+    expect((await lstat(result.path)).isDirectory()).toBe(true);
+  });
+
+  test("does not overwrite an existing backup from a previous repair", async () => {
+    const root = await workspace();
+    await writeFile(join(root, ".opencode"), "second\n", "utf8");
+    await writeFile(join(root, ".opencode.invalid-1700000000000"), "first\n", "utf8");
+
+    const result = await ensureOpencodeStateDir(root, 1700000000000);
+
+    expect(result.movedTo).toBe(join(root, ".opencode.invalid-1700000000000-1"));
+    expect(await readFile(join(root, ".opencode.invalid-1700000000000"), "utf8")).toBe("first\n");
+    expect(await readFile(result.movedTo!, "utf8")).toBe("second\n");
+  });
+
+  test("is idempotent across repeated runs", async () => {
+    const root = await workspace();
+    await writeFile(join(root, ".opencode"), "stray\n", "utf8");
+
+    await ensureOpencodeStateDir(root, 1700000000000);
+    const second = await ensureOpencodeStateDir(root, 1700000000001);
+
+    expect(second.movedTo).toBeNull();
+    expect((await lstat(second.path)).isDirectory()).toBe(true);
+  });
+
+  test("reports the offending path when the stray entry cannot be moved", async () => {
+    const root = await workspace();
+    const statePath = join(root, ".opencode");
+    await writeFile(statePath, "stray\n", "utf8");
+    // A directory already sitting at every candidate backup name makes rename
+    // fail (ENOTDIR/EISDIR), which stands in for the unwritable-folder case.
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const suffix = attempt === 0 ? "" : `-${attempt}`;
+      await mkdir(`${statePath}.invalid-1700000000000${suffix}`, { recursive: true });
+      await writeFile(join(`${statePath}.invalid-1700000000000${suffix}`, "occupied"), "x", "utf8");
+    }
+
+    const promise = ensureOpencodeStateDir(root, 1700000000000);
+    await expect(promise).rejects.toThrow(/\.opencode/);
+    // The stray file is still there for the user to inspect.
+    expect(await exists(statePath)).toBe(true);
+  });
+});

--- a/apps/server/src/opencode-state-dir.ts
+++ b/apps/server/src/opencode-state-dir.ts
@@ -1,0 +1,97 @@
+/**
+ * Guarantees `<workspace>/.opencode` is a usable directory.
+ *
+ * The engine creates that directory during instance bootstrap
+ * (Config.loadInstanceState). `mkdir` tolerates an existing *directory*, but
+ * throws EEXIST when the name is taken by a *file* — and the engine does not
+ * catch it, so instance bootstrap aborts. A failed bootstrap poisons the
+ * whole workspace: every route (provider list, MCP connect, session create)
+ * then answers 500 `UnknownError` with an `err_…` ref, which surfaces in the
+ * app as "Failed to load providers" and "OpenCode is unavailable for this
+ * workspace". Reproduced against the pinned engine binary; see issue #62.
+ *
+ * Two things make this worth repairing rather than reporting:
+ * - LegalWork owns that directory (it stores legalwork.json and the seeded
+ *   opencode.jsonc there), so it cannot simply avoid creating it.
+ * - The engine caches the failed instance, so a workspace stays broken until
+ *   the engine restarts — repairing before the engine spawns is what makes
+ *   the recovery automatic.
+ *
+ * The stray entry is renamed aside, never deleted: it is user data we did not
+ * write, and its contents are the only clue to how it got there.
+ *
+ * apps/desktop/electron/runtime.mjs carries an equivalent implementation for
+ * the Electron main process (separate package, no shared module) — keep the
+ * two in sync.
+ */
+import { lstat, mkdir, rename } from "node:fs/promises";
+import { join } from "node:path";
+
+export const OPENCODE_STATE_DIR_NAME = ".opencode";
+
+export type OpencodeStateDirRepair = {
+  /** Absolute path of the `.opencode` directory. */
+  path: string;
+  /** Where a stray non-directory entry was moved, when one was found. */
+  movedTo: string | null;
+};
+
+/** `<root>/.opencode.invalid-<timestamp>`, with a numeric suffix on collision. */
+async function reserveBackupPath(statePath: string, now: number): Promise<string> {
+  const base = `${statePath}.invalid-${now}`;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const candidate = attempt === 0 ? base : `${base}-${attempt}`;
+    try {
+      await lstat(candidate);
+    } catch {
+      return candidate;
+    }
+  }
+  throw new Error(`Unable to reserve a backup path for ${statePath}`);
+}
+
+/**
+ * Ensure `<workspaceRoot>/.opencode` exists and is a directory, moving a
+ * stray file/symlink of that name aside first. Returns what was done so
+ * callers can log it. Throws only when the directory cannot be established,
+ * with a message naming the path — a silent failure here reappears as an
+ * unexplained 500 from the engine.
+ */
+export async function ensureOpencodeStateDir(
+  workspaceRoot: string,
+  now: number = Date.now(),
+): Promise<OpencodeStateDirRepair> {
+  const statePath = join(workspaceRoot, OPENCODE_STATE_DIR_NAME);
+  let movedTo: string | null = null;
+
+  // lstat, not stat: a symlink pointing at a file (or at nothing) fails the
+  // engine's mkdir the same way, and following it would misreport that.
+  let entry: Awaited<ReturnType<typeof lstat>> | null = null;
+  try {
+    entry = await lstat(statePath);
+  } catch {
+    entry = null;
+  }
+
+  if (entry && !entry.isDirectory()) {
+    movedTo = await reserveBackupPath(statePath, now);
+    try {
+      await rename(statePath, movedTo);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${statePath} must be a folder, but a file is in its place and it could not be moved aside (${reason}). ` +
+          `Rename or remove that file, then restart LegalWork.`,
+      );
+    }
+  }
+
+  try {
+    await mkdir(statePath, { recursive: true });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not create the folder ${statePath} (${reason}).`);
+  }
+
+  return { path: statePath, movedTo };
+}

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -7,6 +7,7 @@ import { ApiError } from "./errors.js";
 import { CORE_OPENCODE_FILES } from "./core-skills.js";
 import { legalworkConfigPath, opencodeConfigPath } from "./workspace-files.js";
 import { readJsoncFile } from "./jsonc.js";
+import { ensureOpencodeStateDir } from "./opencode-state-dir.js";
 import type { ReloadReason } from "./types.js";
 
 // One hash over all bundled-core file contents. Bumps whenever the app ships a new
@@ -107,6 +108,15 @@ export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: s
     throw new ApiError(400, "invalid_workspace_path", "workspace path is required");
   }
   await ensureDir(workspaceRoot);
+  // Before anything writes into .opencode: a stray file of that name makes the
+  // engine's instance bootstrap throw EEXIST, which 500s every route for this
+  // workspace (issue #62).
+  const stateDir = await ensureOpencodeStateDir(workspaceRoot);
+  if (stateDir.movedTo) {
+    console.warn(
+      `[workspace-init] ${stateDir.path} was a file, not a folder; moved it to ${stateDir.movedTo} so OpenCode can start.`,
+    );
+  }
   const reloadReasons = new Set<ReloadReason>();
   if (await ensureOpencodeConfig(workspaceRoot)) reloadReasons.add("config");
   const legalworkConfigChanged = await ensureWorkspaceLegalworkConfig(workspaceRoot, preset);


### PR DESCRIPTION
## Summary
- **Repair a stray `.opencode` file** that prevents the engine from starting a workspace at all — the actual cause of #62. New `ensureOpencodeStateDir` guarantees `<workspace>/.opencode` is a directory, moving a stray file/symlink aside as `.opencode.invalid-<timestamp>`.
- **Give the managed engine a private SQLite DB** (`OPENCODE_DB` → `<runtime storage>/opencode-engine.db`) so it never shares OpenCode's global `opencode.db` with a separately installed OpenCode.
- **Fix the sonner toast wrapper** so the X button (and `toast.dismiss(id)`) actually dismisses toasts.
- Drop a trailing slash from the models URL so the engine stops requesting `…com//api.json`.

## Why
The reporter's engine log shows every `err_…` ref is one failure:

```
PlatformError: AlreadyExists: FileSystem.makeDirectory(<workspace>\.opencode)
  cause: EEXIST: file already exists, mkdir '...\1000-11US-T\.opencode'
  at Config.loadInstanceState → InstanceBootstrap → InstanceStore.boot → Server.listen
```

The engine creates `<workspace>/.opencode` during instance bootstrap. `mkdir` tolerates an existing *directory* but throws `EEXIST` when the name is taken by a **file**, and the engine doesn't catch it — so bootstrap aborts. A failed bootstrap poisons the workspace: every route then answers 500 `UnknownError`, which the app renders as "Failed to load providers", the MCP connect error, and "OpenCode is unavailable for this workspace". Three reported symptoms, one cause.

This supersedes the earlier diagnoses: neither the plugin `file://` URLs (#63, already handled inside the engine) nor the shared database explains it.

Two findings shaped the fix:
- **The engine caches the failed instance.** A poisoned workspace stays broken until the engine restarts — even `/instance/dispose` 500s. So the repair must run *before* the engine spawns.
- **Bumping the pinned engine cannot fix this.** No `mkdir` can create a directory where a file sits. The repair has to be ours.

The other three changes are independent, evidenced fixes: the toast bug is the reporter's "clicking the X does nothing"; the private DB removes a real hazard (they run auto-updating OpenCode **v1.18.4** against our pinned **v1.17.18**, sharing one `opencode.db`); the models URL is visible as `//api.json` in their log.

## Issue
- Closes #62

## Scope
- `apps/server/src/opencode-state-dir.ts` + `apps/desktop/electron/opencode-state-dir.mjs` (new, mirrored across the package boundary): the repair helper.
- Wired into the three places that assume that directory: `runtime.mjs` `ensureOpencodeConfig` (**before** its early return — a workspace with a root-level config would otherwise skip the check and still fail), `workspace-init.ts`, and `workspace-store.mjs`'s `legalwork.json` writer.
- `apps/server/src/managed-opencode-db.ts` (new) + `embedded.ts` / `cli.ts` / `opencode-db.ts`: private engine DB.
- `apps/app/src/components/ui/sonner.tsx`: only pass `id` to sonner when the caller set one.
- Tests: `opencode-state-dir.test.ts` (7), `opencode-state-dir.test.mjs` (6), `managed-opencode-db.test.ts` (9), `sonner-toast-dismiss.test.ts` (2); `benchmarks.e2e.test.ts` env-restore fix.

## Out of scope
- The upstream engine bug itself (one unguarded `mkdir` shouldn't 500 every route for a workspace) — worth reporting separately.
- **Why** the entry was a file on the reporter's machine is still unknown; the repair works regardless of origin, but the answer determines whether it recurs.
- Isolating the rest of the OpenCode home (config, auth.json, plugin cache) — still shared so provider credentials keep working.

## Testing
### Ran
- `cd apps/server && bun test src`
- `cd apps/app && bun test tests/`
- `pnpm --filter @legalwork/desktop test` and `typecheck:electron`
- `pnpm --filter @legalwork/app test:e2e` (against pinned opencode v1.17.18)
- `pnpm typecheck` in `apps/server` and `apps/app`

### Result
- pass/fail: **pass** — server 487, app 194, desktop 86 (2 pre-existing skips), all typechecks clean, e2e exit 0.
- if fail, exact files/errors: n/a

## CI status
- pass: green on the previous head (`79d1533`); re-running on `a0bdf36`
- code-related failures: none
- external/env/auth blockers: none

## Manual verification
Against the **real pinned Windows engine binary** under Wine, matching the reporter's log byte-for-byte (same `hw (chunk-kt6t9jpj.js:71:4288)` frame):

1. `.opencode` as a **file** → `POST /session` returns **500** `UnknownError` + `err_…` ref. Reproduced.
2. `.opencode` as a directory (empty, populated, or a symlink) → **200**. Only a file fails.
3. Ran the real helper against the failing workspace → moved the file to `.opencode.invalid-<ts>`, created the directory, contents preserved.
4. Restarted the engine (what production does anyway, since repair precedes spawn) → `POST /session` **200** and the provider route **200**.
5. DB fix: an `opencode.db` restructured the way a newer OpenCode would → "Database is not empty and has no session table"; with the fix the engine starts on its private DB and both routes return 200.
6. Toast fix: drove the real `<Toaster/>` in headless Chromium — before, the X click leaves the toast; after, it is removed.

## Evidence
- N/A (terminal reproductions above)

## Risk
- The repair renames rather than deletes, so a mis-detection costs a rename, not data. It only triggers when `.opencode` is *not* a directory — the normal path is untouched.
- On machines where the shared DB is foreign, the engine starts with an empty DB, so sessions previously written there aren't listed — accepted cost of not crashing; compatible DBs are copied intact.
- `PINNED_ENGINE_NEWEST_MIGRATION_TIMESTAMP` must be bumped together with `constants.json` `opencodeVersion` (documented at the constant).

## Rollback
- Revert the commits. The repair leaves no lasting state beyond the renamed backup, and the private `opencode-engine.db` is ignored by older builds, which fall back to the shared global DB.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyCs9uPbEcdCucnrwR1auc