### PR TITLE
fix(connectors): give LegalMemory its own brand mark and wordmark

### DIFF
--- a/apps/app/public/ext-legalmemory.svg
+++ b/apps/app/public/ext-legalmemory.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="none">
-  <path d="M32 8 49 18v20L32 48 15 38V18L32 8Z" stroke="#2352DE" stroke-width="3.1" />
-  <path d="m15 18 17 10 17-10M32 28v20M15 38l17-10 17 10" stroke="#2352DE" stroke-width="3.1" />
-  <circle cx="32" cy="8" r="3.6" fill="#2352DE" />
-  <circle cx="15" cy="18" r="3.6" fill="#2352DE" />
-  <circle cx="49" cy="18" r="3.6" fill="#2352DE" />
-  <circle cx="15" cy="38" r="3.6" fill="#2352DE" />
-  <circle cx="49" cy="38" r="3.6" fill="#2352DE" />
-  <circle cx="32" cy="48" r="3.6" fill="#2352DE" />
+  <path d="M32 8 49 18v20L32 48 15 38V18L32 8Z" stroke="#E95700" stroke-width="3.1" />
+  <path d="m15 18 17 10 17-10M32 28v20M15 38l17-10 17 10" stroke="#E95700" stroke-width="3.1" />
+  <circle cx="32" cy="8" r="3.6" fill="#E95700" />
+  <circle cx="15" cy="18" r="3.6" fill="#E95700" />
+  <circle cx="49" cy="18" r="3.6" fill="#E95700" />
+  <circle cx="15" cy="38" r="3.6" fill="#E95700" />
+  <circle cx="49" cy="38" r="3.6" fill="#E95700" />
+  <circle cx="32" cy="48" r="3.6" fill="#E95700" />
 </svg>

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -67,6 +67,11 @@ export type McpDirectoryInfo = {
   /** Product page for a featured connector, opened from a "Learn more" link. */
   learnMoreUrl?: string;
   /**
+   * Render this connector's name as its own wordmark instead of plain text.
+   * Only for products with a real one; see `.lw-brand-wordmark`.
+   */
+  brandWordmark?: boolean;
+  /**
    * A prerequisite the firm must already have before Connect can succeed, shown
    * on its own line so it survives the description clamp. Self-hosted
    * connectors need this: without it, "Connect" looks like it should just work.
@@ -164,6 +169,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     learnMoreUrl: "https://eigenweltlabs.com/legalmemory",
     iconSrc: "/ext-legalmemory.svg",
     get setupNote() { return t("mcp.quick_connect_legalmemory_note"); },
+    brandWordmark: true,
   },
   {
     get name() { return t("mcp.quick_connect_notion_title"); },

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -636,3 +636,28 @@ select:disabled {
     transform: translateY(0) scale(1);
   }
 }
+
+/* LegalMemory wordmark.
+ *
+ * The product site sets its name in an expanded SF Pro cut at weight 900 in
+ * #E95700 (eigenwelt-website/app/legalmemory.css, .lm-wordmark). Reproduced
+ * here so the connector reads as the same product rather than as a row of
+ * plain text among third-party vendors.
+ *
+ * Geist, the app's own face, has no expanded cut, so the system stack carries
+ * the mark exactly as the site does and falls back to the nearest geometric.
+ *
+ * Size matters for more than emphasis: #E95700 on white is 3.6:1, which clears
+ * WCAG AA for large text (3:1) but not for body text (4.5:1). The rule below is
+ * only ever applied at 20px+ at weight 900, comfortably inside "large".
+ */
+.lw-brand-wordmark {
+  font-family: ".SF NS", -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+  font-weight: 900;
+  font-stretch: 200%;
+  font-variation-settings: "wdth" 200, "wght" 900, "opsz" 144;
+  letter-spacing: -0.035em;
+  line-height: 0.92;
+  white-space: nowrap;
+  color: #E95700;
+}

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -40,6 +40,8 @@ export type ExtensionDetailModalProps = {
   setupNote?: string;
   /** Product page, opened from a "Learn more" link under the description. */
   learnMoreUrl?: string;
+  /** Render the name as the product's own wordmark. */
+  brandWordmark?: boolean;
   iconSlug?: string;
   iconSrc?: string;
   fallbackIcon?: LucideIcon;
@@ -192,6 +194,7 @@ export function ExtensionDetailModal({
   description,
   setupNote,
   learnMoreUrl,
+  brandWordmark,
   iconSlug,
   iconSrc,
   kind = "mcp",
@@ -275,7 +278,9 @@ export function ExtensionDetailModal({
             </div>
 
             <div className="min-w-0 flex flex-col gap-1 justify-center self-stretch">
-              <DialogTitle>{name}</DialogTitle>
+              <DialogTitle className={brandWordmark ? "lw-brand-wordmark text-[26px]" : undefined}>
+                {brandWordmark ? name.toUpperCase() : name}
+              </DialogTitle>
               <DialogDescription className="flex flex-wrap items-center gap-2">
                 <span>{kindLabel[kind]}</span>
                 {preview ? (

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -817,6 +817,7 @@ export function McpView(props: McpViewProps) {
             name={detailEntry.name}
             description={detailEntry.description}
             setupNote={detailEntry.setupNote}
+            brandWordmark={detailEntry.brandWordmark}
             learnMoreUrl={detailEntry.learnMoreUrl}
             iconSlug={detailEntry.iconSlug}
             iconSrc={detailEntry.iconSrc}
@@ -1026,7 +1027,11 @@ function McpQuickConnectSection(props: {
                       kind={kind}
                       connecting={connecting}
                     />
-                    <h4 className="truncate text-[15px] font-medium tracking-[-0.01em] text-dls-text">{entry.name}</h4>
+                    {entry.brandWordmark ? (
+                      <h4 className="lw-brand-wordmark truncate text-[21px]">{entry.name.toUpperCase()}</h4>
+                    ) : (
+                      <h4 className="truncate text-[15px] font-medium tracking-[-0.01em] text-dls-text">{entry.name}</h4>
+                    )}
                   </div>
                   {configured ? (
                     <CheckCircle2 size={16} className="mt-1 shrink-0 text-green-9" />


### PR DESCRIPTION
## Summary

The LegalMemory connector was wearing LegalWork's branding. Checked the product site and applied its own.

From `eigenwelt-website/app/legalmemory.css`:

| Token | Value |
|---|---|
| `--lm-black` | `#000000` (ground) |
| `--lm-ink` | `#FFF7F0` (warm off-white) |
| `--lm-orange` | `#E95700` (accent, and the wordmark's colour) |
| `--lm-orange-hi` | `#FF7A2F` (hover) |

**Mark** — was drawn in LegalWork's accent blue, a guess on my part. Now `#E95700`, the same orange the launch film uses for the matter hub node.

**Wordmark** — the name was plain catalog text. LegalMemory is set on the site (`.lm-wordmark`) as LEGALMEMORY in an expanded SF Pro cut at weight 900, and that lettering is most of what makes it recognisable. Card and detail modal now use it.

Geist has no expanded cut, so the rule carries the same system stack the site uses, falling back to the nearest geometric face where SF is unavailable.

## Contrast

`#E95700` on white is **3.6:1**, which clears WCAG AA for large text (3:1) but not body text (4.5:1). The wordmark is only applied at 21px (card) and 26px (modal) at weight 900, both comfortably inside the large-text threshold. Noted in the CSS so nobody reuses the class at body size.

## Scope

- Behind a `brandWordmark` flag rather than a name check, so it stays off for third-party connectors.
- The card's featured border and "Eigenwelt Labs" tag stay on the LegalWork accent. That chrome is LegalWork's furniture; one orange-framed card among 37 would read as a rendering bug rather than branding.

## Testing

- `bun test tests/` — 253 pass, 0 fail
- `pnpm typecheck` — clean
- `node scripts/i18n-audit.mjs --ci` — clean
- Verified in the running dev app over CDP, card and modal. The wordmark fits the card width without truncation.