### PR TITLE
feat(legalmemory): render cited sources as a source list in chat

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -44,6 +44,7 @@ import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
 import { GlobTool } from "@/components/tools/glob"
 import { GrepTool } from "@/components/tools/grep"
 import { LegalMemoryGraphTool } from "@/components/tools/legalmemory-graph"
+import { LegalMemorySourcesTool } from "@/components/tools/legalmemory-sources"
 import { LspTool } from "@/components/tools/lsp"
 import { QuestionTool } from "@/components/tools/question"
 import { SkillTool } from "@/components/tools/skill"
@@ -82,6 +83,7 @@ import {
   isGlobToolPart,
   isGrepToolPart,
   isLegalMemoryGraphToolPart,
+  isLegalMemorySearchToolPart,
   isLspToolPart,
   isQuestionToolPart,
   isReadToolPart,
@@ -209,6 +211,10 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (isLegalMemoryGraphToolPart(part)) {
     return <LegalMemoryGraphTool part={part} />
+  }
+
+  if (isLegalMemorySearchToolPart(part)) {
+    return <LegalMemorySourcesTool part={part} />
   }
 
   return <Tool toolPart={part} />

--- a/apps/app/src/components/tools/legalmemory-sources.tsx
+++ b/apps/app/src/components/tools/legalmemory-sources.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { FileText, ShieldCheck } from "lucide-react"
+
+import {
+  buildLegalMemoryRefPrompt,
+  LEGALMEMORY_REF_EVENT,
+} from "@/components/markdown/legalmemory-ref"
+import type { LegalMemorySearchToolPart } from "@/lib/build-in-tools"
+import {
+  isAuthoritativeStatus,
+  parseLegalMemorySources,
+  type LegalMemorySource,
+} from "@/lib/legalmemory-sources"
+import { Tool } from "@/components/ui/tool"
+
+interface LegalMemorySourcesToolProps {
+  part: LegalMemorySearchToolPart
+}
+
+/**
+ * The cited sources behind a LegalMemory answer.
+ *
+ * Clicking a row asks the agent to export that document into the workspace and
+ * link it back, the same round-trip a reference chip performs — the app holds no
+ * appliance credentials, so it cannot fetch the original itself.
+ *
+ * The status badge is the point of the row: the index holds drafts, redlines and
+ * superseded originals alongside the operative document, so a source is close to
+ * useless without saying which of those it is.
+ */
+export function LegalMemorySourcesTool({ part }: LegalMemorySourcesToolProps) {
+  if (part.state !== "output-available") {
+    return <Tool toolPart={part} />
+  }
+
+  const parsed = parseLegalMemorySources(part.output)
+  if (!parsed) {
+    return <Tool toolPart={part} />
+  }
+
+  const open = (source: LegalMemorySource) => {
+    window.dispatchEvent(
+      new CustomEvent(LEGALMEMORY_REF_EVENT, {
+        detail: {
+          prompt: buildLegalMemoryRefPrompt({ kind: "document", id: source.documentId }, source.title),
+        },
+      }),
+    )
+  }
+
+  return (
+    <div className="w-full overflow-hidden rounded-xl border border-[var(--lw-border)] bg-[var(--lw-surface)]">
+      <div className="flex items-center gap-2 border-b border-[var(--lw-border-subtle)] px-3 py-2 text-xs font-semibold text-[var(--lw-text-secondary)]">
+        <ShieldCheck className="size-3.5 text-[var(--lw-accent)]" />
+        <span>Sources</span>
+        <span className="ml-auto shrink-0 font-normal">
+          {parsed.sources.length} permission-approved{" "}
+          {parsed.sources.length === 1 ? "document" : "documents"}
+        </span>
+      </div>
+
+      <ul className="divide-y divide-[var(--lw-border-subtle)]">
+        {parsed.sources.map((source) => {
+          const meta = [source.docType, source.system].filter(Boolean).join(" · ")
+          return (
+            <li key={source.documentId}>
+              <button
+                type="button"
+                onClick={() => open(source)}
+                title={`Export "${source.title}" into the workspace`}
+                className="flex w-full items-start gap-2.5 px-3 py-2 text-left transition-colors hover:bg-[var(--lw-surface-hover)]"
+              >
+                <FileText className="mt-0.5 size-4 shrink-0 text-[var(--lw-accent)]" />
+                <span className="min-w-0 flex-1">
+                  <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="truncate text-sm font-medium text-[var(--lw-accent)]">
+                      {source.title}
+                    </span>
+                    {source.versionStatus ? (
+                      <span
+                        className={
+                          isAuthoritativeStatus(source.versionStatus)
+                            ? "shrink-0 rounded-full bg-[var(--lw-success-soft)] px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-[var(--lw-success)]"
+                            : "shrink-0 rounded-full border border-[var(--lw-border)] px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-[var(--lw-text-tertiary)]"
+                        }
+                      >
+                        {source.versionStatus}
+                      </span>
+                    ) : null}
+                  </span>
+                  {meta ? (
+                    <span className="mt-0.5 block truncate text-xs text-[var(--lw-text-secondary)]">
+                      {meta}
+                    </span>
+                  ) : null}
+                  {source.excerpt ? (
+                    <span className="mt-1 line-clamp-2 block text-xs leading-relaxed text-[var(--lw-text-tertiary)]">
+                      {source.excerpt}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/app/src/lib/build-in-tools.ts
+++ b/apps/app/src/lib/build-in-tools.ts
@@ -405,3 +405,17 @@ export function isLegalMemoryGraphToolPart(
 ): part is LegalMemoryGraphToolPart {
   return part.type === "dynamic-tool" && LEGALMEMORY_GRAPH_TOOL.test(part.toolName);
 }
+
+export type LegalMemorySearchInput = { query?: string; matter_id?: string; only_final?: boolean };
+export type LegalMemorySearchToolPart = BuiltInDynamicToolPart<string, LegalMemorySearchInput, unknown>;
+
+/** LegalMemory's two retrieval entry points. Both return ranked hits carrying
+ * the citations the source list is built from. Prefix handling as above. */
+const LEGALMEMORY_SEARCH_TOOL =
+  /^(?:(?:legal[_-]?memory|knowledge[_-]?index)[_-])?search[_-](?:semantic|filter)$/i;
+
+export function isLegalMemorySearchToolPart(
+  part: ToolUIPart | DynamicToolUIPart,
+): part is LegalMemorySearchToolPart {
+  return part.type === "dynamic-tool" && LEGALMEMORY_SEARCH_TOOL.test(part.toolName);
+}

--- a/apps/app/src/lib/legalmemory-sources.ts
+++ b/apps/app/src/lib/legalmemory-sources.ts
@@ -1,0 +1,122 @@
+/**
+ * Source list from a LegalMemory search result.
+ *
+ * `search_semantic` and `search_filter` return ranked hits, each carrying the
+ * document's identity, the version that matched, a passage excerpt, and the
+ * citations that prove the caller was allowed to see it. The transcript showed
+ * that as raw JSON; this turns it into the cited source list an answer should
+ * be read alongside.
+ *
+ * Two things here are deliberate:
+ *
+ *   - The system badge comes from `citations[].source_objects[].connector`,
+ *     the connector the object was actually synced from. It is never guessed
+ *     from a path, so "iManage" on a row means iManage.
+ *   - A hit with no citations is dropped. The appliance's own contract is that
+ *     no factual claim may rest on a result with an empty citations array, so
+ *     rendering one as a source would contradict it.
+ */
+
+export type LegalMemorySource = {
+  documentId: string;
+  title: string;
+  /** Human-readable document type, e.g. "Agreement". */
+  docType?: string;
+  /** Version status as stored, e.g. "executed", "draft". */
+  versionStatus?: string;
+  /** Connector display name, e.g. "iManage", "SharePoint". */
+  system?: string;
+  excerpt?: string;
+};
+
+export type LegalMemorySourceList = {
+  sources: LegalMemorySource[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** MCP hands the renderer serialized tool content; a transport that passes the
+ * raw array through is equally valid, so accept both. */
+function coerceHits(output: unknown): unknown[] | null {
+  if (typeof output === "string") {
+    try {
+      const parsed: unknown = JSON.parse(output);
+      return Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return Array.isArray(output) ? output : null;
+}
+
+/** The connector the first authorized source object was synced from. Falls back
+ * to the provider slug when a firm never named the connector. */
+function systemOf(citations: unknown): string | undefined {
+  if (!Array.isArray(citations)) return undefined;
+  for (const citation of citations) {
+    const record = asRecord(citation);
+    const objects = record && Array.isArray(record.source_objects) ? record.source_objects : [];
+    for (const object of objects) {
+      const connector = asRecord(asRecord(object)?.connector);
+      if (!connector) continue;
+      const name = asString(connector.display_name) ?? asString(connector.provider);
+      if (name) return name;
+    }
+  }
+  return undefined;
+}
+
+function hasCitation(citations: unknown): boolean {
+  return Array.isArray(citations) && citations.length > 0;
+}
+
+/** Collapse a passage to a single readable line. */
+function tidyExcerpt(value: unknown): string | undefined {
+  const text = asString(value);
+  if (!text) return undefined;
+  return text.replace(/\s+/g, " ").trim() || undefined;
+}
+
+export function parseLegalMemorySources(output: unknown): LegalMemorySourceList | null {
+  const hits = coerceHits(output);
+  if (!hits) return null;
+
+  const seen = new Set<string>();
+  const sources: LegalMemorySource[] = [];
+  for (const hit of hits) {
+    const record = asRecord(hit);
+    const documentId = record ? asString(record.document_id) : undefined;
+    if (!record || !documentId) continue;
+    if (!hasCitation(record.citations)) continue;
+    // Chunk-level search returns several hits per document; the source list is
+    // about documents, so the best-ranked hit for each one wins.
+    if (seen.has(documentId)) continue;
+    seen.add(documentId);
+    sources.push({
+      documentId,
+      title: asString(record.title) ?? documentId,
+      docType: asString(record.doc_type_label) ?? asString(record.doc_type),
+      versionStatus: asString(record.version_status),
+      system: systemOf(record.citations),
+      excerpt: tidyExcerpt(record.excerpt),
+    });
+  }
+
+  return sources.length ? { sources } : null;
+}
+
+/** Statuses the appliance treats as an authoritative version. Rendered as a
+ * badge so a draft is never mistaken for the operative document. */
+const FINAL_STATUSES = new Set(["executed", "final", "signed"]);
+
+export function isAuthoritativeStatus(status: string | undefined): boolean {
+  return status ? FINAL_STATUSES.has(status.toLowerCase()) : false;
+}

--- a/apps/app/tests/legalmemory-sources.test.ts
+++ b/apps/app/tests/legalmemory-sources.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { isAuthoritativeStatus, parseLegalMemorySources } from "@/lib/legalmemory-sources";
+import { isLegalMemorySearchToolPart } from "@/lib/build-in-tools";
+
+/** Mirrors RetrievalService search hits (`SearchHit.as_dict`). */
+const HIT = {
+  document_id: "doc-afl",
+  project_id: "proj-1",
+  version_id: "ver-afl-3",
+  matter_id: "matter-meridian",
+  title: "Agreement for Lease",
+  doc_type: "agreement",
+  doc_type_label: "Agreement",
+  version_status: "executed",
+  score: 0.91,
+  excerpt: "the Tenant may terminate this Agreement   by written notice\nserved within five Business Days",
+  source_paths: ["/Meridian/AFL.docx"],
+  matched_identifiers: [],
+  citations: [
+    {
+      document: { id: "doc-afl" },
+      source_objects: [
+        { id: "so-1", path: "/Meridian/AFL.docx", connector: { display_name: "iManage", provider: "imanage" } },
+      ],
+    },
+  ],
+};
+
+describe("parseLegalMemorySources", () => {
+  test("builds a source row from a search hit", () => {
+    const { sources } = parseLegalMemorySources([HIT])!;
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toMatchObject({
+      documentId: "doc-afl",
+      title: "Agreement for Lease",
+      docType: "Agreement",
+      versionStatus: "executed",
+      system: "iManage",
+    });
+  });
+
+  test("accepts the payload as serialized JSON, as MCP delivers it", () => {
+    expect(parseLegalMemorySources(JSON.stringify([HIT]))!.sources).toHaveLength(1);
+  });
+
+  test("collapses an excerpt to one readable line", () => {
+    const { sources } = parseLegalMemorySources([HIT])!;
+    expect(sources[0].excerpt).toBe(
+      "the Tenant may terminate this Agreement by written notice served within five Business Days",
+    );
+  });
+
+  test("falls back to the provider slug when the connector was never named", () => {
+    const hit = {
+      ...HIT,
+      citations: [{ source_objects: [{ connector: { provider: "sharepoint" } }] }],
+    };
+    expect(parseLegalMemorySources([hit])!.sources[0].system).toBe("sharepoint");
+  });
+
+  test("drops a hit with no citations rather than presenting it as a source", () => {
+    expect(parseLegalMemorySources([{ ...HIT, citations: [] }])).toBeNull();
+  });
+
+  test("keeps only the best-ranked hit per document", () => {
+    const second = { ...HIT, score: 0.4, excerpt: "a lower-ranked chunk of the same document" };
+    const { sources } = parseLegalMemorySources([HIT, second])!;
+    expect(sources).toHaveLength(1);
+    expect(sources[0].excerpt).toContain("the Tenant may terminate");
+  });
+
+  test("returns null for an unusable or empty payload", () => {
+    expect(parseLegalMemorySources(null)).toBeNull();
+    expect(parseLegalMemorySources("not json")).toBeNull();
+    expect(parseLegalMemorySources([])).toBeNull();
+    expect(parseLegalMemorySources({ hits: [HIT] })).toBeNull();
+  });
+});
+
+describe("isAuthoritativeStatus", () => {
+  test("marks operative versions, not drafts", () => {
+    expect(isAuthoritativeStatus("executed")).toBe(true);
+    expect(isAuthoritativeStatus("Final")).toBe(true);
+    expect(isAuthoritativeStatus("draft")).toBe(false);
+    expect(isAuthoritativeStatus("redline")).toBe(false);
+    expect(isAuthoritativeStatus(undefined)).toBe(false);
+  });
+});
+
+describe("isLegalMemorySearchToolPart", () => {
+  const part = (toolName: string) => ({ type: "dynamic-tool" as const, toolName }) as never;
+
+  test("matches both retrieval entry points under any server name", () => {
+    expect(isLegalMemorySearchToolPart(part("legalmemory_search_semantic"))).toBe(true);
+    expect(isLegalMemorySearchToolPart(part("knowledge-index_search_filter"))).toBe(true);
+    expect(isLegalMemorySearchToolPart(part("search_semantic"))).toBe(true);
+  });
+
+  test("does not swallow other tools", () => {
+    expect(isLegalMemorySearchToolPart(part("legalmemory_find_related_documents"))).toBe(false);
+    expect(isLegalMemorySearchToolPart(part("legalmemory_search_decisions"))).toBe(false);
+    expect(isLegalMemorySearchToolPart(part("grep"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Renders `search_semantic` / `search_filter` results as the cited source list from the launch film. Follow-up to #71 and #74.

<img width="700" alt="source list" src="https://github.com/user-attachments/assets/placeholder" />

Rows show title, document type, source system, version status, and the matched passage.

## Why the status badge is the point

The index holds drafts, redlines and superseded originals next to the operative document. A source row that doesn't say which of those it is invites exactly the mistake the retrieval guidance added in #71 exists to prevent. Executed and final versions are badged distinctly from everything else.

## Correctness notes

- **System provenance is read, not guessed.** It comes from `citations[].source_objects[].connector.display_name`, the connector the object was actually synced from, falling back to the provider slug. It is never parsed out of a path.
- **Hits with an empty `citations` array are dropped.** The appliance's contract is that no factual claim may rest on such a result; listing one as a source would contradict it.
- **One row per document.** Chunk-level search returns several hits per document, so the best-ranked hit wins.
- Unparseable payloads fall back to the generic tool card rather than blanking the transcript.

## On click-to-open

Clicking a row sends the export/link prompt a reference chip sends. It cannot open the original directly: the renderer holds no appliance credentials, and the engine SDK (`Mcp` in `@opencode-ai/sdk`) exposes only `status`/`add`/`connect`/`disconnect` — there is no way to invoke an MCP tool from the app. So the path stays: click → agent calls `download_document` and saves into the workspace → the resulting workspace link opens in the in-app docx viewer.

Closing that last gap would need a new server-side route that calls the tool through the engine's MCP session. Out of scope here, worth its own change.

## Changes

- `lib/legalmemory-sources.ts` (new) — parse hits into source rows.
- `components/tools/legalmemory-sources.tsx` (new) — the card.
- `lib/build-in-tools.ts` — `isLegalMemorySearchToolPart`.
- `components/chat/message-list.tsx` — dispatch.
- `tests/legalmemory-sources.test.ts` (new) — 10 tests against a payload mirroring `SearchHit.as_dict`.

## Testing

- `bun test tests/` — 233 pass, 0 fail
- `pnpm typecheck` — clean
- Rendered the parser output and checked the card visually.