### PR TITLE
Make chat sessions detachable native windows

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePanelRef } from "react-resizable-panels";
-import { Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
+import { AppWindowMac, Columns2, FileText, Folder, Globe, Mic2, ScrollText, Settings2, SquarePen, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { LEGALWORK_EXTENSION_CATALOG } from "../../../../app/constants";
@@ -80,6 +80,7 @@ const STARTUP_SKELETON_ROWS = [
 ];
 const GLOBAL_VOICE_SIDE_PANEL_KEY = "__legalwork_voice__";
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 
 export type OpenSessionTab = {
   workspaceId: string;
@@ -846,6 +847,16 @@ export function SessionPage(props: SessionPageProps) {
     });
   }, [props.sidebar.workspaceSessionGroups]);
 
+  useEffect(() => {
+    if (props.detached || !props.selectedSessionId || !isElectronRuntime()) return;
+    const selectedSessionId = props.selectedSessionId;
+    const handleNativeOpenSessionWindow = () => {
+      openSessionWindow(props.selectedWorkspaceId, selectedSessionId);
+    };
+    window.addEventListener(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, handleNativeOpenSessionWindow);
+    return () => window.removeEventListener(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, handleNativeOpenSessionWindow);
+  }, [openSessionWindow, props.detached, props.selectedSessionId, props.selectedWorkspaceId]);
+
   const closeSessionTab = useCallback((sessionId: string) => {
     setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
     setSplitSessionId((current) => current === sessionId ? null : current);
@@ -1126,6 +1137,17 @@ export function SessionPage(props: SessionPageProps) {
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {/* Revert/redo moved to per-message actions */}
+              {!props.detached && props.selectedSessionId && isElectronRuntime() ? (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => openSessionWindow(props.selectedWorkspaceId, props.selectedSessionId!)}
+                  title="Open chat in new window"
+                  aria-label="Open chat in new window"
+                >
+                  <AppWindowMac size={16} />
+                </Button>
+              ) : null}
               <NotificationBell />
               {props.developerMode ? (
                 <Button

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -16,7 +16,7 @@ import {
 import { materializeLegalMemoryFile } from "../../../../app/lib/legalmemory-file";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
-import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
+import { desktopBridge, openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
 import type {
   PendingPermission,
   PendingQuestion,
@@ -136,6 +136,8 @@ export type SessionPageSurfaceProps = Omit<
 >;
 
 export type SessionPageProps = {
+  /** Native secondary chat window: omit the primary navigation sidebar. */
+  detached?: boolean;
   selectedSessionId: string | null;
   selectedWorkspaceId: string;
   selectedWorkspaceDisplay: {
@@ -737,6 +739,10 @@ export function SessionPage(props: SessionPageProps) {
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
   useEffect(() => {
+    if (!props.detached) return;
+    document.title = selectedSessionTitle || t("session.default_title");
+  }, [props.detached, selectedSessionTitle]);
+  useEffect(() => {
     setSessionTabs((current) => {
       const currentWorkspaceTabs = current.filter((tab) => tab.workspaceId === props.selectedWorkspaceId);
       const next = props.selectedSessionId && !currentWorkspaceTabs.some((tab) => tab.sessionId === props.selectedSessionId)
@@ -832,6 +838,14 @@ export function SessionPage(props: SessionPageProps) {
     props.sidebar.onOpenSession(workspaceId, sessionId);
   }, [props.sidebar]);
 
+  const openSessionWindow = useCallback((workspaceId: string, sessionId: string) => {
+    if (!isElectronRuntime()) return;
+    const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId);
+    void desktopBridge.openSessionWindow({ workspaceId, sessionId, title }).catch(() => {
+      toast.error("Could not open the chat in a new window.");
+    });
+  }, [props.sidebar.workspaceSessionGroups]);
+
   const closeSessionTab = useCallback((sessionId: string) => {
     setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
     setSplitSessionId((current) => current === sessionId ? null : current);
@@ -909,7 +923,7 @@ export function SessionPage(props: SessionPageProps) {
         )}
         style={sidebarProviderStyle}
       >
-        <AppSidebar
+        {!props.detached ? <AppSidebar
           workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
           developerMode={props.sidebar.developerMode}
@@ -922,6 +936,7 @@ export function SessionPage(props: SessionPageProps) {
           newTaskDisabled={props.sidebar.newTaskDisabled}
           onSelectWorkspace={props.sidebar.onSelectWorkspace}
           onOpenSession={openSessionTab}
+          onOpenSessionWindow={isElectronRuntime() ? openSessionWindow : undefined}
           onPrefetchSession={props.sidebar.onPrefetchSession}
           onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
           onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
@@ -951,8 +966,8 @@ export function SessionPage(props: SessionPageProps) {
           activeNav={props.sidebar.activeNav}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
-        />
-        {driveOpen ? (
+        /> : null}
+        {!props.detached && driveOpen ? (
           <LegalMemoryFilesPanel
             key={props.runtimeWorkspaceId ?? "__no_workspace__"}
             client={props.legalworkServerClient}
@@ -1080,9 +1095,9 @@ export function SessionPage(props: SessionPageProps) {
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
-          <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
+          <header className={cn("z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar", props.detached && "mac:pl-20")}>
             <div className="flex min-w-0 items-center gap-3">
-              {shellConfig.sidebar ? (
+              {!props.detached && shellConfig.sidebar ? (
                 <SidebarTrigger className="mac:hidden" />
               ) : (
                 // Keeps the title clear of overlaid leading controls (e.g. the
@@ -1581,7 +1596,7 @@ export function SessionPage(props: SessionPageProps) {
           </div>
         </SidebarInset>
         )}
-        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
+        {!props.detached && shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
       </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -13,6 +13,7 @@ export type SidebarContextValue = {
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onOpenSessionWindow?: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Plus,
   Trash2,
   FolderOpen,
+  AppWindowMac,
   Tag,
 } from "lucide-react";
 import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
@@ -187,6 +188,15 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
   if (variant === "dropdown") {
     return (
       <>
+        {ctx.onOpenSessionWindow ? (
+          <>
+            <DropdownMenuItem onClick={() => ctx.onOpenSessionWindow?.(workspaceId, sessionId)}>
+              <AppWindowMac className="size-4" />
+              Open in New Window
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         <DropdownMenuItem onClick={() => store.getState().togglePin(sessionId)}>
           {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
           {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
@@ -260,6 +270,15 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
 
   return (
     <>
+      {ctx.onOpenSessionWindow ? (
+        <>
+          <ContextMenuItem onClick={() => ctx.onOpenSessionWindow?.(workspaceId, sessionId)}>
+            <AppWindowMac className="size-4" />
+            Open in New Window
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+        </>
+      ) : null}
       <ContextMenuItem onClick={() => store.getState().togglePin(sessionId)}>
         {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
         {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
@@ -450,6 +469,7 @@ export type AppSidebarProps = {
   newTaskDisabled: boolean;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onOpenSessionWindow?: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;
@@ -615,6 +635,7 @@ export function AppSidebar(props: AppSidebarProps) {
     workspaceConnectionStateById: props.workspaceConnectionStateById,
     onSelectWorkspace: props.onSelectWorkspace,
     onOpenSession: props.onOpenSession,
+    onOpenSessionWindow: props.onOpenSessionWindow,
     onPrefetchSession: props.onPrefetchSession,
     onCreateTaskInWorkspace: props.onCreateTaskInWorkspace,
     onOpenRenameSession: props.onOpenRenameSession,
@@ -1545,6 +1566,13 @@ function SessionMenuItem({
     ctx.onOpenSession(workspaceId, session.id);
   };
 
+  const openSessionWindow = (event: React.MouseEvent) => {
+    if (!ctx.onOpenSessionWindow) return;
+    event.preventDefault();
+    event.stopPropagation();
+    ctx.onOpenSessionWindow(workspaceId, session.id);
+  };
+
   const prefetchSession = () => {
     if (workspaceId !== ctx.selectedWorkspaceId) {
       return;
@@ -1575,6 +1603,7 @@ function SessionMenuItem({
                 className={cn("relative", depth > 0 && "ps-13")}
                 isActive={isSelected}
                 onClick={openSession}
+                onDoubleClick={openSessionWindow}
                 onPointerEnter={prefetchSession}
                 onFocus={prefetchSession}
               >
@@ -1608,6 +1637,7 @@ function SessionMenuItem({
         <SidebarMenuSubButton
           isActive={isSelected}
           onClick={openSession}
+          onDoubleClick={openSessionWindow}
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
           className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", isSessionStreaming || isSessionActive && "pe-8")}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -51,6 +51,7 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarRail,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import {
   Collapsible,
@@ -515,7 +516,12 @@ const NAV_ITEM_CLASS =
 
 export function AppSidebar(props: AppSidebarProps) {
   const { config: shellConfig } = useShellConfig();
+  const { isMobile, setOpenMobile } = useSidebar();
   const navigate = useNavigate();
+  const toggleDrive = React.useCallback(() => {
+    if (isMobile) setOpenMobile(false);
+    props.onToggleDrive?.();
+  }, [isMobile, props.onToggleDrive, setOpenMobile]);
   const goSettings = React.useCallback(
     (tab: string) => {
       const ws = props.selectedWorkspaceId.trim();
@@ -714,7 +720,7 @@ export function AppSidebar(props: AppSidebarProps) {
             <SidebarMenuButton
               className={cn(NAV_ITEM_CLASS, "[&_svg]:size-[18px]")}
               isActive={props.driveOpen}
-              onClick={() => props.onToggleDrive?.()}
+              onClick={toggleDrive}
             >
               <HardDrive className="size-[18px]" strokeWidth={1.5} />
               <span>Drive</span>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -310,6 +310,11 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
 export function SessionRoute() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const detached = useMemo(
+    () => new URLSearchParams(location.search).get("detached") === "1",
+    [location.search],
+  );
   const [showLearnings, setShowLearnings] = useState(false);
   // Top-level pages that live in the main shell (sidebar stays, main pane swaps),
   // same mechanism as Learnings. Mutually exclusive — only one main pane at a time.
@@ -1672,6 +1677,7 @@ export function SessionRoute() {
       <TranscriptionSetupStep onDone={finishOnboarding} />
     ) : null}
     <SessionPage
+      detached={detached}
       selectedSessionId={selectedSessionId}
       selectedWorkspaceId={selectedWorkspaceId}
       selectedWorkspaceDisplay={selectedWorkspace ? {

--- a/apps/desktop/electron/app-menu.mjs
+++ b/apps/desktop/electron/app-menu.mjs
@@ -1,11 +1,13 @@
 // Native application menu: template installation, the macOS/system menu
-// actions that forward into the renderer (settings, updates, sidebar, zoom),
+// actions that forward into the renderer (chat windows, settings, updates,
+// sidebar, zoom),
 // and Windows/Linux menu-bar visibility. Extracted from main.mjs as a
 // factory (createRuntimeManager pattern); the NATIVE_MENU_* channels are
 // consumed by the preload bridge.
 import { BrowserWindow, Menu } from "electron";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "legalwork:native-menu:open-settings";
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "legalwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "legalwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "legalwork:native-menu:zoom";
@@ -19,6 +21,19 @@ export function createApplicationMenu({ appName, getWindow, collectSupportLogs }
     win.show();
     win.focus();
     win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
+  }
+
+  async function openSessionWindowFromNativeMenu(targetWindow) {
+    const focusedWindow = targetWindow && !targetWindow.isDestroyed()
+      ? targetWindow
+      : BrowserWindow.getFocusedWindow();
+    const win = focusedWindow && !focusedWindow.isDestroyed()
+      ? focusedWindow
+      : await getWindow();
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    win.webContents.send(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT);
   }
 
   async function checkForUpdatesFromNativeMenu() {
@@ -81,6 +96,13 @@ export function createApplicationMenu({ appName, getWindow, collectSupportLogs }
       {
         label: "File",
         submenu: [
+          {
+            label: "Open Chat in New Window",
+            click: (_menuItem, targetWindow) => {
+              void openSessionWindowFromNativeMenu(targetWindow);
+            },
+          },
+          { type: "separator" },
           ...(isMac
             ? []
             : [

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -19,7 +19,7 @@ const MENU_OVERLAY_WIDTH = 196;
 const MENU_OVERLAY_HEIGHT = 176;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
 
-export function createBrowserPanel({ getWindow, remoteDebugPort }) {
+export function createBrowserPanel({ getWindow, getWindowForEvent, remoteDebugPort }) {
   const browserTabs = new Map();
   let browserTabOrder = [];
   let activeBrowserTabId = null;
@@ -35,9 +35,39 @@ export function createBrowserPanel({ getWindow, remoteDebugPort }) {
   let menuOverlayReady = false;
   let menuOverlayReadyResolvers = [];
   let menuOverlayShowSerial = 0;
+  let hostWindow = null;
 
   function window() {
+    if (hostWindow && !hostWindow.isDestroyed()) return hostWindow;
+    hostWindow = null;
     return getWindow?.() ?? null;
+  }
+
+  function selectHostWindow(event) {
+    const nextWindow = getWindowForEvent?.(event) ?? null;
+    if (!nextWindow || nextWindow.isDestroyed() || nextWindow === window()) return;
+    const previousWindow = window();
+    if (previousWindow && !previousWindow.isDestroyed()) {
+      for (const tab of browserTabs.values()) {
+        try {
+          if (previousWindow.contentView.children.includes(tab.view)) {
+            previousWindow.contentView.removeChildView(tab.view);
+          }
+        } catch {
+          // The previous host may be closing while a new window takes over.
+        }
+      }
+      if (menuOverlayView) {
+        try {
+          if (previousWindow.contentView.children.includes(menuOverlayView)) {
+            previousWindow.contentView.removeChildView(menuOverlayView);
+          }
+        } catch {
+          // Best effort while switching native hosts.
+        }
+      }
+    }
+    hostWindow = nextWindow;
   }
 
   function resetMenuOverlayReady({ resolvePending = false } = {}) {
@@ -724,44 +754,85 @@ export function createBrowserPanel({ getWindow, remoteDebugPort }) {
   }
 
   function registerIpc(ipcMain) {
-    ipcMain.handle("legalwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
-    ipcMain.handle("legalwork:browser:hide", () => hideBrowserView());
-    ipcMain.handle("legalwork:browser:openUrl", (_event, url, provider) => openBrowserUrlForAutomation(url, provider));
-    ipcMain.handle("legalwork:browser:navigate", (_event, url) => {
+    ipcMain.handle("legalwork:browser:show", (event, bounds) => {
+      selectHostWindow(event);
+      return attachBrowserView(bounds);
+    });
+    ipcMain.handle("legalwork:browser:hide", (event) => {
+      selectHostWindow(event);
+      return hideBrowserView();
+    });
+    ipcMain.handle("legalwork:browser:openUrl", (event, url, provider) => {
+      selectHostWindow(event);
+      return openBrowserUrlForAutomation(url, provider);
+    });
+    ipcMain.handle("legalwork:browser:navigate", (event, url) => {
+      selectHostWindow(event);
       const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
       view.webContents.loadURL(normalizeBrowserUrl(url));
     });
-    ipcMain.handle("legalwork:browser:back", () => {
+    ipcMain.handle("legalwork:browser:back", (event) => {
+      selectHostWindow(event);
       const webContents = getActiveWebContents();
       if (webContents?.canGoBack()) webContents.goBack();
     });
-    ipcMain.handle("legalwork:browser:forward", () => {
+    ipcMain.handle("legalwork:browser:forward", (event) => {
+      selectHostWindow(event);
       const webContents = getActiveWebContents();
       if (webContents?.canGoForward()) webContents.goForward();
     });
-    ipcMain.handle("legalwork:browser:reload", () => getActiveWebContents()?.reload());
-    ipcMain.handle("legalwork:browser:bounds", (_event, bounds) => {
+    ipcMain.handle("legalwork:browser:reload", (event) => {
+      selectHostWindow(event);
+      return getActiveWebContents()?.reload();
+    });
+    ipcMain.handle("legalwork:browser:bounds", (event, bounds) => {
+      selectHostWindow(event);
       lastBrowserBounds = bounds;
       const view = getActiveBrowserView();
       if (view && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
         view.setBounds(scaleRendererBounds(bounds));
       }
     });
-    ipcMain.handle("legalwork:browser:state", () => browserStatePayload());
-    ipcMain.handle("legalwork:browser:createTab", (_event, url) => {
+    ipcMain.handle("legalwork:browser:state", (event) => {
+      selectHostWindow(event);
+      return browserStatePayload();
+    });
+    ipcMain.handle("legalwork:browser:createTab", (event, url) => {
+      selectHostWindow(event);
       const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
       const tab = createBrowserTab(target, { select: true });
       return { tabId: tab.tabId };
     });
-    ipcMain.handle("legalwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));
-    ipcMain.handle("legalwork:browser:closeAllTabs", () => closeAllBrowserTabs());
-    ipcMain.handle("legalwork:browser:selectTab", (_event, tabId) => selectBrowserTab(String(tabId ?? "")).tabId);
-    ipcMain.handle("legalwork:browser:reorderTabs", (_event, tabIds) => reorderBrowserTabs(tabIds));
-    ipcMain.handle("legalwork:browser:listTabs", () => listBrowserTabs());
+    ipcMain.handle("legalwork:browser:closeTab", (event, tabId) => {
+      selectHostWindow(event);
+      return closeBrowserTab(tabId == null ? undefined : String(tabId));
+    });
+    ipcMain.handle("legalwork:browser:closeAllTabs", (event) => {
+      selectHostWindow(event);
+      return closeAllBrowserTabs();
+    });
+    ipcMain.handle("legalwork:browser:selectTab", (event, tabId) => {
+      selectHostWindow(event);
+      return selectBrowserTab(String(tabId ?? "")).tabId;
+    });
+    ipcMain.handle("legalwork:browser:reorderTabs", (event, tabIds) => {
+      selectHostWindow(event);
+      return reorderBrowserTabs(tabIds);
+    });
+    ipcMain.handle("legalwork:browser:listTabs", (event) => {
+      selectHostWindow(event);
+      return listBrowserTabs();
+    });
     ipcMain.handle("legalwork:browser:setProxy", (_event, proxy) => setBrowserProxy(proxy));
     ipcMain.handle("legalwork:browser:getProxy", () => browserProxyState());
-    ipcMain.handle("legalwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
-    ipcMain.handle("legalwork:browser:destroy", () => destroyBrowserView());
+    ipcMain.handle("legalwork:browser:tabContextMenu", (event, tabId, point) => {
+      selectHostWindow(event);
+      return showBrowserTabContextMenu(tabId, point);
+    });
+    ipcMain.handle("legalwork:browser:destroy", (event) => {
+      selectHostWindow(event);
+      return destroyBrowserView();
+    });
     ipcMain.on("legalwork:menu-overlay:ready", (event) => {
       if (event.sender !== menuOverlayView?.webContents) return;
       markMenuOverlayReady(menuOverlayView);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -672,6 +672,7 @@ const IDLE_ROUTER_INFO = Object.freeze({
 });
 
 let mainWindow = null;
+const detachedSessionWindows = new Map();
 const pendingDeepLinks = [];
 
 // Relay a content-free error signal to the renderer, which turns it into an
@@ -704,6 +705,7 @@ process.on("unhandledRejection", (reason) => relayAppError("main_unhandledreject
 const browserPanel = createBrowserPanel({
   remoteDebugPort,
   getWindow: () => mainWindow,
+  getWindowForEvent: (event) => BrowserWindow.fromWebContents(event?.sender) ?? null,
 });
 
 const workspaceStore = createWorkspaceStore({
@@ -1506,7 +1508,121 @@ function applyNativeTheme(mode) {
 
   mainWindow?.setVibrancy(macosVibrancyForCurrentTheme());
   mainWindow?.setBackgroundColor("#00000001");
+  for (const window of detachedSessionWindows.values()) {
+    if (window.isDestroyed()) continue;
+    window.setVibrancy(macosVibrancyForCurrentTheme());
+    window.setBackgroundColor("#00000001");
+  }
 
+  return true;
+}
+
+function sessionWindowRoute(workspaceId, sessionId) {
+  return `/workspace/${encodeURIComponent(workspaceId)}/session/${encodeURIComponent(sessionId)}?detached=1`;
+}
+
+function detachedWindowTitle(value) {
+  const title = String(value ?? "").trim();
+  return title ? title.slice(0, 180) : APP_NAME;
+}
+
+async function openDetachedSessionWindow(event, input = {}) {
+  const workspaceId = String(input?.workspaceId ?? "").trim();
+  const sessionId = String(input?.sessionId ?? "").trim();
+  if (!workspaceId || !sessionId) {
+    throw new Error("A workspace and chat session are required to open a new window.");
+  }
+
+  const key = `${workspaceId}:${sessionId}`;
+  const existing = detachedSessionWindows.get(key);
+  if (existing && !existing.isDestroyed()) {
+    if (existing.isMinimized()) existing.restore();
+    existing.show();
+    existing.focus();
+    return true;
+  }
+
+  const preloadPath = path.join(__dirname, "preload.mjs");
+  const windowAppearanceOptions = {};
+  if (process.platform === "darwin") {
+    Object.assign(windowAppearanceOptions, {
+      backgroundColor: "#00000001",
+      titleBarStyle: "hiddenInset",
+      vibrancy: macosVibrancyForCurrentTheme(),
+      visualEffectState: "active",
+    });
+  }
+
+  const sessionWindow = new BrowserWindow({
+    width: 980,
+    height: 760,
+    minWidth: 640,
+    minHeight: 480,
+    title: detachedWindowTitle(input?.title),
+    show: false,
+    ...windowAppearanceOptions,
+    ...(APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty() ? { icon: APP_ICON_IMAGE } : {}),
+    webPreferences: {
+      backgroundThrottling: false,
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      plugins: true,
+    },
+  });
+  detachedSessionWindows.set(key, sessionWindow);
+  applicationMenu.applyVisibility(sessionWindow);
+  recorderServiceInstance?.subscribe(sessionWindow.webContents);
+
+  sessionWindow.on("page-title-updated", (pageTitleEvent, title) => {
+    pageTitleEvent.preventDefault();
+    sessionWindow.setTitle(detachedWindowTitle(title || input?.title));
+  });
+  sessionWindow.once("ready-to-show", () => {
+    sessionWindow.show();
+    sessionWindow.focus();
+  });
+  sessionWindow.on("closed", () => {
+    if (detachedSessionWindows.get(key) === sessionWindow) {
+      detachedSessionWindows.delete(key);
+    }
+  });
+
+  sessionWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith("file://")) {
+      try {
+        void shell.openPath(fileURLToPath(url));
+      } catch {
+        void shell.openExternal(url);
+      }
+      return { action: "deny" };
+    }
+    const local = url.startsWith("http://127.0.0.1") || url.startsWith("http://localhost");
+    if (!local) {
+      void shell.openExternal(url);
+      return { action: "deny" };
+    }
+    return { action: "allow" };
+  });
+  sessionWindow.webContents.on("will-navigate", (navigationEvent, url) => {
+    if (browserPanel.isMainWindowAllowedNavigation(url)) return;
+    navigationEvent.preventDefault();
+    browserPanel.routeBlockedMainWindowNavigation(url);
+  });
+  sessionWindow.webContents.on("did-start-navigation", (_navigationEvent, url, isInPlace, isMainFrame) => {
+    if (!isMainFrame || isInPlace || browserPanel.isMainWindowAllowedNavigation(url)) return;
+    try {
+      sessionWindow.webContents.stop();
+    } catch {
+      // Best effort — routing below still preserves the detached chat.
+    }
+    browserPanel.routeBlockedMainWindowNavigation(url);
+  });
+
+  const sourceUrl = event.sender.getURL();
+  const appDocumentUrl = sourceUrl.split("#", 1)[0];
+  await sessionWindow.loadURL(`${appDocumentUrl}#${sessionWindowRoute(workspaceId, sessionId)}`);
   return true;
 }
 
@@ -1519,6 +1635,9 @@ function applyNativeTheme(mode) {
 // typecheck:electron`.
 /** @type {import("@legalwork/types/desktop-ipc").DesktopCommandHandlers<import("electron").IpcMainInvokeEvent>} */
 const desktopCommandHandlers = {
+  "openSessionWindow": async (event, ...args) => {
+      return openDetachedSessionWindow(event, args[0] ?? {});
+  },
   "workspaceBootstrap": async (event, ...args) => {
       return workspaceStore.readWorkspaceState();
   },

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "legalwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "legalwork:native-menu:open-settings";
+const NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT = "legalwork:native-menu:open-session-window";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "legalwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "legalwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "legalwork:native-menu:zoom";
@@ -209,6 +210,11 @@ ipcRenderer.on(NATIVE_DEEP_LINK_EVENT, (_event, urls) => {
 ipcRenderer.on(NATIVE_MENU_OPEN_SETTINGS_EVENT, () => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new Event(NATIVE_MENU_OPEN_SETTINGS_EVENT));
+});
+
+ipcRenderer.on(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT, () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(NATIVE_MENU_OPEN_SESSION_WINDOW_EVENT));
 });
 
 ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -374,6 +374,12 @@ export type OfficeAddinOpenAppResult = {
 // ---------------------------------------------------------------------------
 
 export type DesktopCommandMap = {
+  // Native windows
+  openSessionWindow: {
+    args: [input: { workspaceId: string; sessionId: string; title?: string }];
+    result: boolean;
+  };
+
   // Workspace state
   workspaceBootstrap: { args: []; result: WorkspaceList };
   workspaceSetSelected: { args: [workspaceId: string]; result: WorkspaceList };


### PR DESCRIPTION
## Summary
- open any chat in a native secondary window from the titlebar, File menu, row context menu, or double-click
- keep the complete chat workspace in the detached window, including files, artifacts, extensions, voice, browser, and terminal panels
- route embedded browser views to whichever native chat window owns the active panel
- reuse and focus an existing detached window for the same workspace/session

## macOS UX basis
- Apple HIG recommends a context-menu or File-menu command for viewing content in a new window
- Apple HIG says toolbar commands should also be available in the menu bar
- Apple Messages uses “Open Conversation in New Window” in File
- sidebar drag remains reserved for the existing organization/reorder interaction; drag-out is an established convention for actual tab bars

## Dependency
Stacked on #89 so the requested work can be reviewed from the exact LegalMemory Drive state.

## Verification
- pnpm --filter @legalwork/app typecheck
- pnpm --filter @legalwork/app test (286 pass)
- pnpm --filter @legalwork/app build
- pnpm --filter @legalwork/desktop typecheck:electron
- pnpm --filter @legalwork/desktop check:electron
- pnpm --filter @legalwork/desktop test (87 pass, 1 skip)
- verified titlebar, native File menu, detached right panels, and browser view in the running Electron dev app