### PR TITLE
Add LegalMemory Drive and detachable chat windows

### DIFF
--- a/apps/app/src/app/lib/legalmemory-connection.ts
+++ b/apps/app/src/app/lib/legalmemory-connection.ts
@@ -1,0 +1,12 @@
+export const LEGALMEMORY_CONNECTION_CHANGED_EVENT = "legalwork:legalmemory-connection-changed";
+
+const LEGALMEMORY_MCP_NAME = /^(?:legal[_-]?memory|knowledge[_-]?index)$/i;
+
+export function isLegalMemoryMcpName(name: string): boolean {
+  return LEGALMEMORY_MCP_NAME.test(name.trim());
+}
+
+export function notifyLegalMemoryConnectionChanged(name: string): void {
+  if (!isLegalMemoryMcpName(name) || typeof window === "undefined") return;
+  window.dispatchEvent(new Event(LEGALMEMORY_CONNECTION_CHANGED_EVENT));
+}

--- a/apps/app/src/app/lib/legalmemory-file.ts
+++ b/apps/app/src/app/lib/legalmemory-file.ts
@@ -25,7 +25,7 @@ export function writeLegalMemoryFileDrag(dataTransfer: DataTransfer, file: Legal
   };
   dataTransfer.effectAllowed = "copy";
   dataTransfer.setData(LEGALMEMORY_FILE_DRAG_TYPE, JSON.stringify(item));
-  dataTransfer.setData("text/plain", file.path);
+  dataTransfer.setData("text/plain", `legalmemory://document/${encodeURIComponent(file.document_id)}`);
 }
 
 export function readLegalMemoryFileDrag(dataTransfer: DataTransfer): LegalMemoryFileDragItem | null {

--- a/apps/app/src/app/lib/legalmemory-file.ts
+++ b/apps/app/src/app/lib/legalmemory-file.ts
@@ -1,0 +1,85 @@
+import type { LegalMemoryTreeFile, LegalworkServerClient } from "./legalwork-server";
+
+export const LEGALMEMORY_FILE_DRAG_TYPE = "application/x-legalwork-legalmemory-file";
+
+export type LegalMemoryFileDragItem = Pick<
+  LegalMemoryTreeFile,
+  "document_id" | "name" | "path" | "source_id" | "source_object_id"
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function hasLegalMemoryFileDrag(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types).includes(LEGALMEMORY_FILE_DRAG_TYPE);
+}
+
+export function writeLegalMemoryFileDrag(dataTransfer: DataTransfer, file: LegalMemoryTreeFile): void {
+  const item: LegalMemoryFileDragItem = {
+    document_id: file.document_id,
+    name: file.name,
+    path: file.path,
+    source_id: file.source_id,
+    source_object_id: file.source_object_id,
+  };
+  dataTransfer.effectAllowed = "copy";
+  dataTransfer.setData(LEGALMEMORY_FILE_DRAG_TYPE, JSON.stringify(item));
+  dataTransfer.setData("text/plain", file.path);
+}
+
+export function readLegalMemoryFileDrag(dataTransfer: DataTransfer): LegalMemoryFileDragItem | null {
+  const raw = dataTransfer.getData(LEGALMEMORY_FILE_DRAG_TYPE);
+  if (!raw) return null;
+  try {
+    const item: unknown = JSON.parse(raw);
+    if (!isRecord(item)) return null;
+    const documentId = item.document_id;
+    const name = item.name;
+    const path = item.path;
+    const sourceId = item.source_id;
+    const sourceObjectId = item.source_object_id;
+    if (
+      typeof documentId !== "string" ||
+      typeof name !== "string" ||
+      typeof path !== "string" ||
+      typeof sourceId !== "string" ||
+      typeof sourceObjectId !== "string"
+    ) return null;
+    return {
+      document_id: documentId,
+      name,
+      path,
+      source_id: sourceId,
+      source_object_id: sourceObjectId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull an authorized LegalMemory original into the workspace and wait until the
+ * normal workspace-file reader can see it. The short readiness poll prevents
+ * the artifact panel from caching a transient miss immediately after export.
+ */
+export async function materializeLegalMemoryFile(
+  client: LegalworkServerClient,
+  workspaceId: string,
+  documentId: string,
+) {
+  const result = await client.legalMemoryOpen(workspaceId, { document_id: documentId });
+  let readinessError: unknown;
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    try {
+      await client.downloadWorkspaceFile(workspaceId, result.path);
+      return result;
+    } catch (error) {
+      readinessError = error;
+      await new Promise((resolve) => window.setTimeout(resolve, 150));
+    }
+  }
+  throw readinessError instanceof Error
+    ? readinessError
+    : new Error("The downloaded LegalMemory file is not ready yet.");
+}

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -620,6 +620,46 @@ export type LegalworkWorkspaceDirectoryList = {
   truncated: boolean;
 };
 
+export type LegalMemoryTreeRoot = {
+  source_id: string;
+  display_name: string;
+  kind: string;
+  project_id: string | null;
+  status: string;
+  files: number;
+};
+
+export type LegalMemoryTreeFolder = {
+  name: string;
+  path: string;
+  files: number;
+};
+
+export type LegalMemoryTreeFile = {
+  source_object_id: string;
+  source_id: string;
+  name: string;
+  path: string;
+  mime_type: string | null;
+  size_bytes: number | null;
+  mtime: string | null;
+  document_id: string;
+};
+
+export type LegalMemoryTreePage = {
+  source_id: string;
+  path: string;
+  folders: LegalMemoryTreeFolder[];
+  files: LegalMemoryTreeFile[];
+  pagination: {
+    total: number;
+    offset: number;
+    limit: number;
+    returned: number;
+    has_more: boolean;
+  };
+};
+
 export type LegalworkInboxItem = {
   id: string;
   name?: string;
@@ -1827,6 +1867,27 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/legalmemory/matters`,
         { token, hostToken, method: "POST", body: {}, timeoutMs: timeouts.config },
+      ),
+    legalMemoryTreeRoots: (workspaceId: string) =>
+      requestJson<{ roots: LegalMemoryTreeRoot[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/legalmemory/tree/roots`,
+        { token, hostToken, method: "POST", body: {}, timeoutMs: timeouts.config },
+      ),
+    legalMemoryTreeChildren: (
+      workspaceId: string,
+      payload: { source_id: string; path?: string; offset?: number; limit?: number },
+    ) =>
+      requestJson<LegalMemoryTreePage>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/legalmemory/tree/children`,
+        { token, hostToken, method: "POST", body: payload, timeoutMs: timeouts.config },
+      ),
+    legalMemoryTreeSearch: (workspaceId: string, payload: { query: string; limit?: number }) =>
+      requestJson<{ files: LegalMemoryTreeFile[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/legalmemory/tree/search`,
+        { token, hostToken, method: "POST", body: payload, timeoutMs: timeouts.config },
       ),
     /** Stored relations around a cited document, so the matter graph does not
      * depend on the agent choosing to traverse. */

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -132,6 +132,9 @@ export type ComposerDraft = {
    * this includes the full pasted text instead.
    */
   resolvedText?: string;
+  /** Internal per-turn context sent as model instructions, never as visible
+   * user-message content. */
+  modelContext?: string;
   /** When set, draft is a slash command invocation */
   command?: { name: string; arguments: string } | undefined;
 };

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   AlertTriangle,
+  ArrowUpRight,
   Check,
   Copy,
   FileIcon,
@@ -107,6 +108,7 @@ import {
 import { cn } from "@/lib/utils"
 import { useOpenTargets } from "@/lib/target-provider"
 import { resolveFilePartOpenTarget } from "@/react-app/domains/session/artifacts/open-target"
+import { LEGALMEMORY_OPEN_EVENT, parseLegalMemoryRef } from "@/components/markdown/legalmemory-ref"
 import { groupMessages, isMessageGroup, getLastTextPart, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText } from "./utils"
 
 function MessageTimestamp({ message, className }: { message: UIMessage; className?: string }) {
@@ -450,7 +452,15 @@ type UserMessageProps = {
   isStreaming: boolean
 }
 
-const USER_SKILL_TOKEN_RE = /(Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/
+const LEGACY_USER_MEMORY_INSTRUCTION_RE = /Read the downloaded LegalMemory copy at workspace path "[^"]+" before answering\. It is "([^"]+)" \((legalmemory:\/\/document\/[\w.:-]+), document_id [^)]+\)\. Use a document-capable tool appropriate for its format \(for example, extract or convert DOCX rather than reading it as plain text\)\. This is a local path reference, not a binary chat attachment\.\s*/g
+const USER_RICH_TOKEN_RE = /(Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\]|\[[^\]\n]+\]\(legalmemory:\/\/document\/[\w.:-]+\))/
+
+function cleanUserMessageText(text: string) {
+  return text.replace(
+    LEGACY_USER_MEMORY_INSTRUCTION_RE,
+    (_match, label: string, uri: string) => `[${label}](${uri}) `,
+  )
+}
 
 function UserSkillChip(props: { name: string }) {
   return (
@@ -460,14 +470,41 @@ function UserSkillChip(props: { name: string }) {
   )
 }
 
-function renderUserTextWithSkillChips(text: string) {
-  if (!USER_SKILL_TOKEN_RE.test(text)) return text
+function UserLegalMemoryChip(props: { label: string; documentId: string }) {
+  return (
+    <button
+      type="button"
+      className="mx-0.5 inline-flex max-w-72 items-center gap-1.5 rounded-full border border-indigo-6/60 bg-indigo-2/55 px-2.5 py-1 text-xs font-medium text-indigo-11 align-middle transition-colors hover:bg-indigo-3/70"
+      title={`Open ${props.label}`}
+      onClick={() => {
+        window.dispatchEvent(new CustomEvent(LEGALMEMORY_OPEN_EVENT, {
+          detail: { documentId: props.documentId, label: props.label },
+        }))
+      }}
+    >
+      <FileIcon className="size-3.5 shrink-0" />
+      <span className="truncate">{props.label}</span>
+      <ArrowUpRight className="size-3.5 shrink-0 opacity-70" />
+    </button>
+  )
+}
+
+function renderUserTextWithReferenceChips(rawText: string) {
+  const text = cleanUserMessageText(rawText)
+  if (!USER_RICH_TOKEN_RE.test(text)) return text
   let offset = 0
-  return text.split(USER_SKILL_TOKEN_RE).map((segment) => {
+  return text.split(USER_RICH_TOKEN_RE).map((segment) => {
     const key = `${offset}:${segment}`
     offset += segment.length
     const skillMatch = segment.match(/^(?:Load )?\[skill ([^\]]+)\](?: and follow its instructions\.)?$/)
     if (skillMatch?.[1]) return <UserSkillChip key={key} name={skillMatch[1]} />
+    const memoryMatch = segment.match(/^\[([^\]\n]+)\]\((legalmemory:\/\/document\/[\w.:-]+)\)$/)
+    if (memoryMatch?.[1] && memoryMatch[2]) {
+      const ref = parseLegalMemoryRef(memoryMatch[2])
+      if (ref?.kind === "document") {
+        return <UserLegalMemoryChip key={key} label={memoryMatch[1]} documentId={ref.id} />
+      }
+    }
     return <React.Fragment key={key}>{segment}</React.Fragment>
   })
 }
@@ -475,7 +512,7 @@ function renderUserTextWithSkillChips(text: string) {
 const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
     const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage } = useMessageList()
-    const messageText = React.useMemo(() => getMessagesText([message]), [message])
+    const messageText = React.useMemo(() => cleanUserMessageText(getMessagesText([message])), [message])
 
     return (
       <Message
@@ -495,7 +532,7 @@ const UserMessage = React.memo(
                     layoutId={message.id}
                     className="bg-foreground/[0.06] text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
                   >
-                    {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
+                    {renderUserTextWithReferenceChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
                   </MessageContent>
                 ) : null}
                 {!isStreaming && (

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -11,6 +11,10 @@ import {
 import { extensionResource } from "../../../app/extensions";
 import { captureAnalyticsEvent } from "../../../app/lib/analytics";
 import { captureAppError } from "../../../app/lib/app-error";
+import {
+  isLegalMemoryMcpName,
+  notifyLegalMemoryConnectionChanged,
+} from "../../../app/lib/legalmemory-connection";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { detectReconnectWithoutAuth, type McpStatusSnapshot } from "../../../app/mcp-auth-state";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
@@ -36,6 +40,7 @@ import type {
   ReloadTrigger,
 } from "../../../app/types";
 import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
+import { getReactQueryClient } from "../../infra/query-client";
 
 import type { LegalworkServerStore } from "./legalwork-server-store";
 
@@ -1020,6 +1025,14 @@ export function createConnectionsStore(options: {
         await resolveWritableLegalworkTarget();
 
       if (isDesktopRuntime()) {
+        // Desktop connect persists the same entry in both local config and the
+        // LegalWork server's runtime store. Removing only the local copies makes
+        // the integration look disconnected while server-owned features (such
+        // as LegalMemory Drive) can still use the surviving runtime entry.
+        if (legalworkClient && legalworkWorkspaceId) {
+          await legalworkClient.removeMcp(legalworkWorkspaceId, name);
+        }
+
         const formattingOptions = { insertSpaces: true, tabSize: 2, eol: "\n" };
         // Remove from the GLOBAL opencode config (applies to every workspace).
         const configFile = await readOpencodeConfig("global", "") as OpencodeConfigFile;
@@ -1034,10 +1047,22 @@ export function createConnectionsStore(options: {
         // Connect merges into the runtime opencode config (the file the
         // packaged engine reads for every workspace), so removal deletes from
         // the same place or the server resurrects on the next instance build.
-        try {
-          await mergeRuntimeMcpServer(name, null);
-        } catch {
-          // Removal from the global config above already succeeded.
+        const runtimeRemoval = await mergeRuntimeMcpServer(name, null);
+        if (!runtimeRemoval.ok) {
+          throw new Error(runtimeRemoval.stderr || runtimeRemoval.stdout || "Failed to remove the runtime MCP config");
+        }
+
+        // The server removal hot-disconnects its engine. Also disconnect the
+        // active desktop client directly for configurations that were sourced
+        // only from a local file and therefore had no server runtime row.
+        const activeClient = options.client();
+        const projectDir = options.projectDir().trim();
+        if (activeClient && projectDir) {
+          try {
+            await activeClient.mcp.disconnect({ directory: projectDir, name });
+          } catch {
+            // A missing/already-disconnected client is the desired end state.
+          }
         }
       } else if (canUseLegalworkServer && legalworkClient && legalworkWorkspaceId) {
         await legalworkClient.removeMcp(legalworkWorkspaceId, name);
@@ -1050,6 +1075,14 @@ export function createConnectionsStore(options: {
       await refreshMcpServers();
       if (snapshot.selectedMcp === name) {
         setStateField("selectedMcp", null);
+      }
+      if (isLegalMemoryMcpName(name)) {
+        const queryClient = getReactQueryClient();
+        await Promise.all([
+          queryClient.resetQueries({ queryKey: ["legalmemory-tree-roots"] }),
+          queryClient.resetQueries({ queryKey: ["legalmemory-tree-search"] }),
+        ]);
+        notifyLegalMemoryConnectionChanged(name);
       }
       setStateField("mcpStatus", null);
       captureAnalyticsEvent("integration_disconnected", {});

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePanelRef } from "react-resizable-panels";
-import { Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
+import { AppWindowMac, Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { LEGALWORK_EXTENSION_CATALOG } from "../../../../app/constants";
@@ -80,6 +80,7 @@ const STARTUP_SKELETON_ROWS = [
 ];
 const GLOBAL_VOICE_SIDE_PANEL_KEY = "__legalwork_voice__";
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 
 export type OpenSessionTab = {
   workspaceId: string;
@@ -846,6 +847,16 @@ export function SessionPage(props: SessionPageProps) {
     });
   }, [props.sidebar.workspaceSessionGroups]);
 
+  useEffect(() => {
+    if (props.detached || !props.selectedSessionId || !isElectronRuntime()) return;
+    const selectedSessionId = props.selectedSessionId;
+    const handleNativeOpenSessionWindow = () => {
+      openSessionWindow(props.selectedWorkspaceId, selectedSessionId);
+    };
+    window.addEventListener(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, handleNativeOpenSessionWindow);
+    return () => window.removeEventListener(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, handleNativeOpenSessionWindow);
+  }, [openSessionWindow, props.detached, props.selectedSessionId, props.selectedWorkspaceId]);
+
   const closeSessionTab = useCallback((sessionId: string) => {
     setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
     setSplitSessionId((current) => current === sessionId ? null : current);
@@ -1126,6 +1137,17 @@ export function SessionPage(props: SessionPageProps) {
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {/* Revert/redo moved to per-message actions */}
+              {!props.detached && props.selectedSessionId && isElectronRuntime() ? (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => openSessionWindow(props.selectedWorkspaceId, props.selectedSessionId!)}
+                  title="Open chat in new window"
+                  aria-label="Open chat in new window"
+                >
+                  <AppWindowMac size={16} />
+                </Button>
+              ) : null}
               <NotificationBell />
               {props.developerMode ? (
                 <Button

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -16,7 +16,7 @@ import {
 import { materializeLegalMemoryFile } from "../../../../app/lib/legalmemory-file";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
-import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
+import { desktopBridge, openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
 import type {
   PendingPermission,
   PendingQuestion,
@@ -136,6 +136,8 @@ export type SessionPageSurfaceProps = Omit<
 >;
 
 export type SessionPageProps = {
+  /** Native secondary chat window: omit the primary navigation sidebar. */
+  detached?: boolean;
   selectedSessionId: string | null;
   selectedWorkspaceId: string;
   selectedWorkspaceDisplay: {
@@ -737,6 +739,10 @@ export function SessionPage(props: SessionPageProps) {
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
   useEffect(() => {
+    if (!props.detached) return;
+    document.title = selectedSessionTitle || t("session.default_title");
+  }, [props.detached, selectedSessionTitle]);
+  useEffect(() => {
     setSessionTabs((current) => {
       const currentWorkspaceTabs = current.filter((tab) => tab.workspaceId === props.selectedWorkspaceId);
       const next = props.selectedSessionId && !currentWorkspaceTabs.some((tab) => tab.sessionId === props.selectedSessionId)
@@ -832,6 +838,14 @@ export function SessionPage(props: SessionPageProps) {
     props.sidebar.onOpenSession(workspaceId, sessionId);
   }, [props.sidebar]);
 
+  const openSessionWindow = useCallback((workspaceId: string, sessionId: string) => {
+    if (!isElectronRuntime()) return;
+    const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId);
+    void desktopBridge.openSessionWindow({ workspaceId, sessionId, title }).catch(() => {
+      toast.error("Could not open the chat in a new window.");
+    });
+  }, [props.sidebar.workspaceSessionGroups]);
+
   const closeSessionTab = useCallback((sessionId: string) => {
     setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
     setSplitSessionId((current) => current === sessionId ? null : current);
@@ -909,7 +923,7 @@ export function SessionPage(props: SessionPageProps) {
         )}
         style={sidebarProviderStyle}
       >
-        <AppSidebar
+        {!props.detached ? <AppSidebar
           workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
           developerMode={props.sidebar.developerMode}
@@ -922,6 +936,7 @@ export function SessionPage(props: SessionPageProps) {
           newTaskDisabled={props.sidebar.newTaskDisabled}
           onSelectWorkspace={props.sidebar.onSelectWorkspace}
           onOpenSession={openSessionTab}
+          onOpenSessionWindow={isElectronRuntime() ? openSessionWindow : undefined}
           onPrefetchSession={props.sidebar.onPrefetchSession}
           onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
           onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
@@ -951,8 +966,8 @@ export function SessionPage(props: SessionPageProps) {
           activeNav={props.sidebar.activeNav}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
-        />
-        {driveOpen ? (
+        /> : null}
+        {!props.detached && driveOpen ? (
           <LegalMemoryFilesPanel
             key={props.runtimeWorkspaceId ?? "__no_workspace__"}
             client={props.legalworkServerClient}
@@ -1080,9 +1095,9 @@ export function SessionPage(props: SessionPageProps) {
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
-          <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
+          <header className={cn("z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar", props.detached && "mac:pl-20")}>
             <div className="flex min-w-0 items-center gap-3">
-              {shellConfig.sidebar ? (
+              {!props.detached && shellConfig.sidebar ? (
                 <SidebarTrigger className="mac:hidden" />
               ) : (
                 // Keeps the title clear of overlaid leading controls (e.g. the
@@ -1581,7 +1596,7 @@ export function SessionPage(props: SessionPageProps) {
           </div>
         </SidebarInset>
         )}
-        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
+        {!props.detached && shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
       </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { usePanelRef } from "react-resizable-panels";
 import { Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
 
@@ -10,7 +11,9 @@ import {
   type LegalworkServerClient,
   type LegalworkServerStatus,
   type LegalworkWorkspaceDirectoryEntry,
+  type LegalMemoryTreeFile,
 } from "../../../../app/lib/legalwork-server";
+import { materializeLegalMemoryFile } from "../../../../app/lib/legalmemory-file";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
 import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -23,6 +26,7 @@ import type {
   WorkspaceSessionGroup,
 } from "../../../../app/types";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import {
   Dialog,
   DialogClose,
@@ -56,11 +60,12 @@ import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
-import { classifyOpenTarget, isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
+import { classifyOpenTarget, isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, resolvePathOpenTarget, type OpenTarget } from "../artifacts/open-target";
 import type { OpenTargetOptions } from "@/lib/target-provider";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
 import { WorkspaceFilesPanel } from "../panel/workspace-files-panel";
+import { LegalMemoryFilesPanel } from "../panel/legalmemory-files-panel";
 import { TerminalDock } from "../terminal/terminal-dock";
 import { LEARNINGS_PANEL_SESSION_ID, useActivePanelTab, usePanelTabStore, useSessionPanelState } from "../panel/panel-tab-store";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
@@ -285,8 +290,10 @@ function controlStringArg(args: unknown, key: string) {
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
+  const queryClient = useQueryClient();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
+  const [driveOpen, setDriveOpen] = useState(false);
   // The side panel's open/close state is keyed per chat session. Top-level
   // mainView pages (Learnings / Benchmark) have no selected session, so they key
   // it on the synthetic LEARNINGS_PANEL_SESSION_ID instead. Without this the key
@@ -619,6 +626,26 @@ export function SessionPage(props: SessionPageProps) {
     preserveSidePanelOnPanelOpenRef.current = true;
     setCurrentSidePanel("panel");
   }, [downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
+  const openLegalMemoryFile = useCallback(async (file: LegalMemoryTreeFile) => {
+    const client = props.legalworkServerClient;
+    const workspaceId = props.runtimeWorkspaceId;
+    if (!client || !workspaceId) {
+      toast.error("Could not open the memory file", { description: "Workspace is not connected." });
+      throw new Error("Workspace is not connected.");
+    }
+    try {
+      const result = await materializeLegalMemoryFile(client, workspaceId, file.document_id);
+      const target = resolvePathOpenTarget(result.path, accessibleTargets, "legalmemory");
+      if (!target) throw new Error("LegalMemory returned an unusable file path.");
+      queryClient.removeQueries({ queryKey: ["artifact-panel", workspaceId, target.id] });
+      openTarget(target, undefined, props.mainView ? LEARNINGS_PANEL_SESSION_ID : undefined);
+    } catch (error) {
+      toast.error(`Could not open ${file.name}`, {
+        description: error instanceof Error ? error.message : "LegalMemory download failed.",
+      });
+      throw error;
+    }
+  }, [accessibleTargets, openTarget, props.legalworkServerClient, props.mainView, props.runtimeWorkspaceId, queryClient]);
   const openExtensionsRailPane = useCallback(() => {
     toggleCurrentSidePanel("extensions");
   }, [toggleCurrentSidePanel]);
@@ -915,6 +942,8 @@ export function SessionPage(props: SessionPageProps) {
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
           onCreateTaskInNewWorkspace={props.sidebar.onCreateTaskInNewWorkspace}
+          onToggleDrive={() => setDriveOpen((open) => !open)}
+          driveOpen={driveOpen}
           onShowLearnings={props.sidebar.onShowLearnings}
           onShowWorkflows={props.sidebar.onShowWorkflows}
           onShowExtensions={props.sidebar.onShowExtensions}
@@ -923,6 +952,19 @@ export function SessionPage(props: SessionPageProps) {
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />
+        {driveOpen ? (
+          <LegalMemoryFilesPanel
+            key={props.runtimeWorkspaceId ?? "__no_workspace__"}
+            client={props.legalworkServerClient}
+            workspaceId={props.runtimeWorkspaceId}
+            onOpenFile={openLegalMemoryFile}
+            onConnectLegalMemory={() => {
+              setDriveOpen(false);
+              props.sidebar.onShowExtensions?.();
+            }}
+            onClose={() => setDriveOpen(false)}
+          />
+        ) : null}
         {props.mainView ? (
           // Top-level pages (Learnings / Skills / Integrations): keep the app chrome the
           // chat has — the draggable top header and the bottom StatusBar (with the

--- a/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
@@ -5,6 +5,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { AlertCircle, ChevronRight, Folder, FolderOpen, HardDrive, Loader2, RotateCw, Search, X } from "lucide-react";
 
 import { writeLegalMemoryFileDrag } from "@/app/lib/legalmemory-file";
+import { LEGALMEMORY_CONNECTION_CHANGED_EVENT } from "@/app/lib/legalmemory-connection";
 import {
   LegalworkServerError,
   type LegalMemoryTreeFile,
@@ -67,6 +68,20 @@ export function LegalMemoryFilesPanel({
   foldersRef.current = folders;
   const openFoldersRef = React.useRef(openFolders);
   openFoldersRef.current = openFolders;
+
+  React.useEffect(() => {
+    const resetDisconnectedTree = () => {
+      setOpenFolders(new Set());
+      setFolders(new Map());
+      setQuery("");
+      setSearchQuery("");
+      setSelectedId(null);
+      setOpeningId(null);
+    };
+
+    window.addEventListener(LEGALMEMORY_CONNECTION_CHANGED_EVENT, resetDisconnectedTree);
+    return () => window.removeEventListener(LEGALMEMORY_CONNECTION_CHANGED_EVENT, resetDisconnectedTree);
+  }, []);
 
   const rootsQuery = useQuery({
     queryKey: ["legalmemory-tree-roots", workspaceId] as const,

--- a/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
@@ -281,18 +281,18 @@ export function LegalMemoryFilesPanel({
       <aside className="flex h-full w-[300px] min-w-[260px] max-w-[34vw] shrink-0 flex-col border-r border-border bg-background mac:bg-background/90 mac:backdrop-blur-2xl">
         <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3 mac:titlebar-no-drag">
           <FolderOpen className="size-4 shrink-0 text-indigo-10" />
-          <h2 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">Drive</h2>
+          <h2 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">Memory Drive</h2>
           {rootsQuery.data && totalsKnown ? (
             <span className="text-[10px] tabular-nums text-muted-foreground">{totalFiles.toLocaleString()}</span>
           ) : null}
           <Tooltip>
-            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={refresh} aria-label="Refresh Drive" />}>
+            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={refresh} aria-label="Refresh Memory Drive" />}>
               <RotateCw className={cn("size-3.5", (rootsQuery.isFetching || search.isFetching) && "animate-spin")} />
             </TooltipTrigger>
             <TooltipContent>Refresh</TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close Drive" />}>
+            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close Memory Drive" />}>
               <X className="size-4" />
             </TooltipTrigger>
             <TooltipContent>Close</TooltipContent>

--- a/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/legalmemory-files-panel.tsx
@@ -1,0 +1,480 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { AlertCircle, ChevronRight, Folder, FolderOpen, HardDrive, Loader2, RotateCw, Search, X } from "lucide-react";
+
+import { writeLegalMemoryFileDrag } from "@/app/lib/legalmemory-file";
+import {
+  LegalworkServerError,
+  type LegalMemoryTreeFile,
+  type LegalMemoryTreeFolder,
+  type LegalMemoryTreePage,
+  type LegalMemoryTreeRoot,
+  type LegalworkServerClient,
+} from "@/app/lib/legalwork-server";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn, formatFileSize } from "@/lib/utils";
+
+import { ArtifactIcon } from "../artifacts/artifact-icon";
+import { classifyOpenTarget } from "../artifacts/open-target";
+
+const PAGE_SIZE = 200;
+const ROW_HEIGHT = 32;
+
+type FolderState = {
+  status: "idle" | "loading" | "error";
+  folders: LegalMemoryTreeFolder[];
+  files: LegalMemoryTreeFile[];
+  total: number;
+  error?: string;
+};
+
+type TreeRow =
+  | { kind: "root"; key: string; depth: number; root: LegalMemoryTreeRoot; open: boolean }
+  | { kind: "folder"; key: string; depth: number; sourceId: string; folder: LegalMemoryTreeFolder; open: boolean }
+  | { kind: "file"; key: string; depth: number; file: LegalMemoryTreeFile; searchResult: boolean }
+  | { kind: "more"; key: string; depth: number; sourceId: string; path: string; loaded: number; remaining: number }
+  | { kind: "status"; key: string; depth: number; label: string; spinning?: boolean };
+
+type LegalMemoryFilesPanelProps = {
+  client: LegalworkServerClient | null;
+  workspaceId: string | null;
+  onOpenFile: (file: LegalMemoryTreeFile) => Promise<void> | void;
+  onConnectLegalMemory?: () => void;
+  onClose: () => void;
+};
+
+const folderKey = (sourceId: string, path: string) => `${sourceId}:${path}`;
+
+export function LegalMemoryFilesPanel({
+  client,
+  workspaceId,
+  onOpenFile,
+  onConnectLegalMemory,
+  onClose,
+}: LegalMemoryFilesPanelProps) {
+  const [openFolders, setOpenFolders] = React.useState<Set<string>>(new Set());
+  const [folders, setFolders] = React.useState<Map<string, FolderState>>(new Map());
+  const [query, setQuery] = React.useState("");
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [openingId, setOpeningId] = React.useState<string | null>(null);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const foldersRef = React.useRef(folders);
+  foldersRef.current = folders;
+  const openFoldersRef = React.useRef(openFolders);
+  openFoldersRef.current = openFolders;
+
+  const rootsQuery = useQuery({
+    queryKey: ["legalmemory-tree-roots", workspaceId] as const,
+    queryFn: async () => {
+      if (!client || !workspaceId) throw new Error("Workspace is not connected.");
+      return client.legalMemoryTreeRoots(workspaceId);
+    },
+    enabled: Boolean(client && workspaceId),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => setSearchQuery(query.trim()), 220);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  const search = useQuery({
+    queryKey: ["legalmemory-tree-search", workspaceId, searchQuery] as const,
+    queryFn: async () => {
+      if (!client || !workspaceId) throw new Error("Workspace is not connected.");
+      return client.legalMemoryTreeSearch(workspaceId, { query: searchQuery, limit: 100 });
+    },
+    enabled: Boolean(client && workspaceId && searchQuery),
+    staleTime: 15_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const loadPage = React.useCallback(async (sourceId: string, path: string, offset: number) => {
+    if (!client || !workspaceId) return;
+    const key = folderKey(sourceId, path);
+    setFolders((current) => {
+      const next = new Map(current);
+      const existing = next.get(key);
+      next.set(key, {
+        status: "loading",
+        folders: existing?.folders ?? [],
+        files: existing?.files ?? [],
+        total: existing?.total ?? 0,
+      });
+      return next;
+    });
+    try {
+      const page: LegalMemoryTreePage = await client.legalMemoryTreeChildren(workspaceId, {
+        source_id: sourceId,
+        path: path || undefined,
+        offset,
+        limit: PAGE_SIZE,
+      });
+      setFolders((current) => {
+        const next = new Map(current);
+        const existing = next.get(key);
+        const files = offset > 0 ? [...(existing?.files ?? []), ...page.files] : page.files;
+        next.set(key, {
+          status: "idle",
+          folders: page.folders,
+          files,
+          total: page.pagination.total,
+        });
+        return next;
+      });
+    } catch (error) {
+      setFolders((current) => {
+        const next = new Map(current);
+        const existing = next.get(key);
+        next.set(key, {
+          status: "error",
+          folders: existing?.folders ?? [],
+          files: existing?.files ?? [],
+          total: existing?.total ?? 0,
+          error: error instanceof Error ? error.message : "Folder listing failed.",
+        });
+        return next;
+      });
+    }
+  }, [client, workspaceId]);
+
+  const toggleFolder = React.useCallback((sourceId: string, path: string) => {
+    const key = folderKey(sourceId, path);
+    const wasOpen = openFoldersRef.current.has(key);
+    setOpenFolders((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+    if (!wasOpen && !foldersRef.current.has(key)) void loadPage(sourceId, path, 0);
+  }, [loadPage]);
+
+  const rows = React.useMemo<TreeRow[]>(() => {
+    if (searchQuery) {
+      if (search.isLoading || search.isFetching) {
+        return [{ kind: "status", key: "search-loading", depth: 0, label: "Searching files…", spinning: true }];
+      }
+      if (search.isError) {
+        return [{ kind: "status", key: "search-error", depth: 0, label: search.error instanceof Error ? search.error.message : "Search failed." }];
+      }
+      const files = search.data?.files ?? [];
+      if (!files.length) return [{ kind: "status", key: "search-empty", depth: 0, label: "No matching files" }];
+      return files.map((file) => ({
+        kind: "file",
+        key: `${file.source_id}:${file.source_object_id}`,
+        depth: 0,
+        file,
+        searchResult: true,
+      }));
+    }
+
+    const roots = rootsQuery.data?.roots ?? [];
+    const next: TreeRow[] = [];
+    const walk = (sourceId: string, path: string, depth: number) => {
+      const key = folderKey(sourceId, path);
+      const state = folders.get(key);
+      if (!state) {
+        next.push({ kind: "status", key: `${key}:loading`, depth, label: "Loading…", spinning: true });
+        return;
+      }
+      if (state.status === "error") {
+        next.push({ kind: "status", key: `${key}:error`, depth, label: state.error ?? "Folder listing failed." });
+        return;
+      }
+      if (state.status === "loading" && state.folders.length === 0 && state.files.length === 0) {
+        next.push({ kind: "status", key: `${key}:loading`, depth, label: "Loading…", spinning: true });
+        return;
+      }
+      for (const folder of state.folders) {
+        const childKey = folderKey(sourceId, folder.path);
+        const isOpen = openFolders.has(childKey);
+        next.push({ kind: "folder", key: childKey, depth, sourceId, folder, open: isOpen });
+        if (isOpen) walk(sourceId, folder.path, depth + 1);
+      }
+      for (const file of state.files) {
+        next.push({ kind: "file", key: file.source_object_id, depth, file, searchResult: false });
+      }
+      if (state.status === "loading") {
+        next.push({ kind: "status", key: `${key}:paging`, depth, label: "Loading…", spinning: true });
+      } else if (state.files.length < state.total) {
+        next.push({
+          kind: "more",
+          key: `${key}:more`,
+          depth,
+          sourceId,
+          path,
+          loaded: state.files.length,
+          remaining: state.total - state.files.length,
+        });
+      }
+    };
+
+    for (const root of roots) {
+      const key = folderKey(root.source_id, "");
+      const isOpen = openFolders.has(key);
+      next.push({ kind: "root", key, depth: 0, root, open: isOpen });
+      if (isOpen) walk(root.source_id, "", 1);
+    }
+    return next;
+  }, [folders, openFolders, rootsQuery.data?.roots, search.data?.files, search.error, search.isError, search.isFetching, search.isLoading, searchQuery]);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 12,
+    getItemKey: (index) => rows[index]?.key ?? index,
+  });
+
+  const openFile = React.useCallback((file: LegalMemoryTreeFile) => {
+    if (openingId) return;
+    setOpeningId(file.source_object_id);
+    void Promise.resolve()
+      .then(() => onOpenFile(file))
+      .then(() => setSelectedId(file.source_object_id))
+      .catch(() => undefined)
+      .finally(() => setOpeningId(null));
+  }, [onOpenFile, openingId]);
+
+  const refresh = React.useCallback(() => {
+    setOpenFolders(new Set());
+    setFolders(new Map());
+    void rootsQuery.refetch();
+    if (searchQuery) void search.refetch();
+  }, [rootsQuery, search, searchQuery]);
+
+  const roots = rootsQuery.data?.roots ?? [];
+  const totalFiles = roots.reduce((sum, root) => sum + root.files, 0);
+  const totalsKnown = roots.every((root) => !root.source_id.startsWith("__legalmemory_mcp__:"));
+  const initialLoading = rootsQuery.isLoading && !rootsQuery.data;
+  const initialError = rootsQuery.isError && !rootsQuery.data;
+  const notConfigured = rootsQuery.error instanceof LegalworkServerError
+    && rootsQuery.error.code === "legalmemory_not_configured";
+
+  return (
+    <TooltipProvider delay={800}>
+      <aside className="flex h-full w-[300px] min-w-[260px] max-w-[34vw] shrink-0 flex-col border-r border-border bg-background mac:bg-background/90 mac:backdrop-blur-2xl">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3 mac:titlebar-no-drag">
+          <FolderOpen className="size-4 shrink-0 text-indigo-10" />
+          <h2 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">Drive</h2>
+          {rootsQuery.data && totalsKnown ? (
+            <span className="text-[10px] tabular-nums text-muted-foreground">{totalFiles.toLocaleString()}</span>
+          ) : null}
+          <Tooltip>
+            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={refresh} aria-label="Refresh Drive" />}>
+              <RotateCw className={cn("size-3.5", (rootsQuery.isFetching || search.isFetching) && "animate-spin")} />
+            </TooltipTrigger>
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close Drive" />}>
+              <X className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent>Close</TooltipContent>
+          </Tooltip>
+        </div>
+
+        {!notConfigured ? <div className="shrink-0 border-b border-border/60 p-2.5">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Search filenames"
+              aria-label="Search LegalMemory files"
+              className="h-8 w-full rounded-lg border border-input bg-muted/30 pl-8 pr-8 text-[13px] text-foreground outline-none placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring"
+            />
+            {query ? (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1.5 text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            ) : null}
+          </div>
+        </div> : null}
+
+        {notConfigured ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+            <HardDrive className="size-8 text-muted-foreground/40" strokeWidth={1.5} />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">Connect LegalMemory</p>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Connect your firm’s knowledge index to browse its files here.
+              </p>
+            </div>
+            {onConnectLegalMemory ? (
+              <Button variant="outline" size="sm" onClick={onConnectLegalMemory}>Open Integrations</Button>
+            ) : null}
+          </div>
+        ) : initialLoading ? (
+          <div className="space-y-1 p-3">
+            {["62%", "78%", "51%", "70%", "45%", "66%"].map((width, index) => (
+              <div key={index} className="flex h-8 items-center gap-2">
+                <Skeleton className="size-4 rounded" />
+                <Skeleton className="h-3.5 rounded" style={{ width }} />
+              </div>
+            ))}
+          </div>
+        ) : initialError ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+            <AlertCircle className="size-7 text-muted-foreground/50" strokeWidth={1.5} />
+            <p className="text-sm text-muted-foreground">
+              {rootsQuery.error instanceof Error ? rootsQuery.error.message : "Could not load LegalMemory."}
+            </p>
+            <Button variant="outline" size="sm" onClick={() => void rootsQuery.refetch()}>Try again</Button>
+          </div>
+        ) : roots.length === 0 && !searchQuery ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+            <FolderOpen className="size-8 text-muted-foreground/40" strokeWidth={1.5} />
+            <p className="text-sm text-muted-foreground">No indexed files are available</p>
+          </div>
+        ) : (
+          <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto py-1.5">
+            <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+              {virtualizer.getVirtualItems().map((item) => {
+                const row = rows[item.index];
+                if (!row) return null;
+                return (
+                  <div
+                    key={item.key}
+                    ref={virtualizer.measureElement}
+                    data-index={item.index}
+                    className="absolute left-0 top-0 w-full"
+                    style={{ transform: `translateY(${item.start}px)` }}
+                  >
+                    <LegalMemoryTreeRow
+                      row={row}
+                      selectedId={selectedId}
+                      openingId={openingId}
+                      onToggle={toggleFolder}
+                      onOpen={openFile}
+                      onLoadMore={loadPage}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </aside>
+    </TooltipProvider>
+  );
+}
+
+function LegalMemoryTreeRow({
+  row,
+  selectedId,
+  openingId,
+  onToggle,
+  onOpen,
+  onLoadMore,
+}: {
+  row: TreeRow;
+  selectedId: string | null;
+  openingId: string | null;
+  onToggle: (sourceId: string, path: string) => void;
+  onOpen: (file: LegalMemoryTreeFile) => void;
+  onLoadMore: (sourceId: string, path: string, offset: number) => void;
+}) {
+  const inset = { paddingLeft: 9 + row.depth * 15 };
+  if (row.kind === "status") {
+    return (
+      <div style={inset} className="flex min-h-8 items-center gap-2 pr-3 text-xs text-muted-foreground">
+        {row.spinning ? <Loader2 className="size-3 animate-spin" /> : <AlertCircle className="size-3" />}
+        <span className="truncate">{row.label}</span>
+      </div>
+    );
+  }
+  if (row.kind === "more") {
+    return (
+      <button
+        type="button"
+        style={inset}
+        onClick={() => onLoadMore(row.sourceId, row.path, row.loaded)}
+        className="flex min-h-8 w-full items-center pr-3 text-left text-xs text-indigo-10 hover:underline"
+      >
+        Show {Math.min(PAGE_SIZE, row.remaining).toLocaleString()} more
+      </button>
+    );
+  }
+  if (row.kind === "root") {
+    return (
+      <button
+        type="button"
+        style={inset}
+        aria-expanded={row.open}
+        onClick={() => onToggle(row.root.source_id, "")}
+        className="group flex min-h-8 w-full items-center gap-1.5 pr-3 text-left hover:bg-muted/60"
+      >
+        <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform", row.open && "rotate-90")} />
+        {row.open ? <FolderOpen className="size-4 shrink-0 fill-indigo-4/30 text-indigo-10" /> : <Folder className="size-4 shrink-0 fill-indigo-4/20 text-indigo-10" />}
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">{row.root.display_name}</span>
+        {!row.root.source_id.startsWith("__legalmemory_mcp__:") ? (
+          <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">{row.root.files.toLocaleString()}</span>
+        ) : null}
+      </button>
+    );
+  }
+  if (row.kind === "folder") {
+    return (
+      <button
+        type="button"
+        style={inset}
+        aria-expanded={row.open}
+        onClick={() => onToggle(row.sourceId, row.folder.path)}
+        title={row.folder.path}
+        className="group flex min-h-8 w-full items-center gap-1.5 pr-3 text-left hover:bg-muted/60"
+      >
+        <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform", row.open && "rotate-90")} />
+        {row.open ? <FolderOpen className="size-4 shrink-0 fill-sky-4/30 text-sky-10" /> : <Folder className="size-4 shrink-0 fill-sky-4/20 text-sky-10" />}
+        <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">{row.folder.name}</span>
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground opacity-0 group-hover:opacity-100">{row.folder.files.toLocaleString()}</span>
+      </button>
+    );
+  }
+
+  const selected = selectedId === row.file.source_object_id;
+  const opening = openingId === row.file.source_object_id;
+  return (
+    <button
+      type="button"
+      draggable
+      style={inset}
+      onDragStart={(event) => writeLegalMemoryFileDrag(event.dataTransfer, row.file)}
+      onClick={() => onOpen(row.file)}
+      title={row.file.path}
+      className={cn(
+        "group relative flex min-h-8 w-full items-center gap-2 pr-3 text-left transition-colors",
+        selected ? "bg-indigo-3/60" : "hover:bg-muted/60",
+      )}
+    >
+      {selected ? <span className="absolute inset-y-0 left-0 w-0.5 bg-indigo-9" /> : null}
+      <span className="ml-[15px] flex size-4 shrink-0 items-center justify-center">
+        {opening ? <Loader2 className="size-3.5 animate-spin text-indigo-10" /> : <ArtifactIcon type={classifyOpenTarget(row.file.name, "file")} className="size-4" />}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className={cn("block truncate text-[13px]", selected ? "font-medium text-foreground" : "text-foreground/90")}>{row.file.name}</span>
+        {row.searchResult ? <span className="block truncate text-[10px] text-muted-foreground">{row.file.path}</span> : null}
+      </span>
+      {!row.searchResult && row.file.size_bytes !== null ? (
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground opacity-0 group-hover:opacity-100">
+          {formatFileSize(row.file.size_bytes)}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -13,6 +13,7 @@ export type SidebarContextValue = {
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onOpenSessionWindow?: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Plus,
   Trash2,
   FolderOpen,
+  AppWindowMac,
   Tag,
 } from "lucide-react";
 import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
@@ -187,6 +188,15 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
   if (variant === "dropdown") {
     return (
       <>
+        {ctx.onOpenSessionWindow ? (
+          <>
+            <DropdownMenuItem onClick={() => ctx.onOpenSessionWindow?.(workspaceId, sessionId)}>
+              <AppWindowMac className="size-4" />
+              Open in New Window
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         <DropdownMenuItem onClick={() => store.getState().togglePin(sessionId)}>
           {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
           {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
@@ -260,6 +270,15 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
 
   return (
     <>
+      {ctx.onOpenSessionWindow ? (
+        <>
+          <ContextMenuItem onClick={() => ctx.onOpenSessionWindow?.(workspaceId, sessionId)}>
+            <AppWindowMac className="size-4" />
+            Open in New Window
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+        </>
+      ) : null}
       <ContextMenuItem onClick={() => store.getState().togglePin(sessionId)}>
         {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
         {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
@@ -450,6 +469,7 @@ export type AppSidebarProps = {
   newTaskDisabled: boolean;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onOpenSessionWindow?: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;
@@ -615,6 +635,7 @@ export function AppSidebar(props: AppSidebarProps) {
     workspaceConnectionStateById: props.workspaceConnectionStateById,
     onSelectWorkspace: props.onSelectWorkspace,
     onOpenSession: props.onOpenSession,
+    onOpenSessionWindow: props.onOpenSessionWindow,
     onPrefetchSession: props.onPrefetchSession,
     onCreateTaskInWorkspace: props.onCreateTaskInWorkspace,
     onOpenRenameSession: props.onOpenRenameSession,
@@ -1545,6 +1566,13 @@ function SessionMenuItem({
     ctx.onOpenSession(workspaceId, session.id);
   };
 
+  const openSessionWindow = (event: React.MouseEvent) => {
+    if (!ctx.onOpenSessionWindow) return;
+    event.preventDefault();
+    event.stopPropagation();
+    ctx.onOpenSessionWindow(workspaceId, session.id);
+  };
+
   const prefetchSession = () => {
     if (workspaceId !== ctx.selectedWorkspaceId) {
       return;
@@ -1575,6 +1603,7 @@ function SessionMenuItem({
                 className={cn("relative", depth > 0 && "ps-13")}
                 isActive={isSelected}
                 onClick={openSession}
+                onDoubleClick={openSessionWindow}
                 onPointerEnter={prefetchSession}
                 onFocus={prefetchSession}
               >
@@ -1608,6 +1637,7 @@ function SessionMenuItem({
         <SidebarMenuSubButton
           isActive={isSelected}
           onClick={openSession}
+          onDoubleClick={openSessionWindow}
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
           className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", isSessionStreaming || isSessionActive && "pe-8")}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -723,7 +723,7 @@ export function AppSidebar(props: AppSidebarProps) {
               onClick={toggleDrive}
             >
               <HardDrive className="size-[18px]" strokeWidth={1.5} />
-              <span>Drive</span>
+              <span>Memory Drive</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -51,6 +51,7 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarRail,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import {
   Collapsible,
@@ -515,7 +516,12 @@ const NAV_ITEM_CLASS =
 
 export function AppSidebar(props: AppSidebarProps) {
   const { config: shellConfig } = useShellConfig();
+  const { isMobile, setOpenMobile } = useSidebar();
   const navigate = useNavigate();
+  const toggleDrive = React.useCallback(() => {
+    if (isMobile) setOpenMobile(false);
+    props.onToggleDrive?.();
+  }, [isMobile, props.onToggleDrive, setOpenMobile]);
   const goSettings = React.useCallback(
     (tab: string) => {
       const ws = props.selectedWorkspaceId.trim();
@@ -714,7 +720,7 @@ export function AppSidebar(props: AppSidebarProps) {
             <SidebarMenuButton
               className={cn(NAV_ITEM_CLASS, "[&_svg]:size-[18px]")}
               isActive={props.driveOpen}
-              onClick={() => props.onToggleDrive?.()}
+              onClick={toggleDrive}
             >
               <HardDrive className="size-[18px]" strokeWidth={1.5} />
               <span>Drive</span>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Sprout,
   ChevronRight,
   FolderPlus,
+  HardDrive,
   Loader2,
   Mic,
   PenLine,
@@ -460,6 +461,8 @@ export type AppSidebarProps = {
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
   onCreateTaskInNewWorkspace: () => void;
+  onToggleDrive?: () => void;
+  driveOpen?: boolean;
   onShowLearnings?: () => void;
   onShowWorkflows?: () => void;
   onShowExtensions?: () => void;
@@ -688,12 +691,12 @@ export function AppSidebar(props: AppSidebarProps) {
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
-              className={cn(NAV_ITEM_CLASS, "[&_svg]:size-[19px]")}
-              isActive={props.activeNav === "learnings"}
-              onClick={() => props.onShowLearnings?.()}
+              className={cn(NAV_ITEM_CLASS, "[&_svg]:size-[18px]")}
+              isActive={props.driveOpen}
+              onClick={() => props.onToggleDrive?.()}
             >
-              <Sprout className="size-[19px]" strokeWidth={1.5} />
-              <span>Learning</span>
+              <HardDrive className="size-[18px]" strokeWidth={1.5} />
+              <span>Drive</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
@@ -724,6 +727,16 @@ export function AppSidebar(props: AppSidebarProps) {
             >
               <Mic className="size-[18px]" strokeWidth={1.5} />
               <span>{t("recorder.nav_label")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              className={cn(NAV_ITEM_CLASS, "[&_svg]:size-[19px]")}
+              isActive={props.activeNav === "learnings"}
+              onClick={() => props.onShowLearnings?.()}
+            >
+              <Sprout className="size-[19px]" strokeWidth={1.5} />
+              <span>Learning</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1157,10 +1157,10 @@ export function ReactSessionComposer(props: ComposerProps) {
             <div className="pointer-events-none absolute inset-3 z-20 flex items-center justify-center rounded-[20px] border-2 border-dashed border-dls-accent bg-[color:color-mix(in_oklab,var(--dls-accent)_10%,transparent)]">
               <div className="rounded-2xl border border-dls-border bg-dls-surface/95 px-5 py-4 text-center">
                 <div className="text-sm font-medium text-dls-text">
-                  {dropzoneKind === "memory" ? "Reference memory file" : t("composer.attach_files")}
+                  {dropzoneKind === "memory" ? "Download memory file" : t("composer.attach_files")}
                 </div>
                 <div className="mt-1 text-xs text-dls-secondary">
-                  {dropzoneKind === "memory" ? "The agent will fetch it from LegalMemory" : t("composer.any_file_type_supported")}
+                  {dropzoneKind === "memory" ? "A project copy will be referenced by path" : t("composer.any_file_type_supported")}
                 </div>
               </div>
             </div>

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -7,6 +7,11 @@ import { toast } from "@/components/ui/sonner";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { LEGALWORK_EXTENSION_CATALOG, type McpDirectoryInfo } from "@/app/constants";
 import type { ImportedPlugin, ImportedPluginFile } from "@/app/lib/extension-imports";
+import {
+  hasLegalMemoryFileDrag,
+  readLegalMemoryFileDrag,
+  type LegalMemoryFileDragItem,
+} from "@/app/lib/legalmemory-file";
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { formatBytes, isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
@@ -91,6 +96,7 @@ type ComposerProps = {
   inputHistory?: string[];
   onPasteText: (text: string) => void;
   onUnsupportedFileLinks: (links: string[]) => void;
+  onDropLegalMemoryFile: (file: LegalMemoryFileDragItem) => void | Promise<void>;
   pastedText: PastedTextChip[];
   onExpandPastedText: (id: string) => void;
   onRemovePastedText: (id: string) => void;
@@ -335,7 +341,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   const [mcpLoaded, setMcpLoaded] = useState(Boolean(props.mcpServers));
   const [pluginsLoaded, setPluginsLoaded] = useState(Boolean(props.importedPlugins));
   const [, setExtensionStateVersion] = useState(0);
-  const [dropzoneActive, setDropzoneActive] = useState(false);
+  const [dropzoneKind, setDropzoneKind] = useState<"attachment" | "memory" | null>(null);
   const [fusionNewTooltipOpen, setFusionNewTooltipOpen] = useState(false);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<LexicalPromptEditorHandle | null>(null);
@@ -1147,11 +1153,15 @@ export function ReactSessionComposer(props: ComposerProps) {
             removes it with backspace like any other inline token.
           */}
 
-          {dropzoneActive ? (
+          {dropzoneKind ? (
             <div className="pointer-events-none absolute inset-3 z-20 flex items-center justify-center rounded-[20px] border-2 border-dashed border-dls-accent bg-[color:color-mix(in_oklab,var(--dls-accent)_10%,transparent)]">
               <div className="rounded-2xl border border-dls-border bg-dls-surface/95 px-5 py-4 text-center">
-                <div className="text-sm font-medium text-dls-text">{t("composer.attach_files")}</div>
-                <div className="mt-1 text-xs text-dls-secondary">{t("composer.any_file_type_supported")}</div>
+                <div className="text-sm font-medium text-dls-text">
+                  {dropzoneKind === "memory" ? "Add memory file to prompt" : t("composer.attach_files")}
+                </div>
+                <div className="mt-1 text-xs text-dls-secondary">
+                  {dropzoneKind === "memory" ? "The file will be available as a workspace reference" : t("composer.any_file_type_supported")}
+                </div>
               </div>
             </div>
           ) : null}
@@ -1223,19 +1233,31 @@ export function ReactSessionComposer(props: ComposerProps) {
                 }
               }}
               onDragOver={(event) => {
+                if (event.dataTransfer && hasLegalMemoryFileDrag(event.dataTransfer)) {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = "copy";
+                  if (dropzoneKind !== "memory") setDropzoneKind("memory");
+                  return;
+                }
                 if (event.dataTransfer?.files?.length) {
                   event.preventDefault();
-                  if (!dropzoneActive) setDropzoneActive(true);
+                  if (dropzoneKind !== "attachment") setDropzoneKind("attachment");
                 }
               }}
               onDragLeave={(event) => {
                 const nextTarget = event.relatedTarget;
                 if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-                setDropzoneActive(false);
+                setDropzoneKind(null);
               }}
               onDrop={(event) => {
+                const memoryFile = event.dataTransfer ? readLegalMemoryFileDrag(event.dataTransfer) : null;
+                setDropzoneKind(null);
+                if (memoryFile) {
+                  event.preventDefault();
+                  void props.onDropLegalMemoryFile(memoryFile);
+                  return;
+                }
                 const files = Array.from(event.dataTransfer?.files ?? []);
-                setDropzoneActive(false);
                 if (!files.length) return;
                 event.preventDefault();
                 void addAttachments(files);

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1157,10 +1157,10 @@ export function ReactSessionComposer(props: ComposerProps) {
             <div className="pointer-events-none absolute inset-3 z-20 flex items-center justify-center rounded-[20px] border-2 border-dashed border-dls-accent bg-[color:color-mix(in_oklab,var(--dls-accent)_10%,transparent)]">
               <div className="rounded-2xl border border-dls-border bg-dls-surface/95 px-5 py-4 text-center">
                 <div className="text-sm font-medium text-dls-text">
-                  {dropzoneKind === "memory" ? "Add memory file to prompt" : t("composer.attach_files")}
+                  {dropzoneKind === "memory" ? "Reference memory file" : t("composer.attach_files")}
                 </div>
                 <div className="mt-1 text-xs text-dls-secondary">
-                  {dropzoneKind === "memory" ? "The file will be available as a workspace reference" : t("composer.any_file_type_supported")}
+                  {dropzoneKind === "memory" ? "The agent will fetch it from LegalMemory" : t("composer.any_file_type_supported")}
                 </div>
               </div>
             </div>

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -84,12 +84,13 @@ type SerializedComposerSkillNode = Spread<
 
 const MENTION_PILL_CLASS: Record<ComposerMentionKind, string> = {
   file: "inline-flex items-center rounded-full border border-gray-6 bg-gray-3 px-2.5 py-1 text-xs font-medium text-gray-11",
+  memory: "inline-flex items-center rounded-full border border-indigo-6/60 bg-indigo-2/40 px-2.5 py-1 text-xs font-medium text-indigo-11",
   agent: "inline-flex items-center rounded-full border border-sky-6/35 bg-sky-3/20 px-2.5 py-1 text-xs font-medium text-sky-11",
   app: "inline-flex items-center rounded-full border border-cyan-6/35 bg-cyan-3/20 px-2.5 py-1 text-xs font-medium text-cyan-11",
 };
 
 function mentionPillText(value: string, kind: ComposerMentionKind) {
-  return `@${kind === "file" ? value.split(/[\\/]/).pop() || value : value}`;
+  return `@${kind === "file" || kind === "memory" ? value.split(/[\\/]/).pop() || value : value}`;
 }
 
 class ComposerMentionNode extends TextNode {

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -32,7 +32,12 @@ import {
   type NodeKey,
 } from "lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
-import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
+import {
+  decodeComposerMentionValue,
+  encodeComposerMentionValue,
+  parseLegalMemoryComposerMention,
+  type ComposerMentionKind,
+} from "./mention-encoding";
 
 type EditorProps = {
   value: string;
@@ -90,6 +95,10 @@ const MENTION_PILL_CLASS: Record<ComposerMentionKind, string> = {
 };
 
 function mentionPillText(value: string, kind: ComposerMentionKind) {
+  if (kind === "memory") {
+    const memory = parseLegalMemoryComposerMention(value);
+    if (memory) return `@${memory.label}`;
+  }
   return `@${kind === "file" || kind === "memory" ? value.split(/[\\/]/).pop() || value : value}`;
 }
 

--- a/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
@@ -16,3 +16,41 @@ export function encodeComposerMentionValue(value: string) {
 export function decodeComposerMentionValue(value: string) {
   return value.replaceAll("%20", " ").replaceAll("%25", "%");
 }
+
+export type LegalMemoryComposerMention = {
+  documentId: string;
+  label: string;
+  uri: string;
+};
+
+const LEGALMEMORY_DOCUMENT_MENTION = /^legalmemory:\/\/document\/([^?\s]+)(?:\?name=(.*))?$/i;
+
+/** Keep the filename in the editor token while retaining the document id the
+ * agent needs. The query is UI metadata; `uri` below is the canonical lookup
+ * reference sent to the model. */
+export function createLegalMemoryComposerMention(documentId: string, label: string): string {
+  return `legalmemory://document/${encodeURIComponent(documentId)}?name=${encodeURIComponent(label)}`;
+}
+
+export function parseLegalMemoryComposerMention(value: string): LegalMemoryComposerMention | null {
+  const match = LEGALMEMORY_DOCUMENT_MENTION.exec(value.trim());
+  if (!match?.[1]) return null;
+  try {
+    const documentId = decodeURIComponent(match[1]);
+    if (!documentId) return null;
+    const label = match[2] ? decodeURIComponent(match[2]) : documentId;
+    return {
+      documentId,
+      label: label.trim() || documentId,
+      uri: `legalmemory://document/${encodeURIComponent(documentId)}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function legalMemoryComposerInstruction(value: string): string {
+  const mention = parseLegalMemoryComposerMention(value);
+  if (!mention) return value;
+  return `Use LegalMemory to fetch and read "${mention.label}" (${mention.uri}, document_id ${mention.documentId}) before answering. This is a LegalMemory reference, not a local workspace file.`;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
@@ -1,5 +1,5 @@
-/** What a composer `@token` refers to: an agent, a workspace file, or a macOS app (Computer Use target). */
-export type ComposerMentionKind = "agent" | "file" | "app";
+/** What a composer `@token` refers to: an agent, a workspace or LegalMemory file, or a macOS app. */
+export type ComposerMentionKind = "agent" | "file" | "memory" | "app";
 
 /**
  * Percent-encode a mention value so it can be embedded in the draft as a single `@token` with no spaces.

--- a/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
@@ -20,16 +20,22 @@ export function decodeComposerMentionValue(value: string) {
 export type LegalMemoryComposerMention = {
   documentId: string;
   label: string;
+  /** Workspace-relative location of the copy the app downloaded before the
+   * mention was inserted. It stays metadata on the memory pill and must never
+   * be promoted to a binary chat attachment. */
+  localPath?: string;
   uri: string;
 };
 
-const LEGALMEMORY_DOCUMENT_MENTION = /^legalmemory:\/\/document\/([^?\s]+)(?:\?name=(.*))?$/i;
+const LEGALMEMORY_DOCUMENT_MENTION = /^legalmemory:\/\/document\/([^?\s]+)(?:\?([^\s]*))?$/i;
 
 /** Keep the filename in the editor token while retaining the document id the
  * agent needs. The query is UI metadata; `uri` below is the canonical lookup
  * reference sent to the model. */
-export function createLegalMemoryComposerMention(documentId: string, label: string): string {
-  return `legalmemory://document/${encodeURIComponent(documentId)}?name=${encodeURIComponent(label)}`;
+export function createLegalMemoryComposerMention(documentId: string, label: string, localPath?: string): string {
+  const params = new URLSearchParams({ name: label });
+  if (localPath?.trim()) params.set("path", localPath.trim());
+  return `legalmemory://document/${encodeURIComponent(documentId)}?${params.toString()}`;
 }
 
 export function parseLegalMemoryComposerMention(value: string): LegalMemoryComposerMention | null {
@@ -38,10 +44,13 @@ export function parseLegalMemoryComposerMention(value: string): LegalMemoryCompo
   try {
     const documentId = decodeURIComponent(match[1]);
     if (!documentId) return null;
-    const label = match[2] ? decodeURIComponent(match[2]) : documentId;
+    const params = new URLSearchParams(match[2] ?? "");
+    const label = params.get("name") ?? documentId;
+    const localPath = params.get("path")?.trim() || undefined;
     return {
       documentId,
       label: label.trim() || documentId,
+      ...(localPath ? { localPath } : {}),
       uri: `legalmemory://document/${encodeURIComponent(documentId)}`,
     };
   } catch {
@@ -52,5 +61,17 @@ export function parseLegalMemoryComposerMention(value: string): LegalMemoryCompo
 export function legalMemoryComposerInstruction(value: string): string {
   const mention = parseLegalMemoryComposerMention(value);
   if (!mention) return value;
+  if (mention.localPath) {
+    return `Read the downloaded LegalMemory copy at workspace path "${mention.localPath}" before answering. It is "${mention.label}" (${mention.uri}, document_id ${mention.documentId}). Use a document-capable tool appropriate for its format (for example, extract or convert DOCX rather than reading it as plain text). This is a local path reference, not a binary chat attachment.`;
+  }
   return `Use LegalMemory to fetch and read "${mention.label}" (${mention.uri}, document_id ${mention.documentId}) before answering. This is a LegalMemory reference, not a local workspace file.`;
+}
+
+/** Visible representation persisted in the user turn. The transcript renderer
+ * turns this ordinary LegalMemory citation into a compact clickable pill. */
+export function legalMemoryComposerDisplayText(value: string): string {
+  const mention = parseLegalMemoryComposerMention(value);
+  if (!mention) return value;
+  const label = mention.label.replaceAll("[", "").replaceAll("]", "");
+  return `[${label || mention.documentId}](${mention.uri})`;
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -60,7 +60,13 @@ import {
 } from "@/app/lib/app-inspector";
 import { useControlAction, type LegalworkControlAction } from "@/react-app/shell/control/control-provider";
 import { ReactSessionComposer } from "./composer/composer";
-import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
+import {
+  createLegalMemoryComposerMention,
+  decodeComposerMentionValue,
+  encodeComposerMentionValue,
+  legalMemoryComposerInstruction,
+  type ComposerMentionKind,
+} from "./composer/mention-encoding";
 import { desktopBridge } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
@@ -948,7 +954,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
         const value = decodeComposerMentionValue(segment.slice(1));
         const kind = mentions[value];
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
-        if (kind === "file" || kind === "memory") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
+        if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
+        if (kind === "memory") return [{ type: "text", text: legalMemoryComposerInstruction(value) } satisfies ComposerDraft["parts"][number]];
         if (kind === "app") return [{ type: "app", name: value } satisfies ComposerDraft["parts"][number]];
       }
       return [{ type: "text", text: segment } satisfies ComposerDraft["parts"][number]];
@@ -960,8 +967,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
       resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
     }
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
-    for (const value of Object.keys(mentions)) {
-      resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
+    for (const [value, kind] of Object.entries(mentions)) {
+      resolved = resolved.replaceAll(
+        `@${encodeComposerMentionValue(value)}`,
+        kind === "memory" ? legalMemoryComposerInstruction(value) : `@${value}`,
+      );
     }
     const slashCommand = parseSlashCommandInvocation(resolved);
     return {
@@ -1211,23 +1221,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   };
 
-  const handleDropLegalMemoryFile = async (file: LegalMemoryFileDragItem) => {
-    try {
-      const result = await materializeLegalMemoryFile(props.client, props.workspaceId, file.document_id);
-      const composerState = useComposerStateStore.getState();
-      const currentDraft = getComposerDraft(composerState, props.sessionId);
-      const currentMentions = getComposerMentions(composerState, props.sessionId);
-      const separator = currentDraft && !/\s$/.test(currentDraft) ? " " : "";
-      setComposerDraft(
-        props.sessionId,
-        `${currentDraft}${separator}@${encodeComposerMentionValue(result.path)} `,
-      );
-      setComposerMentions(props.sessionId, { ...currentMentions, [result.path]: "memory" });
-    } catch (error) {
-      toast.error(`Could not add ${file.name}`, {
-        description: error instanceof Error ? error.message : "LegalMemory download failed",
-      });
-    }
+  const handleDropLegalMemoryFile = (file: LegalMemoryFileDragItem) => {
+    const reference = createLegalMemoryComposerMention(file.document_id, file.name);
+    const composerState = useComposerStateStore.getState();
+    const currentDraft = getComposerDraft(composerState, props.sessionId);
+    const currentMentions = getComposerMentions(composerState, props.sessionId);
+    const separator = currentDraft && !/\s$/.test(currentDraft) ? " " : "";
+    setComposerDraft(
+      props.sessionId,
+      `${currentDraft}${separator}@${encodeComposerMentionValue(reference)} `,
+    );
+    setComposerMentions(props.sessionId, { ...currentMentions, [reference]: "memory" });
   };
 
   const handlePasteText = (text: string) => {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -34,6 +34,10 @@ import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { isOfficeAddinRuntime } from "@/app/lib/runtime-env";
 import { t } from "@/i18n";
 import { readWorkspaceImports, type ImportedPlugin } from "@/app/lib/extension-imports";
+import {
+  materializeLegalMemoryFile,
+  type LegalMemoryFileDragItem,
+} from "@/app/lib/legalmemory-file";
 import type {
   LegalworkServerClient,
   LegalworkSessionSnapshot,
@@ -944,7 +948,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         const value = decodeComposerMentionValue(segment.slice(1));
         const kind = mentions[value];
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
-        if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
+        if (kind === "file" || kind === "memory") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
         if (kind === "app") return [{ type: "app", name: value } satisfies ComposerDraft["parts"][number]];
       }
       return [{ type: "text", text: segment } satisfies ComposerDraft["parts"][number]];
@@ -1207,6 +1211,25 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   };
 
+  const handleDropLegalMemoryFile = async (file: LegalMemoryFileDragItem) => {
+    try {
+      const result = await materializeLegalMemoryFile(props.client, props.workspaceId, file.document_id);
+      const composerState = useComposerStateStore.getState();
+      const currentDraft = getComposerDraft(composerState, props.sessionId);
+      const currentMentions = getComposerMentions(composerState, props.sessionId);
+      const separator = currentDraft && !/\s$/.test(currentDraft) ? " " : "";
+      setComposerDraft(
+        props.sessionId,
+        `${currentDraft}${separator}@${encodeComposerMentionValue(result.path)} `,
+      );
+      setComposerMentions(props.sessionId, { ...currentMentions, [result.path]: "memory" });
+    } catch (error) {
+      toast.error(`Could not add ${file.name}`, {
+        description: error instanceof Error ? error.message : "LegalMemory download failed",
+      });
+    }
+  };
+
   const handlePasteText = (text: string) => {
     const id = `paste-${Math.random().toString(36).slice(2)}`;
     const label = `${id.slice(-4)} · ${text.split(/\r?\n/).length} lines`;
@@ -1294,21 +1317,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (!workspaceId) return;
       void (async () => {
         try {
-          const result = await props.client.legalMemoryOpen(workspaceId, { document_id: documentId });
-          // The route has written the file, but the viewer reads it back
-          // through the workspace API and can get there first: it opens on a
-          // path the read layer does not see yet, renders empty, and caches
-          // that. Closing and reopening the tab then works, which is the
-          // signature of a race rather than a missing file. So wait until the
-          // file is actually readable before opening anything.
-          for (let attempt = 0; attempt < 12; attempt += 1) {
-            try {
-              await props.client.downloadWorkspaceFile(workspaceId, result.path);
-              break;
-            } catch {
-              await new Promise((resolve) => setTimeout(resolve, 150));
-            }
-          }
+          const result = await materializeLegalMemoryFile(props.client, workspaceId, documentId);
           const target = resolvePathOpenTarget(result.path, openTargets, "legalmemory");
           if (!target) return;
           // The viewer caches per target id. This path may have been opened
@@ -1730,6 +1739,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         recentFiles={props.recentFiles}
         searchFiles={props.searchFiles}
         onInsertMention={handleInsertMention}
+        onDropLegalMemoryFile={handleDropLegalMemoryFile}
         inputHistory={inputHistory}
         onPasteText={handlePasteText}
         onUnsupportedFileLinks={handleUnsupportedFileLinks}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -65,6 +65,7 @@ import {
   decodeComposerMentionValue,
   encodeComposerMentionValue,
   legalMemoryComposerInstruction,
+  legalMemoryComposerDisplayText,
   type ComposerMentionKind,
 } from "./composer/mention-encoding";
 import { desktopBridge } from "@/app/lib/desktop";
@@ -452,6 +453,10 @@ function mergeDrafts(drafts: ComposerDraft[]): ComposerDraft | null {
     attachments,
     text: texts.join("\n\n"),
     resolvedText: resolvedTexts.join("\n\n"),
+    modelContext: drafts
+      .map((draft) => draft.modelContext?.trim())
+      .filter((context): context is string => Boolean(context))
+      .join("\n\n") || undefined,
     command: undefined,
   };
 }
@@ -937,6 +942,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
+    const modelContexts: string[] = [];
     const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
@@ -955,7 +961,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
         const kind = mentions[value];
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
         if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
-        if (kind === "memory") return [{ type: "text", text: legalMemoryComposerInstruction(value) } satisfies ComposerDraft["parts"][number]];
+        if (kind === "memory") {
+          modelContexts.push(legalMemoryComposerInstruction(value));
+          return [{ type: "text", text: legalMemoryComposerDisplayText(value) } satisfies ComposerDraft["parts"][number]];
+        }
         if (kind === "app") return [{ type: "app", name: value } satisfies ComposerDraft["parts"][number]];
       }
       return [{ type: "text", text: segment } satisfies ComposerDraft["parts"][number]];
@@ -970,7 +979,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const [value, kind] of Object.entries(mentions)) {
       resolved = resolved.replaceAll(
         `@${encodeComposerMentionValue(value)}`,
-        kind === "memory" ? legalMemoryComposerInstruction(value) : `@${value}`,
+        kind === "memory" ? legalMemoryComposerDisplayText(value) : `@${value}`,
       );
     }
     const slashCommand = parseSlashCommandInvocation(resolved);
@@ -980,6 +989,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       attachments: nextAttachments,
       text,
       resolvedText: resolved,
+      modelContext: [...new Set(modelContexts)].join("\n") || undefined,
       command: slashCommand ?? undefined,
     };
   }, [mentions, pasteParts]);
@@ -1221,17 +1231,27 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   };
 
-  const handleDropLegalMemoryFile = (file: LegalMemoryFileDragItem) => {
-    const reference = createLegalMemoryComposerMention(file.document_id, file.name);
-    const composerState = useComposerStateStore.getState();
-    const currentDraft = getComposerDraft(composerState, props.sessionId);
-    const currentMentions = getComposerMentions(composerState, props.sessionId);
-    const separator = currentDraft && !/\s$/.test(currentDraft) ? " " : "";
-    setComposerDraft(
-      props.sessionId,
-      `${currentDraft}${separator}@${encodeComposerMentionValue(reference)} `,
-    );
-    setComposerMentions(props.sessionId, { ...currentMentions, [reference]: "memory" });
+  const handleDropLegalMemoryFile = async (file: LegalMemoryFileDragItem) => {
+    try {
+      // Materialize the authorized original before inserting the pill. Only its
+      // workspace path is sent to the agent; the binary is deliberately not
+      // added to ComposerDraft.attachments or emitted as a file part.
+      const result = await materializeLegalMemoryFile(props.client, props.workspaceId, file.document_id);
+      const reference = createLegalMemoryComposerMention(file.document_id, file.name, result.path);
+      const composerState = useComposerStateStore.getState();
+      const currentDraft = getComposerDraft(composerState, props.sessionId);
+      const currentMentions = getComposerMentions(composerState, props.sessionId);
+      const separator = currentDraft && !/\s$/.test(currentDraft) ? " " : "";
+      setComposerDraft(
+        props.sessionId,
+        `${currentDraft}${separator}@${encodeComposerMentionValue(reference)} `,
+      );
+      setComposerMentions(props.sessionId, { ...currentMentions, [reference]: "memory" });
+    } catch (error) {
+      toast.error(`Could not download ${file.name}`, {
+        description: error instanceof Error ? error.message : "LegalMemory download failed",
+      });
+    }
   };
 
   const handlePasteText = (text: string) => {

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -605,6 +605,7 @@ export function createSessionActionsStore(options: {
           agent: agent ?? undefined,
           variant: requestVariant,
           ...(promptOverrides ?? {}),
+          ...(resolvedDraft.modelContext?.trim() ? { system: resolvedDraft.modelContext.trim() } : {}),
           parts,
         });
         assertNoClientError(result);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -929,6 +929,9 @@ export function SessionRoute() {
           cacheKey: targetSessionId,
           runtimeKey: environmentRuntimeKey,
         });
+        const turnSystemContext = [envSystemContext, draft.modelContext]
+          .filter((context): context is string => Boolean(context?.trim()))
+          .join("\n\n");
 
         if (!isOfficeAddinRuntime() && isFusionEnabled(targetSessionId)) {
           const candidateModels = getFusionSelectedModels(targetSessionId);
@@ -951,7 +954,7 @@ export function SessionRoute() {
               mainModel: local.prefs.defaultModel ?? undefined,
               agent: selectedAgent ?? undefined,
               variant: modelVariantValue ?? undefined,
-              baseSystem: envSystemContext ?? undefined,
+              baseSystem: turnSystemContext || undefined,
             }).catch((error: unknown) => {
               const message = error instanceof Error ? error.message : String(error);
               toast.error(t("fusion.turn_failed"), { description: message });
@@ -967,7 +970,7 @@ export function SessionRoute() {
           model: local.prefs.defaultModel ?? undefined,
           agent: selectedAgent ?? undefined,
           ...(modelVariantValue ? { variant: modelVariantValue } : {}),
-          ...(envSystemContext ? { system: envSystemContext } : {}),
+          ...(turnSystemContext ? { system: turnSystemContext } : {}),
         });
         if (result.error) {
           throw new Error(serializeSDKError(result.error));

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -310,6 +310,11 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
 export function SessionRoute() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const detached = useMemo(
+    () => new URLSearchParams(location.search).get("detached") === "1",
+    [location.search],
+  );
   const [showLearnings, setShowLearnings] = useState(false);
   // Top-level pages that live in the main shell (sidebar stays, main pane swaps),
   // same mechanism as Learnings. Mutually exclusive — only one main pane at a time.
@@ -1672,6 +1677,7 @@ export function SessionRoute() {
       <TranscriptionSetupStep onDone={finishOnboarding} />
     ) : null}
     <SessionPage
+      detached={detached}
       selectedSessionId={selectedSessionId}
       selectedWorkspaceId={selectedWorkspaceId}
       selectedWorkspaceDisplay={selectedWorkspace ? {

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -6,7 +6,7 @@ const LEGACY_WORKSPACE_LEFT_SIDEBAR_WIDTH_KEY = "legalwork.workspace-shell.left-
 const LEGACY_WORKSPACE_RIGHT_SIDEBAR_EXPANDED_KEY = "legalwork.workspace-shell.right-expanded.v3";
 const LEGACY_WORKSPACE_RIGHT_SIDEBAR_WIDTH_KEY = "legalwork.workspace-shell.right-width.v1";
 
-export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 260;
+export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
 export const MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
 export const MAX_WORKSPACE_LEFT_SIDEBAR_WIDTH = 420;
 export const DEFAULT_WORKSPACE_RIGHT_SIDEBAR_COLLAPSED_WIDTH = 72;

--- a/apps/app/tests/connections-remove-mcp.test.ts
+++ b/apps/app/tests/connections-remove-mcp.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import type { LegalworkServerClient } from "../src/app/lib/legalwork-server";
 import type { LegalworkServerStore } from "../src/react-app/domains/connections/legalwork-server-store";
 
 type DesktopCall = { command: string; args: unknown[] };
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+afterEach(() => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});
 
 describe("desktop MCP removal", () => {
   test("also removes the LegalWork server runtime entry", async () => {

--- a/apps/app/tests/connections-remove-mcp.test.ts
+++ b/apps/app/tests/connections-remove-mcp.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import type { LegalworkServerClient } from "../src/app/lib/legalwork-server";
+import type { LegalworkServerStore } from "../src/react-app/domains/connections/legalwork-server-store";
+
+type DesktopCall = { command: string; args: unknown[] };
+
+describe("desktop MCP removal", () => {
+  test("also removes the LegalWork server runtime entry", async () => {
+    const desktopCalls: DesktopCall[] = [];
+    const browserWindow = new EventTarget() as EventTarget & {
+      __LEGALWORK_ELECTRON__?: {
+        invokeDesktop: (command: string, ...args: unknown[]) => Promise<unknown>;
+      };
+    };
+    browserWindow.__LEGALWORK_ELECTRON__ = {
+      invokeDesktop: async (command, ...args) => {
+        desktopCalls.push({ command, args });
+        if (command === "readOpencodeConfig") {
+          return { path: "/tmp/opencode.jsonc", exists: false, content: null };
+        }
+        if (command === "mergeRuntimeMcpServer") {
+          return { ok: true, status: 0, stdout: "removed", stderr: "" };
+        }
+        throw new Error(`Unexpected desktop command: ${command}`);
+      },
+    };
+    Object.defineProperty(globalThis, "window", {
+      value: browserWindow,
+      configurable: true,
+    });
+
+    const serverCalls: Array<{ workspaceId: string; name: string }> = [];
+    const legalworkClient = {
+      removeMcp: async (workspaceId: string, name: string) => {
+        serverCalls.push({ workspaceId, name });
+        return { items: [] };
+      },
+    } as unknown as LegalworkServerClient;
+    const legalworkServer = {
+      getSnapshot: () => ({
+        legalworkServerStatus: "connected",
+        legalworkServerClient: legalworkClient,
+        legalworkServerCapabilities: { mcp: { read: true, write: true } },
+      }),
+    } as unknown as LegalworkServerStore;
+
+    const { createConnectionsStore } = await import("../src/react-app/domains/connections/store");
+    const { getReactQueryClient } = await import("../src/react-app/infra/query-client");
+    const queryClient = getReactQueryClient();
+    queryClient.setQueryData(["legalmemory-tree-roots", "ws-runtime"], {
+      roots: [{ source_id: "stale-drive-root" }],
+    });
+    const store = createConnectionsStore({
+      client: () => null,
+      setClient: () => undefined,
+      projectDir: () => "/tmp/project",
+      selectedWorkspaceId: () => "ws-local",
+      selectedWorkspaceRoot: () => "/tmp/project",
+      workspaceType: () => "local",
+      legalworkServer,
+      runtimeWorkspaceId: () => "ws-runtime",
+      developerMode: () => false,
+    });
+
+    let connectionChanges = 0;
+    browserWindow.addEventListener("legalwork:legalmemory-connection-changed", () => {
+      connectionChanges += 1;
+    });
+
+    await store.removeMcp("legalmemory");
+
+    expect(serverCalls).toEqual([{ workspaceId: "ws-runtime", name: "legalmemory" }]);
+    expect(desktopCalls).toContainEqual({
+      command: "mergeRuntimeMcpServer",
+      args: ["legalmemory", null],
+    });
+    expect(queryClient.getQueryData(["legalmemory-tree-roots", "ws-runtime"])).toBeUndefined();
+    expect(connectionChanges).toBe(1);
+  });
+});

--- a/apps/app/tests/legalmemory-connection.test.ts
+++ b/apps/app/tests/legalmemory-connection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { isLegalMemoryMcpName } from "../src/app/lib/legalmemory-connection";
+
+describe("LegalMemory MCP identity", () => {
+  test("matches every server name accepted by the LegalMemory routes", () => {
+    expect(isLegalMemoryMcpName("legalmemory")).toBe(true);
+    expect(isLegalMemoryMcpName("legal-memory")).toBe(true);
+    expect(isLegalMemoryMcpName("legal_memory")).toBe(true);
+    expect(isLegalMemoryMcpName("knowledge-index")).toBe(true);
+    expect(isLegalMemoryMcpName("knowledge_index")).toBe(true);
+  });
+
+  test("does not reset Drive for unrelated MCP removals", () => {
+    expect(isLegalMemoryMcpName("notion")).toBe(false);
+  });
+});

--- a/apps/app/tests/mention-encoding.test.ts
+++ b/apps/app/tests/mention-encoding.test.ts
@@ -5,6 +5,7 @@ import {
   decodeComposerMentionValue,
   encodeComposerMentionValue,
   legalMemoryComposerInstruction,
+  legalMemoryComposerDisplayText,
   parseLegalMemoryComposerMention,
 } from "../src/react-app/domains/session/surface/composer/mention-encoding";
 
@@ -37,5 +38,26 @@ describe("mention-encoding", () => {
     expect(instruction).toContain('fetch and read "Member consent final.docx"');
     expect(instruction).toContain("legalmemory://document/doc-123");
     expect(instruction).toContain("not a local workspace file");
+  });
+
+  test("keeps a downloaded workspace path as memory metadata instead of an attachment", () => {
+    const value = createLegalMemoryComposerMention(
+      "doc-123",
+      "Member consent final.docx",
+      ".legalmemory/Member consent final.docx",
+    );
+    expect(parseLegalMemoryComposerMention(value)).toEqual({
+      documentId: "doc-123",
+      label: "Member consent final.docx",
+      localPath: ".legalmemory/Member consent final.docx",
+      uri: "legalmemory://document/doc-123",
+    });
+    const instruction = legalMemoryComposerInstruction(value);
+    expect(instruction).toContain('workspace path ".legalmemory/Member consent final.docx"');
+    expect(instruction).toContain("extract or convert DOCX");
+    expect(instruction).toContain("not a binary chat attachment");
+    expect(legalMemoryComposerDisplayText(value)).toBe(
+      "[Member consent final.docx](legalmemory://document/doc-123)",
+    );
   });
 });

--- a/apps/app/tests/mention-encoding.test.ts
+++ b/apps/app/tests/mention-encoding.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { decodeComposerMentionValue, encodeComposerMentionValue } from "../src/react-app/domains/session/surface/composer/mention-encoding";
+import {
+  createLegalMemoryComposerMention,
+  decodeComposerMentionValue,
+  encodeComposerMentionValue,
+  legalMemoryComposerInstruction,
+  parseLegalMemoryComposerMention,
+} from "../src/react-app/domains/session/surface/composer/mention-encoding";
 
 describe("mention-encoding", () => {
   test("round-trips paths with spaces", () => {
@@ -18,5 +24,18 @@ describe("mention-encoding", () => {
   test("round-trips percent signs", () => {
     const value = "docs/100% done.md";
     expect(decodeComposerMentionValue(encodeComposerMentionValue(value))).toBe(value);
+  });
+
+  test("keeps a memory filename for the pill and a canonical URI for the agent", () => {
+    const value = createLegalMemoryComposerMention("doc-123", "Member consent final.docx");
+    expect(parseLegalMemoryComposerMention(value)).toEqual({
+      documentId: "doc-123",
+      label: "Member consent final.docx",
+      uri: "legalmemory://document/doc-123",
+    });
+    const instruction = legalMemoryComposerInstruction(value);
+    expect(instruction).toContain('fetch and read "Member consent final.docx"');
+    expect(instruction).toContain("legalmemory://document/doc-123");
+    expect(instruction).toContain("not a local workspace file");
   });
 });

--- a/apps/desktop/electron/app-menu.mjs
+++ b/apps/desktop/electron/app-menu.mjs
@@ -1,11 +1,13 @@
 // Native application menu: template installation, the macOS/system menu
-// actions that forward into the renderer (settings, updates, sidebar, zoom),
+// actions that forward into the renderer (chat windows, settings, updates,
+// sidebar, zoom),
 // and Windows/Linux menu-bar visibility. Extracted from main.mjs as a
 // factory (createRuntimeManager pattern); the NATIVE_MENU_* channels are
 // consumed by the preload bridge.
 import { BrowserWindow, Menu } from "electron";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "legalwork:native-menu:open-settings";
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "legalwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "legalwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "legalwork:native-menu:zoom";
@@ -19,6 +21,19 @@ export function createApplicationMenu({ appName, getWindow, collectSupportLogs }
     win.show();
     win.focus();
     win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
+  }
+
+  async function openSessionWindowFromNativeMenu(targetWindow) {
+    const focusedWindow = targetWindow && !targetWindow.isDestroyed()
+      ? targetWindow
+      : BrowserWindow.getFocusedWindow();
+    const win = focusedWindow && !focusedWindow.isDestroyed()
+      ? focusedWindow
+      : await getWindow();
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    win.webContents.send(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT);
   }
 
   async function checkForUpdatesFromNativeMenu() {
@@ -81,6 +96,13 @@ export function createApplicationMenu({ appName, getWindow, collectSupportLogs }
       {
         label: "File",
         submenu: [
+          {
+            label: "Open Chat in New Window",
+            click: (_menuItem, targetWindow) => {
+              void openSessionWindowFromNativeMenu(targetWindow);
+            },
+          },
+          { type: "separator" },
           ...(isMac
             ? []
             : [

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -19,7 +19,7 @@ const MENU_OVERLAY_WIDTH = 196;
 const MENU_OVERLAY_HEIGHT = 176;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
 
-export function createBrowserPanel({ getWindow, remoteDebugPort }) {
+export function createBrowserPanel({ getWindow, getWindowForEvent, remoteDebugPort }) {
   const browserTabs = new Map();
   let browserTabOrder = [];
   let activeBrowserTabId = null;
@@ -35,9 +35,39 @@ export function createBrowserPanel({ getWindow, remoteDebugPort }) {
   let menuOverlayReady = false;
   let menuOverlayReadyResolvers = [];
   let menuOverlayShowSerial = 0;
+  let hostWindow = null;
 
   function window() {
+    if (hostWindow && !hostWindow.isDestroyed()) return hostWindow;
+    hostWindow = null;
     return getWindow?.() ?? null;
+  }
+
+  function selectHostWindow(event) {
+    const nextWindow = getWindowForEvent?.(event) ?? null;
+    if (!nextWindow || nextWindow.isDestroyed() || nextWindow === window()) return;
+    const previousWindow = window();
+    if (previousWindow && !previousWindow.isDestroyed()) {
+      for (const tab of browserTabs.values()) {
+        try {
+          if (previousWindow.contentView.children.includes(tab.view)) {
+            previousWindow.contentView.removeChildView(tab.view);
+          }
+        } catch {
+          // The previous host may be closing while a new window takes over.
+        }
+      }
+      if (menuOverlayView) {
+        try {
+          if (previousWindow.contentView.children.includes(menuOverlayView)) {
+            previousWindow.contentView.removeChildView(menuOverlayView);
+          }
+        } catch {
+          // Best effort while switching native hosts.
+        }
+      }
+    }
+    hostWindow = nextWindow;
   }
 
   function resetMenuOverlayReady({ resolvePending = false } = {}) {
@@ -724,44 +754,85 @@ export function createBrowserPanel({ getWindow, remoteDebugPort }) {
   }
 
   function registerIpc(ipcMain) {
-    ipcMain.handle("legalwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
-    ipcMain.handle("legalwork:browser:hide", () => hideBrowserView());
-    ipcMain.handle("legalwork:browser:openUrl", (_event, url, provider) => openBrowserUrlForAutomation(url, provider));
-    ipcMain.handle("legalwork:browser:navigate", (_event, url) => {
+    ipcMain.handle("legalwork:browser:show", (event, bounds) => {
+      selectHostWindow(event);
+      return attachBrowserView(bounds);
+    });
+    ipcMain.handle("legalwork:browser:hide", (event) => {
+      selectHostWindow(event);
+      return hideBrowserView();
+    });
+    ipcMain.handle("legalwork:browser:openUrl", (event, url, provider) => {
+      selectHostWindow(event);
+      return openBrowserUrlForAutomation(url, provider);
+    });
+    ipcMain.handle("legalwork:browser:navigate", (event, url) => {
+      selectHostWindow(event);
       const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
       view.webContents.loadURL(normalizeBrowserUrl(url));
     });
-    ipcMain.handle("legalwork:browser:back", () => {
+    ipcMain.handle("legalwork:browser:back", (event) => {
+      selectHostWindow(event);
       const webContents = getActiveWebContents();
       if (webContents?.canGoBack()) webContents.goBack();
     });
-    ipcMain.handle("legalwork:browser:forward", () => {
+    ipcMain.handle("legalwork:browser:forward", (event) => {
+      selectHostWindow(event);
       const webContents = getActiveWebContents();
       if (webContents?.canGoForward()) webContents.goForward();
     });
-    ipcMain.handle("legalwork:browser:reload", () => getActiveWebContents()?.reload());
-    ipcMain.handle("legalwork:browser:bounds", (_event, bounds) => {
+    ipcMain.handle("legalwork:browser:reload", (event) => {
+      selectHostWindow(event);
+      return getActiveWebContents()?.reload();
+    });
+    ipcMain.handle("legalwork:browser:bounds", (event, bounds) => {
+      selectHostWindow(event);
       lastBrowserBounds = bounds;
       const view = getActiveBrowserView();
       if (view && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
         view.setBounds(scaleRendererBounds(bounds));
       }
     });
-    ipcMain.handle("legalwork:browser:state", () => browserStatePayload());
-    ipcMain.handle("legalwork:browser:createTab", (_event, url) => {
+    ipcMain.handle("legalwork:browser:state", (event) => {
+      selectHostWindow(event);
+      return browserStatePayload();
+    });
+    ipcMain.handle("legalwork:browser:createTab", (event, url) => {
+      selectHostWindow(event);
       const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
       const tab = createBrowserTab(target, { select: true });
       return { tabId: tab.tabId };
     });
-    ipcMain.handle("legalwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));
-    ipcMain.handle("legalwork:browser:closeAllTabs", () => closeAllBrowserTabs());
-    ipcMain.handle("legalwork:browser:selectTab", (_event, tabId) => selectBrowserTab(String(tabId ?? "")).tabId);
-    ipcMain.handle("legalwork:browser:reorderTabs", (_event, tabIds) => reorderBrowserTabs(tabIds));
-    ipcMain.handle("legalwork:browser:listTabs", () => listBrowserTabs());
+    ipcMain.handle("legalwork:browser:closeTab", (event, tabId) => {
+      selectHostWindow(event);
+      return closeBrowserTab(tabId == null ? undefined : String(tabId));
+    });
+    ipcMain.handle("legalwork:browser:closeAllTabs", (event) => {
+      selectHostWindow(event);
+      return closeAllBrowserTabs();
+    });
+    ipcMain.handle("legalwork:browser:selectTab", (event, tabId) => {
+      selectHostWindow(event);
+      return selectBrowserTab(String(tabId ?? "")).tabId;
+    });
+    ipcMain.handle("legalwork:browser:reorderTabs", (event, tabIds) => {
+      selectHostWindow(event);
+      return reorderBrowserTabs(tabIds);
+    });
+    ipcMain.handle("legalwork:browser:listTabs", (event) => {
+      selectHostWindow(event);
+      return listBrowserTabs();
+    });
     ipcMain.handle("legalwork:browser:setProxy", (_event, proxy) => setBrowserProxy(proxy));
     ipcMain.handle("legalwork:browser:getProxy", () => browserProxyState());
-    ipcMain.handle("legalwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
-    ipcMain.handle("legalwork:browser:destroy", () => destroyBrowserView());
+    ipcMain.handle("legalwork:browser:tabContextMenu", (event, tabId, point) => {
+      selectHostWindow(event);
+      return showBrowserTabContextMenu(tabId, point);
+    });
+    ipcMain.handle("legalwork:browser:destroy", (event) => {
+      selectHostWindow(event);
+      return destroyBrowserView();
+    });
     ipcMain.on("legalwork:menu-overlay:ready", (event) => {
       if (event.sender !== menuOverlayView?.webContents) return;
       markMenuOverlayReady(menuOverlayView);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -672,6 +672,7 @@ const IDLE_ROUTER_INFO = Object.freeze({
 });
 
 let mainWindow = null;
+const detachedSessionWindows = new Map();
 const pendingDeepLinks = [];
 
 // Relay a content-free error signal to the renderer, which turns it into an
@@ -704,6 +705,7 @@ process.on("unhandledRejection", (reason) => relayAppError("main_unhandledreject
 const browserPanel = createBrowserPanel({
   remoteDebugPort,
   getWindow: () => mainWindow,
+  getWindowForEvent: (event) => BrowserWindow.fromWebContents(event?.sender) ?? null,
 });
 
 const workspaceStore = createWorkspaceStore({
@@ -1506,7 +1508,121 @@ function applyNativeTheme(mode) {
 
   mainWindow?.setVibrancy(macosVibrancyForCurrentTheme());
   mainWindow?.setBackgroundColor("#00000001");
+  for (const window of detachedSessionWindows.values()) {
+    if (window.isDestroyed()) continue;
+    window.setVibrancy(macosVibrancyForCurrentTheme());
+    window.setBackgroundColor("#00000001");
+  }
 
+  return true;
+}
+
+function sessionWindowRoute(workspaceId, sessionId) {
+  return `/workspace/${encodeURIComponent(workspaceId)}/session/${encodeURIComponent(sessionId)}?detached=1`;
+}
+
+function detachedWindowTitle(value) {
+  const title = String(value ?? "").trim();
+  return title ? title.slice(0, 180) : APP_NAME;
+}
+
+async function openDetachedSessionWindow(event, input = {}) {
+  const workspaceId = String(input?.workspaceId ?? "").trim();
+  const sessionId = String(input?.sessionId ?? "").trim();
+  if (!workspaceId || !sessionId) {
+    throw new Error("A workspace and chat session are required to open a new window.");
+  }
+
+  const key = `${workspaceId}:${sessionId}`;
+  const existing = detachedSessionWindows.get(key);
+  if (existing && !existing.isDestroyed()) {
+    if (existing.isMinimized()) existing.restore();
+    existing.show();
+    existing.focus();
+    return true;
+  }
+
+  const preloadPath = path.join(__dirname, "preload.mjs");
+  const windowAppearanceOptions = {};
+  if (process.platform === "darwin") {
+    Object.assign(windowAppearanceOptions, {
+      backgroundColor: "#00000001",
+      titleBarStyle: "hiddenInset",
+      vibrancy: macosVibrancyForCurrentTheme(),
+      visualEffectState: "active",
+    });
+  }
+
+  const sessionWindow = new BrowserWindow({
+    width: 980,
+    height: 760,
+    minWidth: 640,
+    minHeight: 480,
+    title: detachedWindowTitle(input?.title),
+    show: false,
+    ...windowAppearanceOptions,
+    ...(APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty() ? { icon: APP_ICON_IMAGE } : {}),
+    webPreferences: {
+      backgroundThrottling: false,
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      plugins: true,
+    },
+  });
+  detachedSessionWindows.set(key, sessionWindow);
+  applicationMenu.applyVisibility(sessionWindow);
+  recorderServiceInstance?.subscribe(sessionWindow.webContents);
+
+  sessionWindow.on("page-title-updated", (pageTitleEvent, title) => {
+    pageTitleEvent.preventDefault();
+    sessionWindow.setTitle(detachedWindowTitle(title || input?.title));
+  });
+  sessionWindow.once("ready-to-show", () => {
+    sessionWindow.show();
+    sessionWindow.focus();
+  });
+  sessionWindow.on("closed", () => {
+    if (detachedSessionWindows.get(key) === sessionWindow) {
+      detachedSessionWindows.delete(key);
+    }
+  });
+
+  sessionWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith("file://")) {
+      try {
+        void shell.openPath(fileURLToPath(url));
+      } catch {
+        void shell.openExternal(url);
+      }
+      return { action: "deny" };
+    }
+    const local = url.startsWith("http://127.0.0.1") || url.startsWith("http://localhost");
+    if (!local) {
+      void shell.openExternal(url);
+      return { action: "deny" };
+    }
+    return { action: "allow" };
+  });
+  sessionWindow.webContents.on("will-navigate", (navigationEvent, url) => {
+    if (browserPanel.isMainWindowAllowedNavigation(url)) return;
+    navigationEvent.preventDefault();
+    browserPanel.routeBlockedMainWindowNavigation(url);
+  });
+  sessionWindow.webContents.on("did-start-navigation", (_navigationEvent, url, isInPlace, isMainFrame) => {
+    if (!isMainFrame || isInPlace || browserPanel.isMainWindowAllowedNavigation(url)) return;
+    try {
+      sessionWindow.webContents.stop();
+    } catch {
+      // Best effort — routing below still preserves the detached chat.
+    }
+    browserPanel.routeBlockedMainWindowNavigation(url);
+  });
+
+  const sourceUrl = event.sender.getURL();
+  const appDocumentUrl = sourceUrl.split("#", 1)[0];
+  await sessionWindow.loadURL(`${appDocumentUrl}#${sessionWindowRoute(workspaceId, sessionId)}`);
   return true;
 }
 
@@ -1519,6 +1635,9 @@ function applyNativeTheme(mode) {
 // typecheck:electron`.
 /** @type {import("@legalwork/types/desktop-ipc").DesktopCommandHandlers<import("electron").IpcMainInvokeEvent>} */
 const desktopCommandHandlers = {
+  "openSessionWindow": async (event, ...args) => {
+      return openDetachedSessionWindow(event, args[0] ?? {});
+  },
   "workspaceBootstrap": async (event, ...args) => {
       return workspaceStore.readWorkspaceState();
   },

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "legalwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "legalwork:native-menu:open-settings";
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "legalwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "legalwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "legalwork:native-menu:zoom";
@@ -209,6 +210,11 @@ ipcRenderer.on(NATIVE_DEEP_LINK_EVENT, (_event, urls) => {
 ipcRenderer.on(NATIVE_MENU_OPEN_SETTINGS_EVENT, () => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new Event(NATIVE_MENU_OPEN_SETTINGS_EVENT));
+});
+
+ipcRenderer.on(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT));
 });
 
 ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {

--- a/apps/server/src/legalmemory-fetch.ts
+++ b/apps/server/src/legalmemory-fetch.ts
@@ -20,6 +20,7 @@
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 
 const JSON_RPC_HEADERS = {
   "content-type": "application/json",
@@ -41,7 +42,82 @@ export type FetchedDocument = {
   bytes: Uint8Array;
 };
 
+const legalMemoryTreeRootSchema = z.object({
+  source_id: z.string(),
+  display_name: z.string(),
+  kind: z.string(),
+  project_id: z.string().nullable(),
+  status: z.string(),
+  files: z.number(),
+});
+
+const legalMemoryTreeFolderSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  files: z.number(),
+});
+
+const legalMemoryTreeFileSchema = z.object({
+  source_object_id: z.string(),
+  source_id: z.string(),
+  name: z.string(),
+  path: z.string(),
+  mime_type: z.string().nullable(),
+  size_bytes: z.number().nullable(),
+  mtime: z.string().nullable(),
+  document_id: z.string(),
+});
+
+const legalMemoryTreePageSchema = z.object({
+  source_id: z.string(),
+  path: z.string(),
+  folders: z.array(legalMemoryTreeFolderSchema),
+  files: z.array(legalMemoryTreeFileSchema),
+  pagination: z.object({
+    total: z.number(),
+    offset: z.number(),
+    limit: z.number(),
+    returned: z.number(),
+    has_more: z.boolean(),
+  }),
+});
+
+export type LegalMemoryTreeRoot = z.infer<typeof legalMemoryTreeRootSchema>;
+export type LegalMemoryTreePage = z.infer<typeof legalMemoryTreePageSchema>;
+export type LegalMemoryTreeFile = z.infer<typeof legalMemoryTreeFileSchema>;
+
 const LEGALMEMORY_SERVER_NAME = /^(?:legal[_-]?memory|knowledge[_-]?index)$/i;
+const LEGALMEMORY_MCP_TREE_SOURCE_PREFIX = "__legalmemory_mcp__:";
+const LEGALMEMORY_MCP_MATTER_PREFIX = "matter/";
+
+const legalMemoryMcpMatterSchema = z.object({
+  id: z.string(),
+  title: z.string().nullable().optional(),
+  visible_versions: z.number().optional(),
+});
+
+const legalMemoryMcpDocumentSchema = z.object({
+  document_id: z.string(),
+  version_id: z.string(),
+  title: z.string().nullable().optional(),
+  source_path: z.string(),
+  doc_date: z.string().nullable().optional(),
+});
+
+const legalMemoryMcpSearchResultSchema = z.object({
+  document_id: z.string(),
+  version_id: z.string(),
+  title: z.string().nullable().optional(),
+  source_paths: z.array(z.string()).optional(),
+  doc_date: z.string().nullable().optional(),
+});
+
+const legalMemoryMcpConnectorSchema = z.object({
+  id: z.string(),
+  project_id: z.string().nullable().optional(),
+  kind: z.string(),
+  display_name: z.string(),
+});
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -76,6 +152,112 @@ export function resolveLegalMemoryServer(
   return null;
 }
 
+/**
+ * The tree is served by the same LegalMemory deployment as MCP and authorizes
+ * against the same bearer token. Keep the appliance URL and token on the
+ * LegalWork server: the renderer only talks to its workspace API.
+ */
+export function legalMemoryTreeApiUrl(serverUrl: string, path: string): string {
+  const url = new URL(serverUrl);
+  const normalizedPath = url.pathname.replace(/\/+$/, "");
+  const mcpSuffix = /\/mcp$/i;
+  if (!mcpSuffix.test(normalizedPath)) {
+    throw new Error("LegalMemory MCP URL must end in /mcp");
+  }
+  url.pathname = `${normalizedPath.replace(mcpSuffix, "")}${path.startsWith("/") ? path : `/${path}`}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+/** The hosted demo exposes its appliance tree through one Clerk-protected
+ * proxy route. Raw appliances expose the four `/api/tree/*` routes directly. */
+export function legalMemoryTreeProxyUrl(serverUrl: string, operation: string): string {
+  const url = new URL(legalMemoryTreeApiUrl(serverUrl, "/api/tree"));
+  url.searchParams.set("op", operation);
+  return url.toString();
+}
+
+async function fetchLegalMemoryTreeResponse(
+  server: LegalMemoryServer,
+  url: URL,
+  bearer?: string,
+): Promise<Response> {
+  return fetch(url, {
+    headers: {
+      accept: "application/json",
+      ...(server.headers ?? {}),
+      ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+    },
+  });
+}
+
+async function fetchLegalMemoryTreeJson(
+  server: LegalMemoryServer,
+  path: string,
+  operation: string,
+  params: Record<string, string | number | undefined>,
+  bearer?: string,
+): Promise<unknown> {
+  const candidates = [
+    new URL(legalMemoryTreeProxyUrl(server.url, operation)),
+    new URL(legalMemoryTreeApiUrl(server.url, path)),
+  ];
+  let lastFailure = "LegalMemory file tree failed";
+  for (const url of candidates) {
+    for (const [name, value] of Object.entries(params)) {
+      if (value !== undefined && value !== "") url.searchParams.set(name, String(value));
+    }
+    const response = await fetchLegalMemoryTreeResponse(server, url, bearer);
+    if (response.ok) return response.json();
+    const detail = (await response.text().catch(() => "")).trim().slice(0, 300);
+    lastFailure = `LegalMemory file tree failed (${response.status})${detail ? `: ${detail}` : ""}`;
+  }
+  throw new Error(lastFailure);
+}
+
+export async function fetchLegalMemoryTreeRoots(
+  server: LegalMemoryServer,
+  bearer?: string,
+): Promise<{ roots: LegalMemoryTreeRoot[] }> {
+  try {
+    const body = await fetchLegalMemoryTreeJson(server, "/api/tree/roots", "roots", {}, bearer);
+    return z.object({ roots: z.array(legalMemoryTreeRootSchema) }).parse(body);
+  } catch {
+    return { roots: await fetchLegalMemoryMcpRoots(server, bearer) };
+  }
+}
+
+export async function fetchLegalMemoryTreeChildren(
+  server: LegalMemoryServer,
+  input: { sourceId: string; path?: string; offset: number; limit: number },
+  bearer?: string,
+): Promise<LegalMemoryTreePage> {
+  if (input.sourceId.startsWith(LEGALMEMORY_MCP_TREE_SOURCE_PREFIX)) {
+    return fetchLegalMemoryMcpChildren(server, input, bearer);
+  }
+  const body = await fetchLegalMemoryTreeJson(server, "/api/tree/children", "children", {
+    source_id: input.sourceId,
+    path: input.path,
+    offset: input.offset,
+    limit: input.limit,
+  }, bearer);
+  return legalMemoryTreePageSchema.parse(body);
+}
+
+export async function fetchLegalMemoryTreeSearch(
+  server: LegalMemoryServer,
+  input: { query: string; limit: number },
+  bearer?: string,
+): Promise<{ files: LegalMemoryTreeFile[] }> {
+  try {
+    const body = await fetchLegalMemoryTreeJson(server, "/api/tree/search", "search", input, bearer);
+    return z.object({ files: z.array(legalMemoryTreeFileSchema) }).parse(body);
+  } catch {
+    return { files: await fetchLegalMemoryMcpSearch(server, input, bearer) };
+  }
+}
+
 /** Parse one streamable-HTTP response body, which is either JSON or an SSE
  * frame carrying the JSON on a `data:` line. */
 function parseRpcBody(text: string): unknown {
@@ -103,6 +285,270 @@ async function rpc(session: Session, method: string, params: unknown, id?: numbe
     throw new Error(`LegalMemory ${method} failed (${response.status})`);
   }
   return parseRpcBody(await response.text());
+}
+
+function legalMemorySession(server: LegalMemoryServer, bearer?: string): Session {
+  return {
+    url: server.url,
+    headers: {
+      ...JSON_RPC_HEADERS,
+      ...(server.headers ?? {}),
+      ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+    },
+  };
+}
+
+function legalMemoryToolPayload(value: unknown): unknown {
+  const envelope = asRecord(value);
+  const error = asRecord(envelope?.error);
+  if (error) throw new Error(String(error.message ?? "LegalMemory tool call failed"));
+  const result = asRecord(envelope?.result ?? envelope);
+  if (!result) throw new Error("LegalMemory returned no tool result");
+  if (result.isError === true) throw new Error("LegalMemory tool call failed");
+  const structured = asRecord(result.structuredContent);
+  if (structured) return structured;
+  if (!Array.isArray(result.content)) throw new Error("LegalMemory returned no structured tool content");
+  for (const item of result.content) {
+    const text = asRecord(item)?.text;
+    if (typeof text !== "string") continue;
+    try {
+      return JSON.parse(text);
+    } catch {
+      // Tool cards may precede the JSON payload; keep looking.
+    }
+  }
+  throw new Error("LegalMemory returned no structured tool content");
+}
+
+async function callLegalMemoryTool(
+  server: LegalMemoryServer,
+  name: string,
+  args: Record<string, unknown>,
+  bearer?: string,
+): Promise<unknown> {
+  const session = legalMemorySession(server, bearer);
+  await rpc(session, "initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "LegalWork", version: "1" },
+  }, 1);
+  await rpc(session, "notifications/initialized", {});
+  const result = await rpc(session, "tools/call", { name, arguments: args }, 2);
+  return legalMemoryToolPayload(result);
+}
+
+function normalizedSourcePath(value: string): string {
+  return value.replace(/\\/g, "/").split("/").filter(Boolean).join("/");
+}
+
+function mcpMatterPath(matterId: string, sourcePath = ""): string {
+  const base = `${LEGALMEMORY_MCP_MATTER_PREFIX}${encodeURIComponent(matterId)}`;
+  return sourcePath ? `${base}/${normalizedSourcePath(sourcePath)}` : base;
+}
+
+function parseMcpMatterPath(path: string): { matterId: string; sourcePath: string } {
+  if (!path.startsWith(LEGALMEMORY_MCP_MATTER_PREFIX)) {
+    throw new Error("LegalMemory returned an unknown MCP folder path");
+  }
+  const rest = path.slice(LEGALMEMORY_MCP_MATTER_PREFIX.length);
+  const separator = rest.indexOf("/");
+  const encodedMatterId = separator === -1 ? rest : rest.slice(0, separator);
+  const matterId = decodeURIComponent(encodedMatterId);
+  if (!matterId) throw new Error("LegalMemory returned an empty matter id");
+  return {
+    matterId,
+    sourcePath: separator === -1 ? "" : normalizedSourcePath(rest.slice(separator + 1)),
+  };
+}
+
+async function fetchLegalMemoryMcpMatters(
+  server: LegalMemoryServer,
+  bearer?: string,
+  input: { limit?: number; offset?: number } = {},
+): Promise<z.infer<typeof legalMemoryMcpMatterSchema>[]> {
+  const payload = await callLegalMemoryTool(server, "list_matters", {
+    limit: input.limit ?? 500,
+    offset: input.offset ?? 0,
+  }, bearer);
+  const body = z.object({ results: z.array(legalMemoryMcpMatterSchema) }).parse(payload);
+  return body.results;
+}
+
+function mcpTreeSourceId(connectorId: string): string {
+  return `${LEGALMEMORY_MCP_TREE_SOURCE_PREFIX}${encodeURIComponent(connectorId)}`;
+}
+
+function findLegalMemoryMcpConnectors(
+  value: unknown,
+  found = new Map<string, z.infer<typeof legalMemoryMcpConnectorSchema>>(),
+  depth = 0,
+): Map<string, z.infer<typeof legalMemoryMcpConnectorSchema>> {
+  if (depth > 8) return found;
+  const record = asRecord(value);
+  if (record) {
+    const connector = legalMemoryMcpConnectorSchema.safeParse(record.connector);
+    if (connector.success) found.set(connector.data.id, connector.data);
+    for (const nested of Object.values(record)) {
+      findLegalMemoryMcpConnectors(nested, found, depth + 1);
+    }
+    return found;
+  }
+  if (Array.isArray(value)) {
+    for (const nested of value) findLegalMemoryMcpConnectors(nested, found, depth + 1);
+  }
+  return found;
+}
+
+/**
+ * Hosted demo deployments currently expose the document tools publicly while
+ * their browser-only tree route sits behind the signed-in page. The MCP
+ * citation on an original carries the real connector identity, so use that as
+ * the compatibility root instead of inventing a "LegalMemory" folder above it.
+ * Appliances with the native tree API skip this path and return every connector
+ * directly.
+ */
+async function fetchLegalMemoryMcpRoots(
+  server: LegalMemoryServer,
+  bearer?: string,
+): Promise<LegalMemoryTreeRoot[]> {
+  const matters = await fetchLegalMemoryMcpMatters(server, bearer);
+  const matter = matters[0];
+  if (!matter) return [];
+  const documents = await fetchLegalMemoryMcpDocuments(server, matter.id, bearer);
+  const document = documents[0];
+  if (!document) return [];
+  const payload = await callLegalMemoryTool(server, "download_document", {
+    document_id: document.document_id,
+    version_id: document.version_id,
+    inline_blob: false,
+  }, bearer);
+  return Array.from(findLegalMemoryMcpConnectors(payload).values(), (connector) => ({
+    source_id: mcpTreeSourceId(connector.id),
+    display_name: connector.display_name,
+    kind: connector.kind,
+    project_id: connector.project_id ?? null,
+    status: "ready",
+    // The MCP matter listing omits unclassified documents and has no exact
+    // estate total. Native tree roots carry the authoritative count.
+    files: 0,
+  })).sort((left, right) => left.display_name.localeCompare(right.display_name));
+}
+
+async function fetchLegalMemoryMcpDocuments(
+  server: LegalMemoryServer,
+  matterId: string,
+  bearer?: string,
+): Promise<z.infer<typeof legalMemoryMcpDocumentSchema>[]> {
+  const payload = await callLegalMemoryTool(server, "list_matter_documents", { matter_id: matterId }, bearer);
+  const body = z.object({ results: z.array(legalMemoryMcpDocumentSchema) }).parse(payload);
+  return body.results;
+}
+
+async function fetchLegalMemoryMcpChildren(
+  server: LegalMemoryServer,
+  input: { sourceId: string; path?: string; offset: number; limit: number },
+  bearer?: string,
+): Promise<LegalMemoryTreePage> {
+  const path = input.path ?? "";
+  const treeSourceId = input.sourceId;
+  if (!path) {
+    const matters = await fetchLegalMemoryMcpMatters(server, bearer);
+    return {
+      source_id: treeSourceId,
+      path,
+      folders: matters.map((matter) => ({
+        name: matter.title?.trim() || matter.id,
+        path: mcpMatterPath(matter.id),
+        files: matter.visible_versions ?? 0,
+      })),
+      files: [],
+      pagination: { total: 0, offset: input.offset, limit: input.limit, returned: 0, has_more: false },
+    };
+  }
+
+  const location = parseMcpMatterPath(path);
+  const documents = await fetchLegalMemoryMcpDocuments(server, location.matterId, bearer);
+  const rawPaths = documents.map((document) => normalizedSourcePath(document.source_path));
+  const matterPrefix = rawPaths[0]?.split("/")[0] ?? "";
+  const folderCounts = new Map<string, number>();
+  const filesById = new Map<string, LegalMemoryTreeFile>();
+  for (const [index, document] of documents.entries()) {
+    const rawPath = rawPaths[index] ?? "";
+    const sourcePath = matterPrefix && rawPath.startsWith(`${matterPrefix}/`)
+      ? rawPath.slice(matterPrefix.length + 1)
+      : rawPath;
+    const relativePath = location.sourcePath
+      ? sourcePath.startsWith(`${location.sourcePath}/`)
+        ? sourcePath.slice(location.sourcePath.length + 1)
+        : ""
+      : sourcePath;
+    if (!relativePath) continue;
+    const segments = relativePath.split("/");
+    if (segments.length > 1) {
+      const name = segments[0];
+      if (name) folderCounts.set(name, (folderCounts.get(name) ?? 0) + 1);
+      continue;
+    }
+    const name = segments[0] || document.title?.trim() || document.document_id;
+    filesById.set(`${document.version_id}:${sourcePath}`, {
+      source_object_id: `${document.version_id}:${sourcePath}`,
+      source_id: treeSourceId,
+      name,
+      path: sourcePath,
+      mime_type: null,
+      size_bytes: null,
+      mtime: document.doc_date ?? null,
+      document_id: document.document_id,
+    });
+  }
+
+  const folders = Array.from(folderCounts, ([name, files]) => ({
+    name,
+    path: mcpMatterPath(location.matterId, [location.sourcePath, name].filter(Boolean).join("/")),
+    files,
+  })).sort((left, right) => left.name.localeCompare(right.name));
+  const allFiles = Array.from(filesById.values()).sort((left, right) => left.name.localeCompare(right.name));
+  const files = allFiles.slice(input.offset, input.offset + input.limit);
+  return {
+    source_id: treeSourceId,
+    path,
+    folders,
+    files,
+    pagination: {
+      total: allFiles.length,
+      offset: input.offset,
+      limit: input.limit,
+      returned: files.length,
+      has_more: input.offset + files.length < allFiles.length,
+    },
+  };
+}
+
+async function fetchLegalMemoryMcpSearch(
+  server: LegalMemoryServer,
+  input: { query: string; limit: number },
+  bearer?: string,
+): Promise<LegalMemoryTreeFile[]> {
+  const payload = await callLegalMemoryTool(server, "search_semantic", {
+    query: input.query,
+    limit: input.limit,
+    offset: 0,
+  }, bearer);
+  const body = z.object({ results: z.array(legalMemoryMcpSearchResultSchema) }).parse(payload);
+  return body.results.flatMap((result) => {
+    const sourcePath = normalizedSourcePath(result.source_paths?.[0] ?? result.title ?? "");
+    if (!sourcePath) return [];
+    return [{
+      source_object_id: `${result.version_id}:${sourcePath}`,
+      source_id: mcpTreeSourceId("search"),
+      name: sourcePath.split("/").pop() ?? result.title?.trim() ?? result.document_id,
+      path: sourcePath,
+      mime_type: null,
+      size_bytes: null,
+      mtime: result.doc_date ?? null,
+      document_id: result.document_id,
+    }];
+  });
 }
 
 /** Walk a tool result for the first base64 resource blob. */

--- a/apps/server/src/legalmemory-tree.test.ts
+++ b/apps/server/src/legalmemory-tree.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { legalMemoryTreeApiUrl, legalMemoryTreeProxyUrl } from "./legalmemory-fetch.js";
+
+describe("LegalMemory tree API URL", () => {
+  test("resolves tree routes beside the configured MCP endpoint", () => {
+    expect(legalMemoryTreeApiUrl("https://memory.firm.example/mcp/", "/api/tree/roots"))
+      .toBe("https://memory.firm.example/api/tree/roots");
+    expect(legalMemoryTreeApiUrl("https://firm.example/legalmemory/mcp?ignored=1", "api/tree/search"))
+      .toBe("https://firm.example/legalmemory/api/tree/search");
+  });
+
+  test("refuses to guess from an unrelated endpoint", () => {
+    expect(() => legalMemoryTreeApiUrl("https://memory.firm.example/events", "/api/tree/roots"))
+      .toThrow("must end in /mcp");
+  });
+
+  test("resolves the hosted demo tree proxy beside MCP", () => {
+    expect(legalMemoryTreeProxyUrl("https://memory.firm.example/mcp/", "children"))
+      .toBe("https://memory.firm.example/api/tree?op=children");
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -8,6 +8,9 @@ import {
   fetchLegalMemoryDocument,
   fetchLegalMemoryGraph,
   fetchLegalMemoryMatters,
+  fetchLegalMemoryTreeChildren,
+  fetchLegalMemoryTreeRoots,
+  fetchLegalMemoryTreeSearch,
   resolveLegalMemoryServer,
 } from "./legalmemory-fetch.js";
 import { fileURLToPath } from "node:url";
@@ -2231,6 +2234,68 @@ function createRoutes(
     }
   });
 
+  // The caller's LegalMemory estate as a lazy file tree. The LegalWork server
+  // owns the configured appliance URL and reuses the engine's MCP bearer, so
+  // the renderer sees neither while each listing keeps the caller's ACLs.
+  addRoute(routes, "POST", "/workspace/:id/legalmemory/tree/roots", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const server = resolveLegalMemoryServer(await listMcp(config, workspace.id, workspace.path));
+    if (!server) throw new ApiError(409, "legalmemory_not_configured", "No LegalMemory server is configured");
+    try {
+      return jsonResponse(await fetchLegalMemoryTreeRoots(server, await engineAccessToken(server.name)));
+    } catch (error) {
+      throw new ApiError(502, "legalmemory_tree_failed", error instanceof Error ? error.message : "File tree failed");
+    }
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/legalmemory/tree/children", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBodyLimited(ctx.request, 16 * 1024);
+    const sourceId = typeof body.source_id === "string" ? body.source_id.trim() : "";
+    const path = typeof body.path === "string" ? body.path.trim() : "";
+    const offset = typeof body.offset === "number" && Number.isInteger(body.offset) ? Math.max(0, body.offset) : 0;
+    const limit = typeof body.limit === "number" && Number.isInteger(body.limit)
+      ? Math.min(250, Math.max(1, body.limit))
+      : 200;
+    if (!sourceId) throw new ApiError(400, "invalid_source_id", "A source_id is required");
+    if (path.length > 4096) throw new ApiError(400, "invalid_tree_path", "The folder path is too long");
+    const server = resolveLegalMemoryServer(await listMcp(config, workspace.id, workspace.path));
+    if (!server) throw new ApiError(409, "legalmemory_not_configured", "No LegalMemory server is configured");
+    try {
+      return jsonResponse(await fetchLegalMemoryTreeChildren(
+        server,
+        { sourceId, path: path || undefined, offset, limit },
+        await engineAccessToken(server.name),
+      ));
+    } catch (error) {
+      throw new ApiError(502, "legalmemory_tree_failed", error instanceof Error ? error.message : "Folder listing failed");
+    }
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/legalmemory/tree/search", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBodyLimited(ctx.request, 16 * 1024);
+    const query = typeof body.query === "string" ? body.query.trim() : "";
+    const limit = typeof body.limit === "number" && Number.isInteger(body.limit)
+      ? Math.min(100, Math.max(1, body.limit))
+      : 100;
+    if (!query) return jsonResponse({ files: [] });
+    const server = resolveLegalMemoryServer(await listMcp(config, workspace.id, workspace.path));
+    if (!server) throw new ApiError(409, "legalmemory_not_configured", "No LegalMemory server is configured");
+    try {
+      return jsonResponse(await fetchLegalMemoryTreeSearch(
+        server,
+        { query, limit },
+        await engineAccessToken(server.name),
+      ));
+    } catch (error) {
+      throw new ApiError(502, "legalmemory_tree_failed", error instanceof Error ? error.message : "File search failed");
+    }
+  });
+
   // The stored relations around a cited document, fetched by the app.
   //
   // The agent is asked to traverse before concluding and does not: on a real
@@ -4262,4 +4327,3 @@ async function materializeBlueprintSessions(config: ServerConfig, workspace: Wor
 
   return { ok: true, created, existing: [], openSessionId };
 }
-

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -374,6 +374,12 @@ export type OfficeAddinOpenAppResult = {
 // ---------------------------------------------------------------------------
 
 export type DesktopCommandMap = {
+  // Native windows
+  openSessionWindow: {
+    args: [input: { workspaceId: string; sessionId: string; title?: string }];
+    result: boolean;
+  };
+
   // Workspace state
   workspaceBootstrap: { args: []; result: WorkspaceList };
   workspaceSetSelected: { args: [workspaceId: string]; result: WorkspaceList };


### PR DESCRIPTION
## Summary

This PR adds a LegalMemory-backed Drive and makes chat sessions behave like native macOS document windows.

https://github.com/user-attachments/assets/f7fa597e-71aa-40ed-ae91-5b7db64d0746

### LegalMemory Drive

- Add Drive above Workflows in the primary sidebar, with Learning directly below Recorder.
- Render each connected LegalMemory system as a root folder; LegalMemory itself is not an extra root.
- Show a clear connection empty state when LegalMemory is unavailable.
- Download selected files into the workspace `.legalmemory` temp folder and open them in the existing right artifact sidebar.
- Support drag-and-drop into chat with a clean file pill. The local downloaded path is sent only as hidden agent context, never as visible prompt text or a binary chat attachment.
- Fully disconnect LegalMemory across the desktop config, LegalWork server runtime store, and active engine so Drive listing and downloads stop immediately.
- Clear cached Drive rows on disconnect, including when the Drive panel was closed.
- Start the primary sidebar at its minimum width and dismiss its narrow-window overlay when Drive opens.

### Native chat windows

- Open a chat in its own native window from the titlebar, File menu, session context menu, or by double-clicking the session row.
- Keep the full chat workspace together in the detached window, including artifact, files, extensions, voice, browser, and terminal sidebars.
- Route embedded browser panels to the native window that owns the active chat.
- Reuse and focus the existing detached window when the same session is opened again.

The explicit titlebar and File menu commands make the capability discoverable; double-click remains a convenient macOS-style shortcut.

## Verification

- `pnpm --filter legalwork-server test` — 508 passed, 2 skipped
- `pnpm --filter legalwork-server typecheck`
- `pnpm --filter @legalwork/app test` — 289 passed
- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter @legalwork/app build`
- `pnpm --filter @legalwork/desktop typecheck:electron`
- `pnpm --filter @legalwork/desktop check:electron`
- `pnpm --filter @legalwork/desktop test` — 87 passed, 1 skipped
- Manually verified the LegalMemory tree, download, file preview, clean chat pill, detached window actions, right-side panels, and responsive Drive behavior in Electron dev.
- Manually verified the disconnected Drive renders its connection state and the LegalMemory tree endpoint returns HTTP 409.