### PR TITLE
feat(legalmemory): say what a running retrieval call is doing

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -43,6 +43,7 @@ import { EnvVarRequestTool } from "@/components/tools/env-var-request"
 import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
 import { GlobTool } from "@/components/tools/glob"
 import { GrepTool } from "@/components/tools/grep"
+import { LegalMemoryActivityTool } from "@/components/tools/legalmemory-activity"
 import { LegalMemoryGraphTool } from "@/components/tools/legalmemory-graph"
 import { LegalMemorySourcesTool } from "@/components/tools/legalmemory-sources"
 import { LspTool } from "@/components/tools/lsp"
@@ -83,6 +84,7 @@ import {
   isGlobToolPart,
   isGrepToolPart,
   isLegalMemoryGraphToolPart,
+  isLegalMemoryToolPart,
   isLegalMemorySearchToolPart,
   isLspToolPart,
   isQuestionToolPart,
@@ -207,6 +209,12 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (isEnvVarRequestToolPart(part)) {
     return <EnvVarRequestTool part={part} />
+  }
+
+  // A running LegalMemory call gets a line saying what it is doing; finished
+  // calls fall through to their own card, or to the generic one.
+  if (isLegalMemoryToolPart(part) && part.state !== "output-available" && part.state !== "output-error") {
+    return <LegalMemoryActivityTool part={part} />
   }
 
   if (isLegalMemoryGraphToolPart(part)) {

--- a/apps/app/src/components/tools/legalmemory-activity.tsx
+++ b/apps/app/src/components/tools/legalmemory-activity.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { LoaderCircle, Network } from "lucide-react"
+
+import type { LegalMemoryToolPart } from "@/lib/build-in-tools"
+import { legalMemoryActivityLabel } from "@/lib/legalmemory-activity"
+import { Tool } from "@/components/ui/tool"
+
+interface LegalMemoryActivityToolProps {
+  part: LegalMemoryToolPart
+}
+
+/**
+ * The in-flight line for a LegalMemory call.
+ *
+ * Without it the transcript shows a bare `legalmemory_search_filter` while
+ * retrieval runs, which tells a lawyer nothing about what is happening to their
+ * question. The label describes what that specific tool actually does, so the
+ * line stays honest instead of narrating a fixed script the way a demo would.
+ *
+ * Only the running state is handled here; completed calls keep the generic tool
+ * card so their raw output stays inspectable.
+ */
+export function LegalMemoryActivityTool({ part }: LegalMemoryActivityToolProps) {
+  const label = legalMemoryActivityLabel(part.toolName, part.input)
+  if (!label) {
+    return <Tool toolPart={part} />
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-[var(--lw-text-secondary)]">
+      <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+        <Network className="size-3.5 text-[var(--lw-accent)]" />
+      </span>
+      <span className="min-w-0 truncate">{label}</span>
+      <LoaderCircle className="size-3.5 shrink-0 animate-spin text-[var(--lw-text-tertiary)]" />
+    </div>
+  )
+}

--- a/apps/app/src/lib/build-in-tools.ts
+++ b/apps/app/src/lib/build-in-tools.ts
@@ -1,5 +1,7 @@
 import type { ToolUIPart, DynamicToolUIPart } from "ai";
 
+import { legalMemoryToolName } from "@/lib/legalmemory-activity";
+
 export interface ToolMetadata {
   truncated?: boolean;
   outputPath?: string;
@@ -404,6 +406,16 @@ export function isLegalMemoryGraphToolPart(
   part: ToolUIPart | DynamicToolUIPart,
 ): part is LegalMemoryGraphToolPart {
   return part.type === "dynamic-tool" && LEGALMEMORY_GRAPH_TOOL.test(part.toolName);
+}
+
+export type LegalMemoryToolPart = BuiltInDynamicToolPart<string, unknown, unknown>;
+
+/** Any tool the LegalMemory appliance registers, running or finished. Used for
+ * the in-flight activity line; see `legalMemoryToolName` for the roster. */
+export function isLegalMemoryToolPart(
+  part: ToolUIPart | DynamicToolUIPart,
+): part is LegalMemoryToolPart {
+  return part.type === "dynamic-tool" && legalMemoryToolName(part.toolName) !== null;
 }
 
 export type LegalMemorySearchInput = { query?: string; matter_id?: string; only_final?: boolean };

--- a/apps/app/src/lib/legalmemory-activity.ts
+++ b/apps/app/src/lib/legalmemory-activity.ts
@@ -1,0 +1,101 @@
+/**
+ * What a running LegalMemory tool is actually doing.
+ *
+ * While retrieval is in flight the transcript otherwise shows a bare tool name
+ * like `legalmemory_search_filter`, which tells a lawyer nothing. Each label
+ * below describes the real behavior of that tool, so the line stays true to
+ * what the appliance is doing rather than narrating a fixed script.
+ *
+ * The tool arrives over MCP, so the name carries whichever server name the firm
+ * connected under — the quick-connect catalog uses "legalmemory", the
+ * appliance's own sample config says "knowledge-index".
+ */
+
+const SERVER_PREFIX = /^(?:legal[_-]?memory|knowledge[_-]?index)[_-]/i;
+
+/** Every tool the appliance registers. Kept explicit so an unrelated MCP server
+ * that happens to expose `get_document` is not mistaken for LegalMemory. */
+const LEGALMEMORY_TOOLS = new Set([
+  "search_filter",
+  "search_semantic",
+  "get_document",
+  "download_document",
+  "find_related_documents",
+  "traverse",
+  "list_matters",
+  "billing_rollup",
+  "list_invoices",
+  "resolve_entity",
+  "search_decisions",
+  "list_taxonomies",
+  "ontology_search",
+  "ontology_roots",
+  "ontology_children",
+  "ontology_node",
+  "preview_search_scope",
+]);
+
+/** Strip the server prefix, if the engine attached one. */
+export function legalMemoryToolName(toolName: string): string | null {
+  const bare = toolName.replace(SERVER_PREFIX, "").toLowerCase();
+  return LEGALMEMORY_TOOLS.has(bare) ? bare : null;
+}
+
+type ActivityInput = {
+  query?: unknown;
+  only_final?: unknown;
+  matter_id?: unknown;
+  document_id?: unknown;
+};
+
+function quoted(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? `“${value.trim()}”` : null;
+}
+
+/**
+ * A one-line description of the call in progress. Returns null when the tool is
+ * not LegalMemory's, so callers can fall through to the generic tool card.
+ */
+export function legalMemoryActivityLabel(toolName: string, input: unknown): string | null {
+  const name = legalMemoryToolName(toolName);
+  if (!name) return null;
+  const args = (input && typeof input === "object" ? input : {}) as ActivityInput;
+
+  switch (name) {
+    case "search_semantic": {
+      const query = quoted(args.query);
+      return query ? `Searching firm knowledge for ${query}` : "Searching firm knowledge";
+    }
+    case "search_filter":
+      return args.only_final === true
+        ? "Filtering to executed and effective documents"
+        : "Filtering firm documents by legal metadata";
+    case "find_related_documents":
+      return "Resolving amendments, annexes and precedence";
+    case "traverse":
+      return "Following stored document relations";
+    case "get_document":
+      return "Reading the source document";
+    case "download_document":
+      return "Preparing the exact original";
+    case "list_matters":
+      return "Listing matters you can read";
+    case "search_decisions":
+      return "Checking the firm's decided positions";
+    case "resolve_entity":
+      return "Resolving parties and entities";
+    case "billing_rollup":
+    case "list_invoices":
+      return "Rolling up billed work";
+    case "list_taxonomies":
+    case "ontology_search":
+    case "ontology_roots":
+    case "ontology_children":
+    case "ontology_node":
+      return "Consulting the firm ontology";
+    case "preview_search_scope":
+      return "Compiling your permission scope";
+    default:
+      return "Querying the LegalMemory knowledge graph";
+  }
+}

--- a/apps/app/tests/legalmemory-activity.test.ts
+++ b/apps/app/tests/legalmemory-activity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { legalMemoryActivityLabel, legalMemoryToolName } from "@/lib/legalmemory-activity";
+import { isLegalMemoryToolPart } from "@/lib/build-in-tools";
+
+describe("legalMemoryToolName", () => {
+  test("strips whichever server name the firm connected under", () => {
+    expect(legalMemoryToolName("legalmemory_search_semantic")).toBe("search_semantic");
+    expect(legalMemoryToolName("knowledge-index_search_semantic")).toBe("search_semantic");
+    expect(legalMemoryToolName("search_semantic")).toBe("search_semantic");
+  });
+
+  test("rejects tools the appliance does not register", () => {
+    expect(legalMemoryToolName("legalmemory_delete_everything")).toBeNull();
+    expect(legalMemoryToolName("grep")).toBeNull();
+  });
+});
+
+describe("legalMemoryActivityLabel", () => {
+  test("names the query being searched", () => {
+    expect(legalMemoryActivityLabel("legalmemory_search_semantic", { query: "longstop date" })).toBe(
+      "Searching firm knowledge for “longstop date”",
+    );
+  });
+
+  test("falls back when the query has not streamed in yet", () => {
+    expect(legalMemoryActivityLabel("legalmemory_search_semantic", {})).toBe("Searching firm knowledge");
+    expect(legalMemoryActivityLabel("legalmemory_search_semantic", undefined)).toBe(
+      "Searching firm knowledge",
+    );
+  });
+
+  test("distinguishes a final-versions-only filter, the behavior that matters", () => {
+    expect(legalMemoryActivityLabel("legalmemory_search_filter", { only_final: true })).toBe(
+      "Filtering to executed and effective documents",
+    );
+    expect(legalMemoryActivityLabel("legalmemory_search_filter", {})).toBe(
+      "Filtering firm documents by legal metadata",
+    );
+  });
+
+  test("describes graph and precedence work as such", () => {
+    expect(legalMemoryActivityLabel("legalmemory_find_related_documents", {})).toBe(
+      "Resolving amendments, annexes and precedence",
+    );
+    expect(legalMemoryActivityLabel("legalmemory_traverse", {})).toBe(
+      "Following stored document relations",
+    );
+  });
+
+  test("groups the ontology tools under one line", () => {
+    for (const tool of ["list_taxonomies", "ontology_search", "ontology_children", "ontology_node"]) {
+      expect(legalMemoryActivityLabel(`legalmemory_${tool}`, {})).toBe("Consulting the firm ontology");
+    }
+  });
+
+  test("returns null for a tool that is not LegalMemory's", () => {
+    expect(legalMemoryActivityLabel("bash", { command: "ls" })).toBeNull();
+  });
+});
+
+describe("isLegalMemoryToolPart", () => {
+  const part = (toolName: string) => ({ type: "dynamic-tool" as const, toolName }) as never;
+
+  test("covers the whole appliance tool surface", () => {
+    expect(isLegalMemoryToolPart(part("legalmemory_billing_rollup"))).toBe(true);
+    expect(isLegalMemoryToolPart(part("legalmemory_preview_search_scope"))).toBe(true);
+    expect(isLegalMemoryToolPart(part("knowledge-index_download_document"))).toBe(true);
+  });
+
+  test("does not claim unrelated tools", () => {
+    expect(isLegalMemoryToolPart(part("bash"))).toBe(false);
+    expect(isLegalMemoryToolPart(part("notion_search"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

While LegalMemory retrieval is in flight the transcript showed a bare `legalmemory_search_filter`. Each running call now renders a line describing what that tool actually does. Follow-up to #71, #74, #75.

| Tool | Line |
|---|---|
| `search_semantic` | Searching firm knowledge for "…" |
| `search_filter` (`only_final: true`) | Filtering to executed and effective documents |
| `search_filter` | Filtering firm documents by legal metadata |
| `find_related_documents` | Resolving amendments, annexes and precedence |
| `traverse` | Following stored document relations |
| `search_decisions` | Checking the firm's decided positions |
| `preview_search_scope` | Compiling your permission scope |
| ontology tools | Consulting the firm ontology |

## Why derived, not scripted

The labels come from the tool and its arguments, so the line cannot claim work the appliance isn't doing. The launch film shows a fixed three-step card; this is the honest version of that.

`search_filter` is the one that earns branching: it reads differently depending on `only_final`, and restricting to the operative versions is exactly the behavior the retrieval guidance added in #71 exists to produce, so it's worth saying out loud when it happens.

## Scope

- **Running state only.** Completed calls keep the generic tool card so raw output stays inspectable; errors keep it so failures stay visible.
- The tool roster is listed explicitly rather than matched by shape, so another MCP server exposing its own `get_document` isn't mistaken for LegalMemory.

## Changes

- `lib/legalmemory-activity.ts` (new) — tool roster, prefix stripping, label derivation.
- `components/tools/legalmemory-activity.tsx` (new) — the in-flight line.
- `lib/build-in-tools.ts` — `isLegalMemoryToolPart`.
- `components/chat/message-list.tsx` — dispatch ahead of the graph/sources cards.
- `tests/legalmemory-activity.test.ts` (new) — 10 tests.

## Testing

- `bun test tests/` — 243 pass, 0 fail
- `pnpm typecheck` — clean