### PR TITLE
fix(connectors): use the LegalMemory mark, and carry its note into the detail modal

### DIFF
--- a/apps/app/public/ext-legalmemory.svg
+++ b/apps/app/public/ext-legalmemory.svg
@@ -1,6 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96">
-  <rect width="96" height="96" fill="#0F0F12"></rect>
-  <rect x="14" y="14" width="32" height="32" fill="#E8442A"></rect>
-  <rect x="50" y="50" width="32" height="32" fill="#1F4D3F"></rect>
-  <rect x="50" y="14" width="32" height="32" fill="#F2EDE4"></rect>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="none">
+  <path d="M32 8 49 18v20L32 48 15 38V18L32 8Z" stroke="#2352DE" stroke-width="3.1" />
+  <path d="m15 18 17 10 17-10M32 28v20M15 38l17-10 17 10" stroke="#2352DE" stroke-width="3.1" />
+  <circle cx="32" cy="8" r="3.6" fill="#2352DE" />
+  <circle cx="15" cy="18" r="3.6" fill="#2352DE" />
+  <circle cx="49" cy="18" r="3.6" fill="#2352DE" />
+  <circle cx="15" cy="38" r="3.6" fill="#2352DE" />
+  <circle cx="49" cy="38" r="3.6" fill="#2352DE" />
+  <circle cx="32" cy="48" r="3.6" fill="#2352DE" />
 </svg>

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource react */
+import { openDesktopUrl } from "@/app/lib/desktop";
 import { CheckCircle2, ExternalLink, Loader2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -35,6 +36,10 @@ export type ExtensionDetailModalProps = {
   onClose: () => void;
   name: string;
   description: string;
+  /** A prerequisite the firm must already have before Connect can succeed. */
+  setupNote?: string;
+  /** Product page, opened from a "Learn more" link under the description. */
+  learnMoreUrl?: string;
   iconSlug?: string;
   iconSrc?: string;
   fallbackIcon?: LucideIcon;
@@ -185,6 +190,8 @@ export function ExtensionDetailModal({
   onClose,
   name,
   description,
+  setupNote,
+  learnMoreUrl,
   iconSlug,
   iconSrc,
   kind = "mcp",
@@ -289,6 +296,20 @@ export function ExtensionDetailModal({
             <div className="text-sm leading-relaxed text-card-foreground">
               {description}
             </div>
+
+            {setupNote ? (
+              <div className="text-sm leading-relaxed text-muted-foreground">{setupNote}</div>
+            ) : null}
+
+            {learnMoreUrl ? (
+              <button
+                type="button"
+                className="text-sm font-medium text-dls-accent underline-offset-2 hover:underline"
+                onClick={() => { void openDesktopUrl(learnMoreUrl); }}
+              >
+                Learn more
+              </button>
+            ) : null}
 
             {setupInstructions ? (
               <Card variant="outline" size="sm">

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -816,6 +816,8 @@ export function McpView(props: McpViewProps) {
             onClose={() => setDetailEntry(null)}
             name={detailEntry.name}
             description={detailEntry.description}
+            setupNote={detailEntry.setupNote}
+            learnMoreUrl={detailEntry.learnMoreUrl}
             iconSlug={detailEntry.iconSlug}
             iconSrc={detailEntry.iconSrc}
             fallbackIcon={serviceIcon(detailEntry.name)}


### PR DESCRIPTION
## Summary

Two fixes to the featured LegalMemory connector from #78.

**Wrong logo.** The icon was the Eigenwelt Labs corporate mark, and an outdated palette of it. LegalMemory has its own mark, the hexagonal node graph the product page uses (`eigenwelt-website/components/legalmemory/bits.tsx`), which also reads as what the product is. Drawn in brand blue since a standalone SVG file can't inherit `currentColor`.

**The note and link only existed on the card.** Clicking through to the detail modal, which is where someone actually decides whether to press Connect, dropped both. The modal offered a Connect button with no hint that a running deployment is needed first, and nowhere to go to get one. Both now render under the description there too.

## Changes

- `public/ext-legalmemory.svg` — replaced with the LegalMemory node-graph mark.
- `extension-detail-modal.tsx` — `setupNote` and `learnMoreUrl` props, rendered under the description.
- `mcp-view.tsx` — passes both from the catalog entry.

## Testing

- `bun test tests/` — 253 pass, 0 fail
- `pnpm typecheck` — clean
- `node scripts/i18n-audit.mjs --ci` — clean
- Verified in the running dev app over CDP, opening the modal from the card (hard reload needed to bust the cached SVG).