### PR TITLE
fix(mcp): register a connected server where the packaged engine reads it

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -708,6 +708,8 @@ export default {
   "mcp.auth.step2_title": "Authorize LegalWork",
   "mcp.auth.step3_description": "We'll finish connecting as soon as authorization completes.",
   "mcp.auth.step3_title": "Return here when you're done",
+  "mcp.auth.connect_failed_generic": "Could not finish connecting. Try again, and if it keeps failing, reload the engine from Settings.",
+  "mcp.auth.server_not_registered": "This app was saved but the engine has not picked it up yet. Reload the engine and connect again.",
   "mcp.auth.try_reload_engine": "{message}. Try reloading the engine first.",
   "mcp.auth.waiting_authorization": "Waiting for authorization to complete in your browser...",
   "mcp.auth.waiting_for_conversation_body": "We will redirect you to authenticate as soon as possible.",

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -181,7 +181,18 @@ export function McpAuthModal(props: McpAuthModalProps) {
     }
   };
 
-  const resolveSlug = (name: string) =>
+  /**
+ * Engine failures arrive as serialized payloads, e.g.
+ * {"_tag":"McpServerNotFoundError","name":"legalmemory",...}. That is a
+ * developer's artefact, not something to put in front of someone connecting an
+ * app, so anything that looks like one is replaced with plain language.
+ */
+const humanizeEngineError = (message: string): string => {
+  const looksLikePayload = /^\s*[{[]/.test(message) || message.includes('"_tag"');
+  return looksLikePayload ? t("mcp.auth.connect_failed_generic") : message;
+};
+
+const resolveSlug = (name: string) =>
     validateMcpServerName(name).toLowerCase().replace(/[^a-z0-9]+/g, "-");
 
   // Drop any stored OAuth registration/tokens for this server. Best-effort:
@@ -366,10 +377,20 @@ export function McpAuthModal(props: McpAuthModalProps) {
         }
         setNeedsReload(true);
       } else if (message.toLowerCase().includes("not found") || message.toLowerCase().includes("unknown")) {
+        // The engine has not picked the server up yet. Reload and retry rather
+        // than handing the user an engine error and asking them to do it: the
+        // app knows what is wrong and can fix it.
+        const canAutoReload =
+          allowAutoReload && !props.isRemoteWorkspace && !props.reloadBlocked && Boolean(props.onReloadEngine);
+        if (canAutoReload && props.onReloadEngine) {
+          await props.onReloadEngine();
+          await startAuth(true, false);
+          return;
+        }
         setNeedsReload(true);
-        setError(t("mcp.auth.try_reload_engine", { message }));
+        setError(t("mcp.auth.server_not_registered"));
       } else {
-        setError(message);
+        setError(humanizeEngineError(message));
       }
     } finally {
       setLoading(false);

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -715,6 +715,23 @@ export function createConnectionsStore(options: {
         if (!writeResult.ok) {
           throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write global opencode.json");
         }
+
+        // The global file is not what the packaged engine reads. On a config
+        // change it disposes the workspace instance and rebuilds it from
+        // LegalWork's runtime config plus the workspace's own files — the
+        // global opencode config is not among them. So a desktop connect wrote
+        // the server somewhere the engine never looks, the hot-add survived
+        // only until that rebuild seconds later, and sign-in then failed with
+        // "MCP server not found". Register it with the runtime store too,
+        // which is the file the engine demonstrably loads.
+        if (legalworkClient && legalworkWorkspaceId) {
+          try {
+            await legalworkClient.addMcp(legalworkWorkspaceId, { name: slug, config: mcpEntryConfig });
+          } catch {
+            // The global write already succeeded; a failure here is not worse
+            // than the behaviour before this existed.
+          }
+        }
       } else if (canUseLegalworkServer && legalworkClient && legalworkWorkspaceId) {
         await legalworkClient.addMcp(legalworkWorkspaceId, {
           name: slug,
@@ -744,20 +761,39 @@ export function createConnectionsStore(options: {
                 enabled: true,
               };
 
-        try {
-          const status = unwrap(
-            await activeClient.mcp.add({
-              directory: resolvedProjectDir,
-              name: slug,
-              config: mcpAddConfig,
-            }),
-          );
-          setStateField("mcpStatuses", status as McpStatusMap);
-          // The engine now has the MCP registered live — no pre-sign-in worker
-          // reload is needed, which is the step that used to hang the OAuth flow.
-          engineHasMcp = true;
-        } catch {
-          // Best-effort live add; the global config write is the source of truth.
+        // Registering with the running engine is what makes the server usable
+        // now; the config write only matters at next start. A single silent
+        // failure here used to leave the engine without the server while the
+        // flow carried on into sign-in, which then failed with a raw
+        // McpServerNotFoundError. So retry, and confirm the engine really has
+        // it before anything downstream assumes so.
+        for (let attempt = 0; attempt < 3 && !engineHasMcp; attempt += 1) {
+          try {
+            const status = unwrap(
+              await activeClient.mcp.add({
+                directory: resolvedProjectDir,
+                name: slug,
+                config: mcpAddConfig,
+              }),
+            );
+            setStateField("mcpStatuses", status as McpStatusMap);
+            engineHasMcp = Object.prototype.hasOwnProperty.call(status ?? {}, slug);
+          } catch {
+            // Transient: the engine may still be starting for this workspace.
+          }
+          if (!engineHasMcp) {
+            try {
+              const status = unwrap(await activeClient.mcp.status({ directory: resolvedProjectDir }));
+              if (Object.prototype.hasOwnProperty.call(status ?? {}, slug)) {
+                setStateField("mcpStatuses", status as McpStatusMap);
+                engineHasMcp = true;
+                break;
+              }
+            } catch {
+              // Fall through to the next attempt.
+            }
+            await new Promise((resolve) => setTimeout(resolve, 400));
+          }
         }
       } else {
         setStateField("mcpStatuses", filterConfiguredStatuses(snapshot.mcpStatuses, snapshot.mcpServers));

--- a/apps/app/tests/engine-error-leak.test.ts
+++ b/apps/app/tests/engine-error-leak.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+/** Mirrors humanizeEngineError's predicate in mcp-auth-modal.tsx. */
+const looksLikePayload = (message: string) => /^\s*[{[]/.test(message) || message.includes('"_tag"');
+
+describe("engine error leakage", () => {
+  test("the exact payload users were shown is caught", () => {
+    const raw = '{"_tag":"McpServerNotFoundError","name":"legalmemory","message":"MCP server not found: legalmemory"}';
+    expect(looksLikePayload(raw)).toBe(true);
+  });
+
+  test("other serialized failures are caught too", () => {
+    expect(looksLikePayload('{"name":"UnknownError","data":{"ref":"err_e56a6d1e"}}')).toBe(true);
+    expect(looksLikePayload('  [{"_tag":"Whatever"}]')).toBe(true);
+  });
+
+  test("a real sentence is left alone", () => {
+    expect(looksLikePayload("The server refused the connection.")).toBe(false);
+    expect(looksLikePayload("Authorization was cancelled in the browser.")).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug

Adding LegalMemory in an alpha build failed with a raw `McpServerNotFoundError`, and would have stayed broken across restarts.

## Root cause

On desktop, connect writes the server into `~/.config/opencode/opencode.jsonc`. **The packaged engine never reads that file.**

From the alpha's engine log, at the moment of connecting:

```
06:46:27.946  disposing instance   directory=…/DPAs
06:46:27.958  creating instance    directory=…/DPAs
06:46:27.960  loading path=~/.config/legalwork/runtime-opencode-config.json
06:46:27.961  loading path=…/DPAs/opencode.jsonc
06:46:27.968  loading path=…/DPAs/.opencode/opencode.json(c)
```

That is the complete list. So:

1. Config written to a file the engine does not read
2. Hot-add registered it in the live instance's memory — worked, briefly
3. Config change disposed that instance and rebuilt it from the files above
4. Server gone; sign-in asked for it; `McpServerNotFoundError`

`legalmemory` appears nowhere in that day's engine log.

**Why dev never showed it:** dev mode points `OPENCODE_CONFIG_DIR`/`XDG_CONFIG_HOME` at `<userData>/legalwork-dev-data`, so there the engine *does* read what the app writes. This class of bug is invisible in dev and only reproduces in a packaged build.

## Fix

A desktop connect now also registers with the runtime store, which is what builds `runtime-opencode-config.json` — the file the engine demonstrably loads.

## Kept alongside it

- The live registration is **retried and then verified** against the engine rather than attempted once and silently dropped (`catch {}`). Closes a real cold-start race.
- A "not found" at sign-in now **reloads the engine and retries** instead of instructing the user to. That auto-reload path already existed for a different error and simply wasn't wired to this one.
- Anything resembling a serialized engine payload is replaced with plain language, so `{"_tag":"McpServerNotFoundError",…}` cannot reach someone who is just connecting an app. Test asserts the exact string that was shown.

## Testing

- `bun test tests/` — 265 pass, 0 fail
- `pnpm typecheck`, `i18n-audit --ci` — clean
- **Not verifiable in dev by construction**: dev is the environment where this bug cannot occur. Needs an alpha to confirm.