### PR TITLE
fix(legalmemory): read the paginated list envelope for matter titles

### DIFF
--- a/apps/server/src/legalmemory-fetch.ts
+++ b/apps/server/src/legalmemory-fetch.ts
@@ -336,8 +336,12 @@ export async function fetchLegalMemoryMatters(
     if (typeof text !== "string") continue;
     try {
       const parsed: unknown = JSON.parse(text);
-      if (!Array.isArray(parsed)) continue;
-      for (const entry of parsed) {
+      // Every list-shaped appliance tool returns {results, page}; older builds
+      // returned the bare array this was written against. Both are read, because
+      // the firm's appliance version is not ours to choose.
+      const rows = Array.isArray(parsed) ? parsed : asRecord(parsed)?.results;
+      if (!Array.isArray(rows)) continue;
+      for (const entry of rows) {
         const record = asRecord(entry);
         const id = record ? asString(record.id) : undefined;
         const title = record ? asString(record.title) : undefined;


### PR DESCRIPTION
`fetchLegalMemoryMatters` parsed the tool result as a bare JSON array. The
appliance returns `{results, page}` from every list-shaped tool now, so the
parse fell through and returned an empty map — against the live deployment,
0 matter titles where there are 250. It fails closed and silently: source rows
in chat just lose their matter subtitle.

Reads both shapes; the appliance version a firm runs is not ours to choose.

Verified by running `fetchLegalMemoryMatters` against the live deployment:
0 before, 250 after. Download and graph paths are unaffected.