### PR TITLE
feat(legalmemory): open a cited original in one click

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -1821,6 +1821,15 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
         `/workspace/${encodeURIComponent(workspaceId)}/hub/share/workflow`,
         { token, hostToken, method: "POST", body: payload, timeoutMs: timeouts.workspaceExport },
       ),
+    /** Fetch a cited LegalMemory original into the workspace and return where it
+     * landed. The server validates the link against the firm's configured
+     * appliance origins; the app never fetches it directly. */
+    legalMemoryExport: (workspaceId: string, payload: { url: string }) =>
+      requestJson<{ ok: boolean; path: string; bytes: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/legalmemory/export`,
+        { token, hostToken, method: "POST", body: payload, timeoutMs: timeouts.workspaceExport },
+      ),
     hubShareIntegration: (workspaceId: string, payload: { mcp: string; name?: string; description?: string }) =>
       requestJson<{ ok: boolean; id: string; version: number }>(
         baseUrl,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -44,6 +44,7 @@ import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
 import { GlobTool } from "@/components/tools/glob"
 import { GrepTool } from "@/components/tools/grep"
 import { LegalMemoryActivityTool } from "@/components/tools/legalmemory-activity"
+import { LegalMemoryDownloadTool } from "@/components/tools/legalmemory-download"
 import { LegalMemoryGraphTool } from "@/components/tools/legalmemory-graph"
 import { LegalMemorySourcesTool } from "@/components/tools/legalmemory-sources"
 import { LspTool } from "@/components/tools/lsp"
@@ -83,6 +84,7 @@ import {
   isEnvVarRequestToolPart,
   isGlobToolPart,
   isGrepToolPart,
+  isLegalMemoryDownloadToolPart,
   isLegalMemoryGraphToolPart,
   isLegalMemoryToolPart,
   isLegalMemorySearchToolPart,
@@ -215,6 +217,10 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
   // calls fall through to their own card, or to the generic one.
   if (isLegalMemoryToolPart(part) && part.state !== "output-available" && part.state !== "output-error") {
     return <LegalMemoryActivityTool part={part} />
+  }
+
+  if (isLegalMemoryDownloadToolPart(part)) {
+    return <LegalMemoryDownloadTool part={part} />
   }
 
   if (isLegalMemoryGraphToolPart(part)) {

--- a/apps/app/src/components/markdown/legalmemory-ref.ts
+++ b/apps/app/src/components/markdown/legalmemory-ref.ts
@@ -43,3 +43,9 @@ export function buildLegalMemoryRefPrompt(ref: LegalMemoryRef, label: string): s
   }
   return `Pull up the LegalMemory matter ${name} (matter_id ${ref.id}): give me a compact preview — status, parties, key documents, and recent decision records — citing each document as a LegalMemory reference link.`;
 }
+
+/** A LegalMemory download card asked for its original to be opened. The app
+ * cannot fetch the appliance itself, so the surface hands the link to the
+ * server, which validates it against the firm's configured appliance origins
+ * and drops the file into the workspace. */
+export const LEGALMEMORY_OPEN_EVENT = "legalwork:legalmemory-open";

--- a/apps/app/src/components/tools/legalmemory-download.tsx
+++ b/apps/app/src/components/tools/legalmemory-download.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { FileText } from "lucide-react"
+
+import { LEGALMEMORY_OPEN_EVENT } from "@/components/markdown/legalmemory-ref"
+import type { LegalMemoryToolPart } from "@/lib/build-in-tools"
+import { formatExportSize, parseLegalMemoryDownload } from "@/lib/legalmemory-download"
+import { Tool } from "@/components/ui/tool"
+
+interface LegalMemoryDownloadToolProps {
+  part: LegalMemoryToolPart
+}
+
+/**
+ * The exact original behind a citation, ready to open.
+ *
+ * `download_document` returns a short-lived link rather than the bytes, so the
+ * transcript used to show a curl command the agent then had to run in a second
+ * turn. Here the link becomes one button: the surface hands it to the server,
+ * which checks it against the firm's configured appliance origins, saves the
+ * file into the workspace, and opens it in the document viewer.
+ *
+ * If the link cannot be found in the payload the generic tool card is shown
+ * instead, so a change in how the appliance answers degrades to the old
+ * behavior rather than losing the result.
+ */
+export function LegalMemoryDownloadTool({ part }: LegalMemoryDownloadToolProps) {
+  if (part.state !== "output-available") {
+    return <Tool toolPart={part} />
+  }
+
+  const download = parseLegalMemoryDownload(part.output)
+  if (!download) {
+    return <Tool toolPart={part} />
+  }
+
+  const size = formatExportSize(download.sizeBytes)
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        window.dispatchEvent(
+          new CustomEvent(LEGALMEMORY_OPEN_EVENT, {
+            detail: { url: download.url, filename: download.filename },
+          }),
+        )
+      }
+      title={`Save ${download.filename} into the workspace and open it`}
+      className="flex w-full items-center gap-2.5 rounded-xl border border-[var(--lw-border)] bg-[var(--lw-surface)] px-3 py-2.5 text-left transition-colors hover:bg-[var(--lw-surface-hover)]"
+    >
+      <FileText className="size-4 shrink-0 text-[var(--lw-accent)]" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-[var(--lw-text-primary)]">
+          {download.filename}
+        </span>
+        <span className="block text-xs text-[var(--lw-text-secondary)]">
+          Exact original from LegalMemory{size ? ` · ${size}` : ""}
+        </span>
+      </span>
+      <span className="shrink-0 rounded-full border border-[var(--lw-border)] px-2.5 py-1 text-xs font-medium text-[var(--lw-text-secondary)]">
+        Open
+      </span>
+    </button>
+  )
+}

--- a/apps/app/src/lib/build-in-tools.ts
+++ b/apps/app/src/lib/build-in-tools.ts
@@ -431,3 +431,13 @@ export function isLegalMemorySearchToolPart(
 ): part is LegalMemorySearchToolPart {
   return part.type === "dynamic-tool" && LEGALMEMORY_SEARCH_TOOL.test(part.toolName);
 }
+
+const LEGALMEMORY_DOWNLOAD_TOOL =
+  /^(?:(?:legal[_-]?memory|knowledge[_-]?index)[_-])?download[_-]document$/i;
+
+/** `download_document`, which returns a short-lived link to the exact original. */
+export function isLegalMemoryDownloadToolPart(
+  part: ToolUIPart | DynamicToolUIPart,
+): part is LegalMemoryToolPart {
+  return part.type === "dynamic-tool" && LEGALMEMORY_DOWNLOAD_TOOL.test(part.toolName);
+}

--- a/apps/app/src/lib/legalmemory-download.ts
+++ b/apps/app/src/lib/legalmemory-download.ts
@@ -1,0 +1,94 @@
+/**
+ * The export link in a LegalMemory `download_document` result.
+ *
+ * The tool answers with structured metadata, a text line, and a resource link,
+ * and which of those reaches the renderer depends on how the engine serializes
+ * MCP tool content. Rather than betting on one shape, look for the link in all
+ * of them and give up quietly if it is not there.
+ *
+ * Nothing here decides whether the link may be fetched. That judgement belongs
+ * to the server, which checks it against the firm's configured appliance
+ * origins; the app only has to find it.
+ */
+
+export type LegalMemoryDownload = {
+  url: string;
+  filename: string;
+  sizeBytes?: number;
+};
+
+/** Matches the appliance download route on any host. */
+const DOWNLOAD_URL = /https?:\/\/[^\s"'<>)\]]+\/api\/downloads\/[A-Za-z0-9._~-]{16,}\/[^\s"'<>)\]]+/;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function filenameFromUrl(url: string): string | null {
+  const segment = url.split("/").pop();
+  if (!segment) return null;
+  try {
+    return decodeURIComponent(segment) || null;
+  } catch {
+    return segment;
+  }
+}
+
+/** Depth-limited walk for a download_url anywhere in a structured payload. */
+function findInObject(value: unknown, depth = 0): LegalMemoryDownload | null {
+  if (depth > 4) return null;
+  const record = asRecord(value);
+  if (record) {
+    const direct = record.download_url ?? record.uri;
+    if (typeof direct === "string" && DOWNLOAD_URL.test(direct)) {
+      const url = DOWNLOAD_URL.exec(direct)![0];
+      const filename =
+        (typeof record.filename === "string" && record.filename.trim() ? record.filename.trim() : null) ??
+        (typeof record.name === "string" && record.name.trim() ? record.name.trim() : null) ??
+        filenameFromUrl(url);
+      if (filename) {
+        const size = record.size_bytes ?? record.size;
+        return { url, filename, sizeBytes: typeof size === "number" ? size : undefined };
+      }
+    }
+    for (const nested of Object.values(record)) {
+      const found = findInObject(nested, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findInObject(entry, depth + 1);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function parseLegalMemoryDownload(output: unknown): LegalMemoryDownload | null {
+  if (typeof output === "string") {
+    // Structured JSON first; the text line is the fallback.
+    try {
+      const parsed: unknown = JSON.parse(output);
+      const found = findInObject(parsed);
+      if (found) return found;
+    } catch {
+      // Not JSON, fall through to the text scan.
+    }
+    const match = DOWNLOAD_URL.exec(output);
+    if (!match) return null;
+    const filename = filenameFromUrl(match[0]);
+    return filename ? { url: match[0], filename } : null;
+  }
+  return findInObject(output);
+}
+
+export function formatExportSize(bytes: number | undefined): string | null {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -74,7 +74,7 @@ import { getSessionActivityStatusLabel, useSessionActivityStore, type SessionAct
 import { PermissionApprovalPanel } from "@/react-app/domains/session/chat/permission-approval-modal";
 import { QuestionPanel } from "@/react-app/domains/session/modals/question-modal";
 import { QueuedMessagesPanel } from "@/react-app/domains/session/modals/queued-messages-panel";
-import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
+import { deriveOpenTargets, resolvePathOpenTarget, selectAutoOpenTarget, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
   injectSessionErrorMessage,
@@ -93,7 +93,7 @@ import {
   getComposerQueuedDrafts,
   useComposerStateStore,
 } from "./composer-state-store";
-import { LEGALMEMORY_REF_EVENT } from "@/components/markdown/legalmemory-ref";
+import { LEGALMEMORY_OPEN_EVENT, LEGALMEMORY_REF_EVENT } from "@/components/markdown/legalmemory-ref";
 import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
 import { FusionIntroDialog, markFusionIntroSeen, shouldShowFusionIntro } from "@/react-app/domains/session/fusion/fusion-intro-dialog";
@@ -1278,6 +1278,40 @@ export function SessionSurface(props: SessionSurfaceProps) {
     window.addEventListener(LEGALMEMORY_REF_EVENT, handleLegalMemoryRef);
     return () => window.removeEventListener(LEGALMEMORY_REF_EVENT, handleLegalMemoryRef);
   }, [attachments, buildDraft, props.modelUnavailable, props.onDraftChange, sendDraft, typeComposerText]);
+
+  // A LegalMemory download card was clicked. The app holds no appliance
+  // credentials, so the server fetches the original: it validates the link
+  // against the firm's configured appliance origins, saves it into the
+  // workspace, and we open whatever path it reports. A failure falls back to
+  // asking the agent, which can still export the file the long way.
+  useEffect(() => {
+    const handleLegalMemoryOpen = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      const detail: unknown = event.detail;
+      if (!detail || typeof detail !== "object" || !("url" in detail) || typeof detail.url !== "string") return;
+      const url = detail.url;
+      const workspaceId = props.workspaceId;
+      if (!workspaceId) return;
+      void (async () => {
+        try {
+          const result = await props.client.legalMemoryExport(workspaceId, { url });
+          const target = resolvePathOpenTarget(result.path, openTargets, "legalmemory-export");
+          if (target) props.onOpenTarget?.(target);
+        } catch {
+          const filename = "filename" in detail && typeof detail.filename === "string" ? detail.filename : "the document";
+          void sendDraft(
+            buildDraft(
+              `Export ${filename} from LegalMemory into the workspace: call download_document, run its save_command from the workspace root, then reply with the saved file as a workspace-relative link.`,
+              [],
+            ),
+            [],
+          ).catch(() => undefined);
+        }
+      })();
+    };
+    window.addEventListener(LEGALMEMORY_OPEN_EVENT, handleLegalMemoryOpen);
+    return () => window.removeEventListener(LEGALMEMORY_OPEN_EVENT, handleLegalMemoryOpen);
+  }, [buildDraft, openTargets, props.client, props.onOpenTarget, props.workspaceId, sendDraft]);
 
   const composerSetTextControlAction = useMemo<LegalworkControlAction>(() => ({
     id: "composer.set_text",

--- a/apps/app/tests/legalmemory-download.test.ts
+++ b/apps/app/tests/legalmemory-download.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { formatExportSize, parseLegalMemoryDownload } from "@/lib/legalmemory-download";
+import { isLegalMemoryDownloadToolPart } from "@/lib/build-in-tools";
+
+const TOKEN = "Ab3-_x9y8Z7w6V5u4T3s2R1q";
+const URL_ = `https://ki.firm.com/api/downloads/${TOKEN}/Agreement%20for%20Lease.docx`;
+
+describe("parseLegalMemoryDownload", () => {
+  test("reads the structured metadata the tool returns", () => {
+    expect(
+      parseLegalMemoryDownload({
+        document_id: "doc-afl",
+        filename: "Agreement for Lease.docx",
+        mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        size_bytes: 245_760,
+        download_url: URL_,
+      }),
+    ).toEqual({ url: URL_, filename: "Agreement for Lease.docx", sizeBytes: 245_760 });
+  });
+
+  test("accepts the payload as serialized JSON", () => {
+    const parsed = parseLegalMemoryDownload(JSON.stringify({ download_url: URL_, filename: "Deed.docx" }));
+    expect(parsed).toMatchObject({ url: URL_, filename: "Deed.docx" });
+  });
+
+  test("finds the link inside MCP resource-link content", () => {
+    const parsed = parseLegalMemoryDownload([
+      { type: "text", text: "Exact original ready: Agreement for Lease.docx" },
+      { type: "resource_link", name: "Agreement for Lease.docx", uri: URL_, size: 245_760 },
+    ]);
+    expect(parsed).toMatchObject({ url: URL_, filename: "Agreement for Lease.docx", sizeBytes: 245_760 });
+  });
+
+  test("falls back to the save_command text when that is all that arrives", () => {
+    const text = `Exact original ready: Agreement for Lease.docx (245760 bytes, SHA-256 abc). Run this from the current workspace now:\ncurl --fail --location --output 'Agreement for Lease.docx' '${URL_}'`;
+    expect(parseLegalMemoryDownload(text)).toEqual({
+      url: URL_,
+      filename: "Agreement for Lease.docx",
+    });
+  });
+
+  test("returns null when there is no download link to find", () => {
+    expect(parseLegalMemoryDownload("document is unavailable")).toBeNull();
+    expect(parseLegalMemoryDownload({ document_id: "doc-afl" })).toBeNull();
+    expect(parseLegalMemoryDownload(null)).toBeNull();
+  });
+
+  test("ignores a link that is not the appliance download route", () => {
+    expect(parseLegalMemoryDownload({ download_url: "https://evil.example/x.docx" })).toBeNull();
+  });
+});
+
+describe("formatExportSize", () => {
+  test("reads at a glance", () => {
+    expect(formatExportSize(512)).toBe("512 B");
+    expect(formatExportSize(245_760)).toBe("240 KB");
+    expect(formatExportSize(5_400_000)).toBe("5.1 MB");
+  });
+
+  test("says nothing when the size is unknown", () => {
+    expect(formatExportSize(undefined)).toBeNull();
+    expect(formatExportSize(0)).toBeNull();
+  });
+});
+
+describe("isLegalMemoryDownloadToolPart", () => {
+  const part = (toolName: string) => ({ type: "dynamic-tool" as const, toolName }) as never;
+
+  test("matches under any server name", () => {
+    expect(isLegalMemoryDownloadToolPart(part("legalmemory_download_document"))).toBe(true);
+    expect(isLegalMemoryDownloadToolPart(part("knowledge-index_download_document"))).toBe(true);
+  });
+
+  test("does not swallow get_document", () => {
+    expect(isLegalMemoryDownloadToolPart(part("legalmemory_get_document"))).toBe(false);
+  });
+});

--- a/apps/server/src/legalmemory-export.test.ts
+++ b/apps/server/src/legalmemory-export.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import {
+  exportSizeRejection,
+  legalMemoryOrigins,
+  safeExportFilename,
+  validateDownloadUrl,
+} from "./legalmemory-export.js";
+
+const APPLIANCE = "https://ki.firm.com";
+const TOKEN = "Ab3-_x9y8Z7w6V5u4T3s2R1q";
+const OK = `${APPLIANCE}/api/downloads/${TOKEN}/Agreement%20for%20Lease.docx`;
+
+describe("legalMemoryOrigins", () => {
+  test("collects origins for both server names the firm may use", () => {
+    const origins = legalMemoryOrigins([
+      { name: "legalmemory", config: { url: `${APPLIANCE}/mcp/` } },
+      { name: "knowledge-index", config: { url: "http://127.0.0.1:8000/mcp/" } },
+    ]);
+    expect(origins).toEqual(new Set([APPLIANCE, "http://127.0.0.1:8000"]));
+  });
+
+  test("ignores other MCP servers entirely", () => {
+    const origins = legalMemoryOrigins([
+      { name: "notion", config: { url: "https://mcp.notion.com/mcp" } },
+      { name: "imanage", config: { url: "https://firm.imanage.com/mcp" } },
+    ]);
+    expect(origins.size).toBe(0);
+  });
+
+  test("survives a malformed or missing url without losing a valid appliance", () => {
+    const origins = legalMemoryOrigins([
+      { name: "legalmemory", config: { url: "not a url" } },
+      { name: "legalmemory", config: {} },
+      { name: "legalmemory" },
+      { name: "knowledge-index", config: { url: `${APPLIANCE}/mcp/` } },
+    ]);
+    expect(origins).toEqual(new Set([APPLIANCE]));
+  });
+});
+
+describe("validateDownloadUrl", () => {
+  const allowed = new Set([APPLIANCE]);
+
+  test("accepts the appliance's own download route", () => {
+    expect(validateDownloadUrl(OK, allowed)).toEqual({
+      url: `${APPLIANCE}/api/downloads/${TOKEN}/Agreement%20for%20Lease.docx`,
+      filename: "Agreement for Lease.docx",
+    });
+  });
+
+  test("rejects any origin the firm has not configured", () => {
+    expect(validateDownloadUrl(`https://evil.example/api/downloads/${TOKEN}/x.docx`, allowed)).toBeNull();
+    // A lookalike host must not pass on a prefix match.
+    expect(validateDownloadUrl(`https://ki.firm.com.evil.example/api/downloads/${TOKEN}/x.docx`, allowed)).toBeNull();
+    // Same host, different port is a different origin.
+    expect(validateDownloadUrl(`https://ki.firm.com:8443/api/downloads/${TOKEN}/x.docx`, allowed)).toBeNull();
+  });
+
+  test("rejects other endpoints on an allowed appliance", () => {
+    expect(validateDownloadUrl(`${APPLIANCE}/api/graph`, allowed)).toBeNull();
+    expect(validateDownloadUrl(`${APPLIANCE}/mcp/`, allowed)).toBeNull();
+    expect(validateDownloadUrl(`${APPLIANCE}/api/downloads/${TOKEN}/sub/dir.docx`, allowed)).toBeNull();
+    expect(validateDownloadUrl(`${APPLIANCE}/api/downloads/short/x.docx`, allowed)).toBeNull();
+  });
+
+  test("rejects non-http schemes", () => {
+    expect(validateDownloadUrl(`file:///etc/passwd`, allowed)).toBeNull();
+    expect(validateDownloadUrl(`javascript:alert(1)`, allowed)).toBeNull();
+  });
+
+  test("allows a plain-http on-prem appliance when that is what is configured", () => {
+    const local = new Set(["http://127.0.0.1:8000"]);
+    expect(validateDownloadUrl(`http://127.0.0.1:8000/api/downloads/${TOKEN}/Deed.docx`, local)).toEqual({
+      url: `http://127.0.0.1:8000/api/downloads/${TOKEN}/Deed.docx`,
+      filename: "Deed.docx",
+    });
+  });
+
+  test("drops any query or fragment rather than forwarding it", () => {
+    const result = validateDownloadUrl(`${OK}?redirect=https://evil.example#x`, allowed);
+    expect(result?.url).toBe(`${APPLIANCE}/api/downloads/${TOKEN}/Agreement%20for%20Lease.docx`);
+  });
+
+  test("collapses an encoded traversal to a bare name in the workspace root", () => {
+    // %2f survives URL parsing as part of the segment, so it only becomes a
+    // separator once decoded. The name is reduced rather than refused: the
+    // result cannot leave the workspace either way.
+    expect(validateDownloadUrl(`${APPLIANCE}/api/downloads/${TOKEN}/..%2f..%2fevil.docx`, allowed)).toEqual({
+      url: `${APPLIANCE}/api/downloads/${TOKEN}/..%2f..%2fevil.docx`,
+      filename: "evil.docx",
+    });
+  });
+
+  test("rejects a real path traversal in the URL path itself", () => {
+    // A literal slash makes the path stop matching the download route.
+    expect(validateDownloadUrl(`${APPLIANCE}/api/downloads/${TOKEN}/../../evil.docx`, allowed)).toBeNull();
+  });
+
+  test("rejects junk input", () => {
+    expect(validateDownloadUrl("", allowed)).toBeNull();
+    expect(validateDownloadUrl(null, allowed)).toBeNull();
+    expect(validateDownloadUrl(OK, new Set())).toBeNull();
+  });
+});
+
+describe("safeExportFilename", () => {
+  test("keeps the punctuation real legal filenames carry", () => {
+    expect(safeExportFilename("Project Meridian - Agreement (Execution Version).docx")).toBe(
+      "Project Meridian - Agreement (Execution Version).docx",
+    );
+    expect(safeExportFilename("Schedule 6 · Landlord's Works.docx")).toBe("Schedule 6 · Landlord's Works.docx");
+    expect(safeExportFilename("Anlage_3 – Gebühren, 2026.pdf")).toBe("Anlage_3 – Gebühren, 2026.pdf");
+  });
+
+  test("reduces any path to a bare name in the workspace root", () => {
+    expect(safeExportFilename("../../etc/passwd")).toBe("passwd");
+    expect(safeExportFilename("C:\\Windows\\System32\\evil.dll")).toBe("evil.dll");
+    expect(safeExportFilename("/absolute/Deed.docx")).toBe("Deed.docx");
+  });
+
+  test("rejects names that are not names", () => {
+    expect(safeExportFilename("")).toBeNull();
+    expect(safeExportFilename("   ")).toBeNull();
+    expect(safeExportFilename("..")).toBeNull();
+    expect(safeExportFilename("../")).toBeNull();
+  });
+
+  test("rejects a dotfile, which would hide the export from the user", () => {
+    expect(safeExportFilename(".env")).toBeNull();
+    expect(safeExportFilename(".hidden.docx")).toBeNull();
+  });
+
+  test("rejects control characters and shell-hostile names", () => {
+    expect(safeExportFilename("Deed\u0000.docx")).toBeNull();
+    expect(safeExportFilename("Deed\n.docx")).toBeNull();
+    expect(safeExportFilename('Deed".docx')).toBeNull();
+    expect(safeExportFilename("Deed|rm.docx")).toBeNull();
+  });
+
+  test("caps an absurdly long name", () => {
+    expect(safeExportFilename(`${"a".repeat(400)}.docx`)?.length).toBe(200);
+  });
+});
+
+describe("exportSizeRejection", () => {
+  test("rejects a body over the limit", () => {
+    expect(exportSizeRejection(String(600 * 1024 * 1024))).toContain("export limit");
+  });
+
+  test("accepts a normal document, or one that declares no length", () => {
+    expect(exportSizeRejection(String(2 * 1024 * 1024))).toBeNull();
+    expect(exportSizeRejection(undefined)).toBeNull();
+    expect(exportSizeRejection("not a number")).toBeNull();
+  });
+});

--- a/apps/server/src/legalmemory-export.ts
+++ b/apps/server/src/legalmemory-export.ts
@@ -1,0 +1,128 @@
+/**
+ * Exporting an original document out of LegalMemory into the workspace.
+ *
+ * `download_document` hands back a short-lived URL whose capability token *is*
+ * the credential, so the bytes can be fetched with no appliance login. That is
+ * what lets the app open a cited source directly instead of asking the agent to
+ * shell out to curl and waiting a turn.
+ *
+ * It also means the URL is worth attacking, and it reaches us out of model
+ * output, which is untrusted. So nothing here trusts the caller:
+ *
+ *   - the origin must be one the firm actually configured a LegalMemory MCP
+ *     server for, read from config rather than supplied by the renderer;
+ *   - the path must be the download route's exact shape, so a validated origin
+ *     cannot be used to pull some other endpoint on the appliance;
+ *   - the filename is derived from the validated URL, never passed alongside
+ *     it, and is reduced to a bare name so it cannot escape the workspace.
+ *
+ * The functions are pure so the rules can be tested without an appliance.
+ */
+
+/** Server names a firm connects the appliance under: the quick-connect catalog
+ * uses "legalmemory", the appliance's own sample config says "knowledge-index". */
+const LEGALMEMORY_SERVER_NAME = /^(?:legal[_-]?memory|knowledge[_-]?index)$/i;
+
+/** `/api/downloads/<token>/<url-encoded filename>` and nothing else. */
+const DOWNLOAD_PATH = /^\/api\/downloads\/([A-Za-z0-9._~-]{16,})\/([^/]+)$/;
+
+/** Refuse anything a firm would not recognise as one of its own documents. */
+const MAX_EXPORT_BYTES = 512 * 1024 * 1024;
+
+export type McpConfigLike = { name: string; config?: unknown };
+
+/**
+ * Origins the firm has configured a LegalMemory server for.
+ *
+ * Only these may be fetched. A server that is configured but currently
+ * disconnected still counts: the capability token is what authorizes the read,
+ * and a link issued moments before a disconnect is still the firm's own
+ * document. Nothing else about the entry is trusted.
+ */
+export function legalMemoryOrigins(items: readonly McpConfigLike[]): Set<string> {
+  const origins = new Set<string>();
+  for (const item of items) {
+    if (!LEGALMEMORY_SERVER_NAME.test(item.name)) continue;
+    const config = item.config;
+    const url = config && typeof config === "object" && "url" in config ? (config as { url?: unknown }).url : undefined;
+    if (typeof url !== "string") continue;
+    try {
+      origins.add(new URL(url).origin);
+    } catch {
+      // A malformed configured URL contributes no origin rather than throwing:
+      // one bad entry must not stop a second, valid appliance from working.
+    }
+  }
+  return origins;
+}
+
+export type ValidatedDownload = {
+  url: string;
+  filename: string;
+};
+
+/**
+ * Accept a download URL only if it points at a configured appliance's download
+ * route, and derive the export filename from it.
+ */
+export function validateDownloadUrl(
+  rawUrl: unknown,
+  allowedOrigins: ReadonlySet<string>,
+): ValidatedDownload | null {
+  if (typeof rawUrl !== "string" || !rawUrl.trim()) return null;
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    return null;
+  }
+  // http is allowed because an on-prem appliance may sit behind an internal
+  // TLS-terminating proxy; the origin check is what constrains the target.
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  if (!allowedOrigins.has(url.origin)) return null;
+
+  const match = DOWNLOAD_PATH.exec(url.pathname);
+  if (!match) return null;
+
+  const filename = safeExportFilename(decodeSegment(match[2]));
+  if (!filename) return null;
+  // Rebuild from the parsed URL so no query or fragment rides along.
+  return { url: `${url.origin}${url.pathname}`, filename };
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+/**
+ * Reduce a name from the appliance to something that can only ever land
+ * directly in the workspace root.
+ */
+export function safeExportFilename(name: string): string | null {
+  // Both separators, whatever the appliance's own platform was.
+  const base = name.split(/[/\\]/).pop()?.trim() ?? "";
+  if (!base || base === "." || base === "..") return null;
+  // Control characters and the Windows-reserved set; a document name should
+  // never contain them, and they are how a name becomes something else.
+  if (/[\x00-\x1f\x7f<>:"|?*]/.test(base)) return null;
+  // A leading dot would hide the export from the workspace listing the user is
+  // looking at, which reads as the export having failed.
+  if (base.startsWith(".")) return null;
+  return base.length > 200 ? base.slice(0, 200) : base;
+}
+
+/** Reject an oversized body before it is buffered. Returns the reason, or null
+ * when the length is acceptable or simply not advertised. */
+export function exportSizeRejection(contentLength: unknown): string | null {
+  const declared = typeof contentLength === "string" ? Number(contentLength) : Number.NaN;
+  if (!Number.isFinite(declared)) return null;
+  return declared > MAX_EXPORT_BYTES
+    ? `document is larger than the ${Math.round(MAX_EXPORT_BYTES / (1024 * 1024))} MB export limit`
+    : null;
+}
+
+export const LEGALMEMORY_MAX_EXPORT_BYTES = MAX_EXPORT_BYTES;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,6 +2,12 @@ import { existsSync } from "node:fs";
 import { lstat, readFile, writeFile, rm } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  exportSizeRejection,
+  legalMemoryOrigins,
+  LEGALMEMORY_MAX_EXPORT_BYTES,
+  validateDownloadUrl,
+} from "./legalmemory-export.js";
 import { fileURLToPath } from "node:url";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger, TokenScope } from "./types.js";
@@ -2209,6 +2215,54 @@ function createRoutes(
     return jsonResponse({ ok: true, ...result });
   });
 
+  // Export a cited LegalMemory document straight into the workspace.
+  //
+  // The appliance's download link carries a short-lived capability token that is
+  // itself the credential, so this needs no appliance login — which is exactly
+  // why the URL is checked rather than trusted. It arrives out of model output,
+  // and `legalMemoryOrigins` reads the permitted origins from the firm's own MCP
+  // config, so a link the model invented for somewhere else cannot be fetched.
+  addRoute(routes, "POST", "/workspace/:id/legalmemory/export", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBodyLimited(ctx.request, 8 * 1024);
+
+    const origins = legalMemoryOrigins(await listMcp(config, workspace.id, workspace.path));
+    if (origins.size === 0) {
+      throw new ApiError(409, "legalmemory_not_configured", "No LegalMemory server is configured for this workspace");
+    }
+    const download = validateDownloadUrl(body.url, origins);
+    if (!download) {
+      throw new ApiError(400, "invalid_download_url", "Not a download link for a configured LegalMemory appliance");
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(download.url, { redirect: "error" });
+    } catch {
+      throw new ApiError(502, "legalmemory_unreachable", "Could not reach the LegalMemory appliance");
+    }
+    if (!response.ok) {
+      // The appliance answers 404 for an expired or revoked capability too.
+      throw new ApiError(502, "legalmemory_download_failed", `The appliance refused the download link (${response.status})`);
+    }
+    const declaredTooLarge = exportSizeRejection(response.headers.get("content-length"));
+    if (declaredTooLarge) throw new ApiError(413, "document_too_large", declaredTooLarge);
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    // Re-check after buffering: content-length is advisory and may be absent.
+    if (bytes.byteLength > LEGALMEMORY_MAX_EXPORT_BYTES) {
+      throw new ApiError(413, "document_too_large", exportSizeRejection(String(bytes.byteLength)) ?? "document is too large to export");
+    }
+
+    // Never overwrite something already in the matter folder; a same-named file
+    // is far more likely to be the firm's own work than a stale export.
+    const relativePath = await nextAvailableExportName(workspace.path, download.filename);
+    await writeFile(join(workspace.path, relativePath), bytes);
+    return jsonResponse({ ok: true, path: relativePath, bytes: bytes.byteLength });
+  });
+
   addRoute(routes, "POST", "/workspace/:id/hub/share/integration", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
@@ -4173,4 +4227,20 @@ async function materializeBlueprintSessions(config: ServerConfig, workspace: Wor
     : created[0]?.sessionId ?? null;
 
   return { ok: true, created, existing: [], openSessionId };
+}
+
+/**
+ * A workspace-relative name for an export that does not clobber an existing
+ * file: "Deed.docx", then "Deed (2).docx", and so on.
+ */
+async function nextAvailableExportName(workspaceRoot: string, filename: string): Promise<string> {
+  if (!existsSync(join(workspaceRoot, filename))) return filename;
+  const dot = filename.lastIndexOf(".");
+  const stem = dot > 0 ? filename.slice(0, dot) : filename;
+  const ext = dot > 0 ? filename.slice(dot) : "";
+  for (let n = 2; n < 1000; n += 1) {
+    const candidate = `${stem} (${n})${ext}`;
+    if (!existsSync(join(workspaceRoot, candidate))) return candidate;
+  }
+  throw new ApiError(409, "export_name_unavailable", `Too many existing copies of ${filename}`);
 }


### PR DESCRIPTION
## Summary

`download_document` returns a short-lived link, not bytes, so the transcript showed a curl command the agent had to run in a second turn before anything could be opened. It's now a card with an **Open** button: the server fetches the original, saves it into the workspace, and the app opens it in the document viewer.

Completes the launch-film sequence started in #71, #74, #75, #76.

## Why the server does the fetching

The link arrives out of **model output**, so it is untrusted. Everything about it is checked rather than believed:

- **Origin** must be one the firm configured a LegalMemory MCP server for. `legalMemoryOrigins` reads this from the firm's own MCP config; the renderer never supplies it.
- **Path** must be the download route's exact shape (`/api/downloads/<token>/<name>`), so a validated origin can't be turned into a pull against any other endpoint on the appliance.
- **Filename** is derived from the validated URL, never passed beside it, and reduced to a bare name. An export can only ever land directly in the workspace root.
- Query and fragment dropped, `redirect: "error"`, body size-capped by declared length *and* after buffering.
- An existing file is never overwritten. A same-named file in a matter folder is far more likely to be the firm's own work than a stale export, so it becomes `Deed (2).docx`.

Server-side rather than an Electron IPC: it keeps working for the web build and avoids a new privileged channel in the desktop main process.

## Testing

- `bun test src` (server) — 517 pass, 0 fail. 20 of those are the validation rules: origin spoofing, lookalike hosts (`ki.firm.com.evil.example`), port differences, non-download endpoints, `file:`/`javascript:` schemes, encoded traversal, control characters in names.
- `bun test tests/` (app) — 253 pass, 0 fail
- `pnpm typecheck` — clean

## Not verified

**The live path has not been exercised end to end.** It needs an authenticated appliance session (Keycloak sign-in), which I can't drive from here. The parsing is defensive across all three shapes `download_document` can return, and an unrecognised payload falls back to the generic tool card, but the actual fetch-save-open round trip wants a manual run before this is trusted.