### PR TITLE
fix(connectors): let the LegalMemory wordmark stand on its own

### DIFF
--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -246,8 +246,8 @@ export function ExtensionDetailModal({
       >
         <DialogHeader>
           <div className="flex min-w-0 items-start gap-4">
-            {/* Icon */}
-            <div className="relative shrink-0">
+            {/* Icon. Omitted for a product whose name is already its mark. */}
+            <div className={cn("relative shrink-0", brandWordmark && "hidden")}>
               <div
                 className={cn(
                   "flex size-12 items-center justify-center rounded-xl border",

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1019,14 +1019,24 @@ function McpQuickConnectSection(props: {
                 className={`${quickCardClass} ${entry.featured ? quickCardFeaturedClass : ""} ${hidden ? "opacity-70" : ""} ${props.busy ? "pointer-events-none opacity-60" : ""}`}
               >
                 <div className="flex items-start justify-between gap-2">
-                  <div className="flex min-w-0 items-center gap-2.5">
-                    <LedgerBrandIcon
-                      name={entry.name}
-                      iconSlug={entry.iconSlug}
-                      iconSrc={entry.iconSrc}
-                      kind={kind}
-                      connecting={connecting}
-                    />
+                  {/* Without a glyph the header row would collapse to the
+                      wordmark's own 0.92 line box, which reads as cramped and
+                      leaves this card's first row shorter than every other
+                      card's. Hold the icon's height and centre the lettering
+                      in it. */}
+                  <div className={`flex min-w-0 items-center gap-2.5 ${entry.brandWordmark ? "min-h-10" : ""}`}>
+                    {/* A product with its own wordmark needs no glyph beside it:
+                        the lettering is the mark, and a second one reads as
+                        clutter rather than as branding. */}
+                    {entry.brandWordmark ? null : (
+                      <LedgerBrandIcon
+                        name={entry.name}
+                        iconSlug={entry.iconSlug}
+                        iconSrc={entry.iconSrc}
+                        kind={kind}
+                        connecting={connecting}
+                      />
+                    )}
                     {entry.brandWordmark ? (
                       <h4 className="lw-brand-wordmark truncate text-[21px]">{entry.name.toUpperCase()}</h4>
                     ) : (
@@ -1039,7 +1049,7 @@ function McpQuickConnectSection(props: {
                     <CircleAlert size={16} className="mt-1 shrink-0 text-amber-9" />
                   ) : null}
                 </div>
-                <p className={`mt-2 text-[13px] leading-relaxed text-dls-secondary ${entry.featured ? "line-clamp-4" : "line-clamp-2"}`}>{entry.description}</p>
+                <p className={`text-[13px] leading-relaxed text-dls-secondary ${entry.brandWordmark ? "mt-3" : "mt-2"} ${entry.featured ? "line-clamp-4" : "line-clamp-2"}`}>{entry.description}</p>
                 {entry.setupNote ? (
                   <p className="mt-1.5 text-[12px] leading-relaxed text-dls-secondary/80">{entry.setupNote}</p>
                 ) : null}


### PR DESCRIPTION
## Summary

The card carried both the node glyph and the wordmark. The lettering *is* the mark, so the glyph beside it read as clutter rather than as branding. Dropped from the card and from the detail modal header, which had the same pair.

## The spacing bug that removing it exposed

The header row had been getting its height from the 40px icon. With the icon gone it collapsed to the wordmark's own `line-height: 0.92` box, so the lettering sat hard against the top of the card with the description immediately underneath, and this card's first row no longer lined up with every other card's.

The row now holds that height and centres the wordmark in it, with a little more air before the copy starts.

## Changes

- `mcp-view.tsx` — icon omitted when `brandWordmark`; header row keeps `min-h-10`; description gets `mt-3` instead of `mt-2` under a wordmark.
- `extension-detail-modal.tsx` — icon block hidden when `brandWordmark`.

## Testing

- `bun test tests/` — 253 pass, 0 fail
- `pnpm typecheck` — clean
- Verified in the running dev app over CDP, card and modal.