### PR TITLE
Add Personalisation settings with local memory

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -112,6 +112,23 @@ export type LegalworkServerSettings = {
   remoteAccessEnabled?: boolean;
 };
 
+export const LEGALWORK_PERSONALITY_VALUES = [
+  "default",
+  "pragmatic",
+  "professional",
+  "friendly",
+  "candid",
+] as const;
+
+export type LegalworkPersonality = (typeof LEGALWORK_PERSONALITY_VALUES)[number];
+
+export type LegalworkPersonalizationSettings = {
+  customInstructions: string;
+  localMemoriesEnabled: boolean;
+  allowToolAssistedMemory: boolean;
+  personality: LegalworkPersonality;
+};
+
 /** One model from the Eigenwelt platform manifest / sign-in exchange. */
 export type EigenweltManifestModel = {
   id: string;
@@ -1283,6 +1300,28 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
         method: "PUT",
         body: payload,
         timeoutMs: timeouts.status,
+      }),
+    getPersonalization: () =>
+      requestJson<{ settings: LegalworkPersonalizationSettings }>(baseUrl, "/personalization", {
+        token,
+        hostToken,
+        timeoutMs: timeouts.config,
+      }),
+    setPersonalization: (settings: LegalworkPersonalizationSettings) =>
+      requestJson<{ settings: LegalworkPersonalizationSettings; updatedAt: number }>(baseUrl, "/personalization", {
+        token,
+        hostToken,
+        method: "PUT",
+        body: settings,
+        timeoutMs: timeouts.config,
+      }),
+    deleteLocalMemories: () =>
+      requestJson<{ ok: boolean; deletedDirectories: number }>(baseUrl, "/personalization/memories", {
+        token,
+        hostToken,
+        method: "DELETE",
+        body: { confirm: true },
+        timeoutMs: timeouts.config,
       }),
     capabilities: () => requestJson<LegalworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken, timeoutMs: timeouts.capabilities }),
     googleWorkspaceStatus: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/status", { token, hostToken, timeoutMs: timeouts.status }),

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -184,6 +184,7 @@ export const SETTINGS_TAB_VALUES = [
   "general",
   "ai",
   "account",
+  "personalisation",
   "benchmark",
   "preferences",
   "permissions",

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -9,6 +9,7 @@ import {
   Mic,
   RefreshCcw,
   ShieldCheck,
+  Sparkles,
   Zap,
   type LucideIcon,
 } from "lucide-react";
@@ -35,6 +36,12 @@ const globalItems: SettingsItem[] = [
     icon: Building2,
     title: t("settings.tab_account"),
     desc: t("settings.tab_description_account"),
+  },
+  {
+    tab: "personalisation",
+    icon: Sparkles,
+    title: "Personalisation",
+    desc: "System prompt additions, local memory, and response personality.",
   },
   { tab: "safety", icon: ShieldCheck, title: "Tool Permissions", desc: "Decide what LegalWork can do on its own across all workspaces." },
   { tab: "shell", icon: Layout, title: "Customization", desc: "Branding and task suggestions." },

--- a/apps/app/src/react-app/domains/settings/pages/personalisation-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/personalisation-view.tsx
@@ -1,0 +1,298 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import { Info } from "lucide-react";
+
+import {
+  LEGALWORK_PERSONALITY_VALUES,
+  type LegalworkPersonality,
+  type LegalworkPersonalizationSettings,
+  type LegalworkServerClient,
+} from "@/app/lib/legalwork-server";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/components/ui/sonner";
+import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal";
+
+import {
+  LayoutSection,
+  LayoutSectionDescription,
+  LayoutSectionHeader,
+  LayoutSectionItem,
+  LayoutSectionItemDescription,
+  LayoutSectionItemHeader,
+  LayoutSectionItemHeaderActions,
+  LayoutSectionItemTitle,
+  LayoutSectionTitle,
+  LayoutStack,
+} from "../settings-layout";
+import { SettingsNotice } from "../settings-section";
+
+const DEFAULT_SETTINGS: LegalworkPersonalizationSettings = {
+  customInstructions: "",
+  localMemoriesEnabled: false,
+  allowToolAssistedMemory: true,
+  personality: "pragmatic",
+};
+
+const PERSONALITY_LABELS: Record<LegalworkPersonality, string> = {
+  default: "Default",
+  pragmatic: "Pragmatic",
+  professional: "Professional",
+  friendly: "Friendly",
+  candid: "Candid",
+};
+
+function isPersonality(value: unknown): value is LegalworkPersonality {
+  return typeof value === "string" && LEGALWORK_PERSONALITY_VALUES.some((personality) => personality === value);
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : "Personalisation settings could not be updated.";
+}
+
+export type PersonalisationViewProps = {
+  client: LegalworkServerClient | null;
+  onSettingsApplied: () => void;
+  onOpenLink: (url: string) => void;
+};
+
+export function PersonalisationView(props: PersonalisationViewProps) {
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [instructionsDraft, setInstructionsDraft] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    if (!props.client) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void props.client.getPersonalization()
+      .then(({ settings: loaded }) => {
+        if (cancelled) return;
+        setSettings(loaded);
+        setInstructionsDraft(loaded.customInstructions);
+      })
+      .catch((loadError) => {
+        if (!cancelled) setError(describeError(loadError));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [props.client]);
+
+  const instructionsChanged = instructionsDraft !== settings.customInstructions;
+  const remainingCharacters = 12_000 - instructionsDraft.length;
+  const disabled = loading || busy || !props.client;
+
+  const persist = async (next: LegalworkPersonalizationSettings, successMessage?: string) => {
+    if (!props.client) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await props.client.setPersonalization(next);
+      setSettings(result.settings);
+      setInstructionsDraft(result.settings.customInstructions);
+      props.onSettingsApplied();
+      if (successMessage) toast.success(successMessage);
+    } catch (saveError) {
+      const message = describeError(saveError);
+      setError(message);
+      toast.error(message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const personalityItems = useMemo(
+    () => LEGALWORK_PERSONALITY_VALUES.map((value) => ({ value, label: PERSONALITY_LABELS[value] })),
+    [],
+  );
+
+  const deleteMemories = async () => {
+    if (!props.client) return;
+    setDeleteOpen(false);
+    setBusy(true);
+    setError(null);
+    try {
+      await props.client.deleteLocalMemories();
+      toast.success("Local memories deleted.");
+    } catch (deleteError) {
+      const message = describeError(deleteError);
+      setError(message);
+      toast.error(message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <LayoutStack>
+        {!props.client ? (
+          <SettingsNotice tone="warning">
+            Connect to the LegalWork server to manage host-wide personalisation.
+          </SettingsNotice>
+        ) : null}
+        {error ? <SettingsNotice tone="error">{error}</SettingsNotice> : null}
+
+        <LayoutSection>
+          <LayoutSectionHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <LayoutSectionTitle>System prompt additions</LayoutSectionTitle>
+                <LayoutSectionDescription>
+                  Add instructions and context that LegalWork includes in the system prompt for every chat on this host.
+                </LayoutSectionDescription>
+              </div>
+              <Button
+                size="sm"
+                disabled={disabled || !instructionsChanged || remainingCharacters < 0}
+                onClick={() => void persist(
+                  { ...settings, customInstructions: instructionsDraft },
+                  "System prompt additions saved.",
+                )}
+              >
+                Save
+              </Button>
+            </div>
+          </LayoutSectionHeader>
+
+          <div className="space-y-1.5">
+            <Textarea
+              value={instructionsDraft}
+              maxLength={12_000}
+              disabled={disabled}
+              onChange={(event) => setInstructionsDraft(event.currentTarget.value)}
+              placeholder="Add your system prompt additions…"
+              aria-label="System prompt additions"
+              className="min-h-52 resize-y rounded-2xl bg-surface px-4 py-3.5"
+            />
+            <div className="text-right text-xs text-muted-foreground">
+              {remainingCharacters.toLocaleString()} characters remaining
+            </div>
+          </div>
+        </LayoutSection>
+
+        <LayoutSection>
+          <LayoutSectionHeader>
+            <LayoutSectionTitle>Memory</LayoutSectionTitle>
+            <LayoutSectionDescription>
+              Configure how local memories are collected and used on this host.{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline"
+                onClick={() => props.onOpenLink("https://www.opencode.asia/ecosystem/plugins/agent-memory/")}
+              >
+                Learn more
+              </button>
+            </LayoutSectionDescription>
+          </LayoutSectionHeader>
+
+          <LayoutSectionItem>
+            <LayoutSectionItemHeader>
+              <LayoutSectionItemTitle>Enable local memories</LayoutSectionItemTitle>
+              <LayoutSectionItemDescription>
+                Create private memory blocks from chats on this host and use them to personalise future chats.
+              </LayoutSectionItemDescription>
+              <LayoutSectionItemHeaderActions>
+                <Switch
+                  aria-label="Enable local memories"
+                  checked={settings.localMemoriesEnabled}
+                  disabled={disabled}
+                  onCheckedChange={(checked) => void persist({ ...settings, localMemoriesEnabled: checked })}
+                />
+              </LayoutSectionItemHeaderActions>
+            </LayoutSectionItemHeader>
+          </LayoutSectionItem>
+
+          <LayoutSectionItem>
+            <LayoutSectionItemHeader>
+              <LayoutSectionItemTitle>Allow memory generation from tool-assisted chats</LayoutSectionItemTitle>
+              <LayoutSectionItemDescription>
+                Let LegalWork retain durable context from chats that used MCP tools or web search.
+              </LayoutSectionItemDescription>
+              <LayoutSectionItemHeaderActions>
+                <Switch
+                  aria-label="Allow memory generation from tool-assisted chats"
+                  checked={settings.allowToolAssistedMemory}
+                  disabled={disabled}
+                  onCheckedChange={(checked) => void persist({ ...settings, allowToolAssistedMemory: checked })}
+                />
+              </LayoutSectionItemHeaderActions>
+            </LayoutSectionItemHeader>
+          </LayoutSectionItem>
+
+          <LayoutSectionItem>
+            <LayoutSectionItemHeader>
+              <LayoutSectionItemTitle>Delete local memories</LayoutSectionItemTitle>
+              <LayoutSectionItemDescription>
+                Permanently delete all global and workspace memory blocks stored on this host.
+              </LayoutSectionItemDescription>
+              <LayoutSectionItemHeaderActions>
+                <Button variant="destructive" size="sm" disabled={disabled} onClick={() => setDeleteOpen(true)}>
+                  Delete
+                </Button>
+              </LayoutSectionItemHeaderActions>
+            </LayoutSectionItemHeader>
+          </LayoutSectionItem>
+        </LayoutSection>
+
+        <div className="flex items-start gap-3 rounded-2xl border border-amber-7/30 bg-amber-2/30 px-4 py-3 text-sm text-amber-12">
+          <Info className="mt-0.5 size-4 shrink-0 text-amber-10" />
+          <span>
+            Personality settings may be followed differently by different models. Fine-tune LegalWork&apos;s tone in System prompt additions.
+          </span>
+        </div>
+
+        <LayoutSection>
+          <LayoutSectionItem>
+            <LayoutSectionItemHeader>
+              <LayoutSectionItemTitle>Personality</LayoutSectionItemTitle>
+              <LayoutSectionItemDescription>Choose the default tone for LegalWork responses.</LayoutSectionItemDescription>
+              <LayoutSectionItemHeaderActions>
+                <Select
+                  value={settings.personality}
+                  disabled={disabled}
+                  onValueChange={(value) => {
+                    if (isPersonality(value)) void persist({ ...settings, personality: value });
+                  }}
+                >
+                  <SelectTrigger className="w-44" aria-label="Personality">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {personalityItems.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </LayoutSectionItemHeaderActions>
+            </LayoutSectionItemHeader>
+          </LayoutSectionItem>
+        </LayoutSection>
+      </LayoutStack>
+
+      <ConfirmModal
+        open={deleteOpen}
+        title="Delete all local memories?"
+        message="This permanently removes the global and workspace memory blocks stored on this LegalWork host. This cannot be undone."
+        confirmLabel="Delete memories"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={() => void deleteMemories()}
+        onCancel={() => setDeleteOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/shell/panel.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/panel.tsx
@@ -37,12 +37,7 @@ type SettingsPanelHeadingProps = {
 };
 
 export function SettingsPanelHeading(props: SettingsPanelHeadingProps) {
-  return (
-    <div className={cn("flex flex-col gap-y-2", props.className)}>
-      <span className="lw-section-eyebrow">Settings</span>
-      {props.children}
-    </div>
-  );
+  return <div className={cn("flex flex-col gap-y-2", props.className)}>{props.children}</div>;
 }
 
 type SettingsPanelTitleProps = {

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -19,6 +19,7 @@ import {
   Puzzle,
   RefreshCcw,
   ShieldCheck,
+  Sparkles,
   Store,
   UserCircle,
   Wrench,
@@ -65,6 +66,8 @@ export function getSettingsTabIcon(tab: SettingsTab) {
       return Zap;
     case "account":
       return Building2;
+    case "personalisation":
+      return Sparkles;
     case "benchmark":
       return Gauge;
     case "preferences":
@@ -114,6 +117,8 @@ export function getSettingsTabLabel(tab: SettingsTab) {
       return "AI Providers";
     case "account":
       return t("settings.tab_account");
+    case "personalisation":
+      return "Personalisation";
     case "benchmark":
       return t("settings.tab_benchmark");
     case "preferences":
@@ -165,6 +170,8 @@ export function getSettingsTabDescription(tab: SettingsTab) {
       return "Connect services that provide AI models";
     case "account":
       return t("settings.tab_description_account");
+    case "personalisation":
+      return "System prompt additions, local memory, and response personality";
     case "benchmark":
       return t("settings.tab_description_benchmark");
     case "preferences":
@@ -222,7 +229,7 @@ export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {
   // "preferences" is the Privacy tab (usage-analytics opt-out toggle).
   // "benchmark" is not listed here: it lives on the Learnings page in the main
   // app shell (embedded singleView surface), not in the settings sidebar.
-  const tabs: SettingsTab[] = ["ai", "account", "safety", "shell", "environment", "preferences", "updates"];
+  const tabs: SettingsTab[] = ["ai", "account", "personalisation", "safety", "shell", "environment", "preferences", "updates"];
   // Office add-ins install into local desktop apps, so the tab is desktop-only.
   // Placed right after the first tab.
   if (isDesktopRuntime()) tabs.splice(1, 0, "office-addins");

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -74,6 +74,7 @@ import { useSettingsExtensionController } from "@/react-app/domains/settings/set
 import { buildExtensionItems } from "@/react-app/domains/settings/extension-items";
 import { isLegalWorkExtensionEnabled, LEGALWORK_EXTENSION_STATE_CHANGED, setLegalWorkExtensionEnabled } from "@/react-app/domains/settings/extension-state";
 import { PreferencesView } from "@/react-app/domains/settings/pages/preferences-view";
+import { PersonalisationView } from "@/react-app/domains/settings/pages/personalisation-view";
 import { ShellCustomizationView } from "@/react-app/domains/settings/pages/shell-view";
 import { GeneralSettingsView } from "@/react-app/domains/settings/pages/general-view";
 import { AuthorizedFoldersPanel } from "@/react-app/domains/settings/panels/authorized-folders-panel";
@@ -229,6 +230,7 @@ function parseSettingsPath(pathname: string): {
     case "general":
     case "ai":
     case "account":
+    case "personalisation":
     case "preferences":
     case "permissions":
     case "safety":
@@ -2054,6 +2056,20 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             onConfigApplied={() => {
               void reloadWorkspaceEngineFromUi();
             }}
+          />
+        );
+      case "personalisation":
+        return (
+          <PersonalisationView
+            client={legalworkClient ?? legalworkServerSnapshot.legalworkServerClient}
+            onSettingsApplied={() => {
+              reloadCoordinator.markReloadRequired("config", {
+                type: "config",
+                name: "Personalisation",
+                action: "updated",
+              });
+            }}
+            onOpenLink={(url) => platform.openLink(url)}
           />
         );
       case "benchmark":

--- a/apps/server/src/legalwork-runtime-config.test.ts
+++ b/apps/server/src/legalwork-runtime-config.test.ts
@@ -9,7 +9,11 @@ import {
   writeLegalworkRuntimeConfigFile,
 } from "./legalwork-runtime-config.js";
 import { eigenweltFreeManifestCachePath } from "./eigenwelt-free.js";
-import { GLOBAL_TOOL_PERMISSIONS_ID, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  GLOBAL_PERSONALIZATION_ID,
+  GLOBAL_TOOL_PERMISSIONS_ID,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 const roots: string[] = [];
@@ -161,6 +165,36 @@ describe("legalwork runtime config file", () => {
     // Global tool key + this workspace's own external_directory, merged.
     expect(permission.bash).toBe("ask");
     expect(permission.external_directory).toEqual({ "/tmp/shared/*": "allow" });
+  });
+
+  test("global personalisation rewrites the active workspace config", async () => {
+    const { config } = await setup();
+    await writeLegalworkRuntimeConfigFile(config, "ws_1");
+    cleanups.push(keepLegalworkRuntimeConfigFileFresh(config, "ws_1"));
+
+    await writeRuntimeOpencodeConfig(config, GLOBAL_PERSONALIZATION_ID, (current) => ({
+      ...current,
+      personalization: {
+        customInstructions: "Use concise issue-rule-analysis conclusions.",
+        localMemoriesEnabled: true,
+        allowToolAssistedMemory: false,
+        personality: "professional",
+      },
+    }));
+
+    let prompt = "";
+    let plugins: string[] = [];
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const parsed = await readConfigFile(config);
+      const agents = parsed.agent as Record<string, Record<string, unknown>>;
+      prompt = typeof agents.legalwork?.prompt === "string" ? agents.legalwork.prompt : "";
+      plugins = Array.isArray(parsed.plugin) ? parsed.plugin.filter((item) => typeof item === "string") : [];
+      if (prompt.includes("issue-rule-analysis")) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    expect(prompt).toContain("Use concise issue-rule-analysis conclusions.");
+    expect(plugins).toContain("opencode-agent-memory@0.2.0");
   });
 });
 

--- a/apps/server/src/legalwork-runtime-config.ts
+++ b/apps/server/src/legalwork-runtime-config.ts
@@ -30,9 +30,11 @@ import {
 import type { ServerConfig } from "./types.js";
 import {
   applyGlobalToolPermissions,
+  GLOBAL_PERSONALIZATION_ID,
   GLOBAL_TOOL_PERMISSIONS_ID,
   onRuntimeOpencodeConfigWrite,
   readGlobalToolPermissions,
+  readGlobalPersonalizationSettings,
   readRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
   runtimeAgentMap,
@@ -40,6 +42,7 @@ import {
   runtimePluginList,
   runtimeStorageDir,
 } from "./runtime-opencode-config-store.js";
+import { AGENT_MEMORY_PLUGIN_SPEC, buildPersonalizedAgentPrompt } from "./personalization.js";
 import {
   buildEigenweltFreeProviderBlock,
   EIGENWELT_FREE_PROVIDER_ID,
@@ -121,6 +124,9 @@ export async function buildLegalworkRuntimeConfigObject(
         await readGlobalToolPermissions(config),
       )
     : {};
+  const personalization = config
+    ? await readGlobalPersonalizationSettings(config)
+    : null;
   // Free Eigenwelt tier: served from the DISK CACHE only — config building
   // must never block on the network. refreshEigenweltFreeManifest (cli.ts /
   // embedded.ts) keeps the cache fresh out-of-band (minting this device's
@@ -173,7 +179,9 @@ export async function buildLegalworkRuntimeConfigObject(
         description: "LegalWork default agent",
         mode: "primary",
         temperature: 0.2,
-        prompt: LEGALWORK_AGENT_PROMPT,
+        prompt: personalization
+          ? buildPersonalizedAgentPrompt(LEGALWORK_AGENT_PROMPT, personalization)
+          : LEGALWORK_AGENT_PROMPT,
       },
     },
     plugin: [
@@ -191,8 +199,9 @@ export async function buildLegalworkRuntimeConfigObject(
       bundledPluginSpec(legalworkExcelToolsPluginPath()),
       bundledPluginSpec(legalworkPowerPointToolsPluginPath()),
       bundledPluginSpec(legalworkBenchmarkToolsPluginPath()),
+      ...(personalization?.localMemoriesEnabled ? [AGENT_MEMORY_PLUGIN_SPEC] : []),
       ...runtimePluginList(runtimeConfig),
-    ],
+    ].filter((item, index, list) => list.indexOf(item) === index),
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
     mcp: runtimeMcpMap(runtimeConfig),
   };
@@ -239,8 +248,13 @@ export async function writeLegalworkRuntimeConfigFile(config: ServerConfig, work
  */
 export function keepLegalworkRuntimeConfigFileFresh(config: ServerConfig, workspaceId: string): () => void {
   return onRuntimeOpencodeConfigWrite((writeConfig, writtenWorkspaceId) => {
-    // Global tool-permission writes affect every workspace's derived config.
-    if (writtenWorkspaceId !== workspaceId && writtenWorkspaceId !== GLOBAL_TOOL_PERMISSIONS_ID) return;
+    // Global tool-permission and personalisation writes affect every
+    // workspace's derived config.
+    if (
+      writtenWorkspaceId !== workspaceId &&
+      writtenWorkspaceId !== GLOBAL_TOOL_PERMISSIONS_ID &&
+      writtenWorkspaceId !== GLOBAL_PERSONALIZATION_ID
+    ) return;
     void writeLegalworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
   });
 }

--- a/apps/server/src/personalization.test.ts
+++ b/apps/server/src/personalization.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AGENT_MEMORY_PLUGIN_SPEC,
+  buildPersonalizedAgentPrompt,
+  deleteAllLocalMemories,
+} from "./personalization.js";
+import {
+  GLOBAL_PERSONALIZATION_ID,
+  readGlobalPersonalizationSettings,
+  readRuntimeOpencodeConfig,
+  type PersonalizationSettings,
+} from "./runtime-opencode-config-store.js";
+import { buildLegalworkRuntimeConfigObject } from "./legalwork-runtime-config.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const roots: string[] = [];
+let previousDb: string | undefined;
+
+afterEach(async () => {
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  if (previousDb === undefined) delete process.env.LEGALWORK_RUNTIME_DB;
+  else process.env.LEGALWORK_RUNTIME_DB = previousDb;
+});
+
+async function setup() {
+  const root = await mkdtemp(join(tmpdir(), "legalwork-personalization-"));
+  roots.push(root);
+  previousDb = process.env.LEGALWORK_RUNTIME_DB;
+  process.env.LEGALWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const workspace = join(root, "workspace");
+  await mkdir(workspace, { recursive: true });
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: "ws_1", name: "Test", path: workspace, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspace],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  return { config, root, workspace };
+}
+
+async function missing(path: string) {
+  await expect(stat(path)).rejects.toThrow();
+}
+
+describe("Personalisation", () => {
+  test("appends personality, custom instructions, and the privacy-aware memory policy", () => {
+    const prompt = buildPersonalizedAgentPrompt("Base prompt", {
+      customInstructions: "Always use short headings.",
+      localMemoriesEnabled: true,
+      allowToolAssistedMemory: false,
+      personality: "pragmatic",
+    });
+    expect(prompt).toContain("Base prompt");
+    expect(prompt).toContain("Always use short headings.");
+    expect(prompt).toContain("Use a pragmatic tone");
+    expect(prompt).toContain("Do not create or update memory from web search");
+  });
+
+  test("persists host-wide settings and activates Agent Memory in the runtime config", async () => {
+    const { config } = await setup();
+    const server = await startServer(config);
+    try {
+      const settings: PersonalizationSettings = {
+        customInstructions: "Use numbered recommendations.",
+        localMemoriesEnabled: true,
+        allowToolAssistedMemory: true,
+        personality: "professional",
+      };
+      const put = await fetch(`http://127.0.0.1:${server.port}/personalization`, {
+        method: "PUT",
+        headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      expect(put.status).toBe(200);
+      expect(await put.json()).toMatchObject({ settings });
+
+      const get = await fetch(`http://127.0.0.1:${server.port}/personalization`, {
+        headers: { authorization: `Bearer ${config.token}` },
+      });
+      expect(get.status).toBe(200);
+      expect(await get.json()).toEqual({ settings });
+      expect(await readGlobalPersonalizationSettings(config)).toEqual(settings);
+      expect((await readRuntimeOpencodeConfig(config, GLOBAL_PERSONALIZATION_ID)).personalization).toEqual(settings);
+
+      const runtime = await buildLegalworkRuntimeConfigObject(config, "ws_1");
+      expect(runtime.plugin).toContain(AGENT_MEMORY_PLUGIN_SPEC);
+      const agents = runtime.agent as Record<string, Record<string, unknown>>;
+      expect(agents.legalwork?.prompt).toContain("Use numbered recommendations.");
+      expect(agents.legalwork?.prompt).toContain("Use a professional tone");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("deletes global and workspace memory blocks without touching their parent directories", async () => {
+    const { config, root, workspace } = await setup();
+    const globalMemory = join(root, "test-global-memory");
+    const projectMemory = join(workspace, ".opencode", "memory");
+    await mkdir(globalMemory, { recursive: true });
+    await mkdir(projectMemory, { recursive: true });
+    await writeFile(join(globalMemory, "human.md"), "private preference", "utf8");
+    await writeFile(join(projectMemory, "project.md"), "private matter context", "utf8");
+
+    expect(await deleteAllLocalMemories(config, globalMemory)).toBe(2);
+    await missing(globalMemory);
+    await missing(projectMemory);
+    expect((await stat(workspace)).isDirectory()).toBe(true);
+  });
+});

--- a/apps/server/src/personalization.ts
+++ b/apps/server/src/personalization.ts
@@ -1,0 +1,71 @@
+import { rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { PersonalizationSettings, Personality } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+/** Pinned because OpenCode otherwise re-downloads unpinned plugins on every start. */
+export const AGENT_MEMORY_PLUGIN_SPEC = "opencode-agent-memory@0.2.0";
+
+const PERSONALITY_PROMPTS: Record<Personality, string | null> = {
+  default: null,
+  pragmatic:
+    "Use a pragmatic tone: be direct, concrete, and action-oriented. Lead with the useful answer and make trade-offs explicit.",
+  professional:
+    "Use a professional tone: polished, measured, precise, and appropriate for legal work.",
+  friendly:
+    "Use a friendly tone: warm, approachable, and collaborative while remaining precise.",
+  candid:
+    "Use a candid tone: be frank and concise, respectfully challenge weak assumptions, and do not hide material concerns.",
+};
+
+export function buildPersonalizedAgentPrompt(
+  basePrompt: string,
+  settings: PersonalizationSettings,
+): string {
+  const additions: string[] = [];
+  const personalityPrompt = PERSONALITY_PROMPTS[settings.personality];
+  if (personalityPrompt) additions.push(`## Response personality\n\n${personalityPrompt}`);
+
+  const customInstructions = settings.customInstructions.trim();
+  if (customInstructions) {
+    additions.push(
+      `## User-provided system prompt additions\n\nFollow these host-wide instructions in every chat unless they conflict with higher-priority safety or application instructions:\n\n${customInstructions}`,
+    );
+  }
+
+  if (settings.localMemoriesEnabled) {
+    additions.push(
+      settings.allowToolAssistedMemory
+        ? "## Local memory policy\n\nYou may use the local memory tools to retain durable, high-signal preferences and context from chats, including chats that used web search or MCP tools. Never store secrets, credentials, privileged matter content, or transient task details."
+        : "## Local memory policy\n\nUse the local memory tools only for durable information the user states directly in chat. Do not create or update memory from web search, MCP results, other tool output, documents, or inferred private matter details. Never store secrets, credentials, privileged matter content, or transient task details.",
+    );
+  }
+
+  return additions.length ? `${basePrompt}\n\n${additions.join("\n\n")}` : basePrompt;
+}
+
+/**
+ * Agent Memory 0.2.0 stores global blocks under ~/.config/opencode/memory and
+ * project blocks under each workspace's .opencode/memory directory.
+ */
+export function localMemoryDirectories(
+  config: ServerConfig,
+  globalMemoryDirectory = join(homedir(), ".config", "opencode", "memory"),
+): string[] {
+  const directories = [
+    globalMemoryDirectory,
+    ...config.workspaces.map((workspace) => join(workspace.path, ".opencode", "memory")),
+  ];
+  return directories.filter((directory, index) => directories.indexOf(directory) === index);
+}
+
+export async function deleteAllLocalMemories(
+  config: ServerConfig,
+  globalMemoryDirectory?: string,
+): Promise<number> {
+  const directories = localMemoryDirectories(config, globalMemoryDirectory);
+  await Promise.all(directories.map((directory) => rm(directory, { recursive: true, force: true })));
+  return directories.length;
+}

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -16,7 +16,34 @@ export type RuntimeOpencodeConfig = {
   };
   provider?: Record<string, unknown>;
   agent?: Record<string, Record<string, unknown>>;
+  personalization?: PersonalizationSettings;
 };
+
+export const PERSONALITY_VALUES = [
+  "default",
+  "pragmatic",
+  "professional",
+  "friendly",
+  "candid",
+] as const;
+
+export type Personality = (typeof PERSONALITY_VALUES)[number];
+
+export type PersonalizationSettings = {
+  customInstructions: string;
+  localMemoriesEnabled: boolean;
+  allowToolAssistedMemory: boolean;
+  personality: Personality;
+};
+
+export const DEFAULT_PERSONALIZATION_SETTINGS: PersonalizationSettings = {
+  customInstructions: "",
+  localMemoriesEnabled: false,
+  allowToolAssistedMemory: true,
+  personality: "pragmatic",
+};
+
+export const MAX_CUSTOM_INSTRUCTIONS_LENGTH = 12_000;
 
 const runtimeOpencodeConfigs = sqliteTable("runtime_opencode_configs", {
   workspaceId: text("workspace_id").primaryKey(),
@@ -31,6 +58,31 @@ type RuntimeOpencodeDb = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isPersonality(value: unknown): value is Personality {
+  return typeof value === "string" && PERSONALITY_VALUES.some((item) => item === value);
+}
+
+export function normalizePersonalizationSettings(value: unknown): PersonalizationSettings {
+  if (!isRecord(value)) return { ...DEFAULT_PERSONALIZATION_SETTINGS };
+  return {
+    customInstructions:
+      typeof value.customInstructions === "string"
+        ? value.customInstructions.slice(0, MAX_CUSTOM_INSTRUCTIONS_LENGTH)
+        : DEFAULT_PERSONALIZATION_SETTINGS.customInstructions,
+    localMemoriesEnabled:
+      typeof value.localMemoriesEnabled === "boolean"
+        ? value.localMemoriesEnabled
+        : DEFAULT_PERSONALIZATION_SETTINGS.localMemoriesEnabled,
+    allowToolAssistedMemory:
+      typeof value.allowToolAssistedMemory === "boolean"
+        ? value.allowToolAssistedMemory
+        : DEFAULT_PERSONALIZATION_SETTINGS.allowToolAssistedMemory,
+    personality: isPersonality(value.personality)
+      ? value.personality
+      : DEFAULT_PERSONALIZATION_SETTINGS.personality,
+  };
 }
 
 function recordRecordMap(value: unknown): Record<string, Record<string, unknown>> | undefined {
@@ -53,6 +105,9 @@ function normalizeRuntimeOpencodeConfig(value: unknown): RuntimeOpencodeConfig {
   const permission = isRecord(value.permission) && Object.keys(value.permission).length ? value.permission : undefined;
   const provider = isRecord(value.provider) ? value.provider : undefined;
   const agent = recordRecordMap(value.agent);
+  const personalization = isRecord(value.personalization)
+    ? normalizePersonalizationSettings(value.personalization)
+    : undefined;
   return {
     ...(defaultAgent ? { default_agent: defaultAgent } : {}),
     ...(plugin ? { plugin } : {}),
@@ -61,6 +116,7 @@ function normalizeRuntimeOpencodeConfig(value: unknown): RuntimeOpencodeConfig {
     ...(permission ? { permission } : {}),
     ...(provider ? { provider } : {}),
     ...(agent ? { agent } : {}),
+    ...(personalization ? { personalization } : {}),
   };
 }
 
@@ -153,6 +209,16 @@ async function runtimeDb(config: ServerConfig): Promise<RuntimeOpencodeDb> {
  * `ws_<hash>`).
  */
 export const GLOBAL_TOOL_PERMISSIONS_ID = "__global_tool_permissions__";
+
+/** Host-wide personalisation shared by every workspace served on this device. */
+export const GLOBAL_PERSONALIZATION_ID = "__global_personalization__";
+
+export async function readGlobalPersonalizationSettings(
+  config: ServerConfig,
+): Promise<PersonalizationSettings> {
+  const globalConfig = await readRuntimeOpencodeConfig(config, GLOBAL_PERSONALIZATION_ID);
+  return normalizePersonalizationSettings(globalConfig.personalization);
+}
 
 /** Read the global tool-permission map (never contains external_directory). */
 export async function readGlobalToolPermissions(config: ServerConfig): Promise<Record<string, unknown>> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -85,15 +85,20 @@ import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import {
   applyGlobalToolPermissions,
+  GLOBAL_PERSONALIZATION_ID,
   GLOBAL_TOOL_PERMISSIONS_ID,
+  isPersonality,
+  MAX_CUSTOM_INSTRUCTIONS_LENGTH,
   mergeOpencodeConfigs,
   mergeRuntimeProviderPatch,
+  readGlobalPersonalizationSettings,
   readGlobalToolPermissions,
   readRuntimeOpencodeConfig,
   runtimeMcpMap,
   type RuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
+import { deleteAllLocalMemories } from "./personalization.js";
 import {
   mergeLegalworkWorkspaceConfigs,
   readLegalworkWorkspaceConfig,
@@ -206,6 +211,37 @@ function readStringField(value: unknown, key: string): string {
   if (!isRecord(value)) return "";
   const field = value[key];
   return typeof field === "string" ? field.trim() : "";
+}
+
+function parsePersonalizationPayload(value: unknown) {
+  if (!isRecord(value)) {
+    throw new ApiError(400, "invalid_personalization", "Personalisation settings are required");
+  }
+  if (typeof value.customInstructions !== "string") {
+    throw new ApiError(400, "invalid_personalization", "customInstructions must be a string");
+  }
+  if (value.customInstructions.length > MAX_CUSTOM_INSTRUCTIONS_LENGTH) {
+    throw new ApiError(
+      400,
+      "invalid_personalization",
+      `customInstructions must be ${MAX_CUSTOM_INSTRUCTIONS_LENGTH} characters or fewer`,
+    );
+  }
+  if (typeof value.localMemoriesEnabled !== "boolean") {
+    throw new ApiError(400, "invalid_personalization", "localMemoriesEnabled must be a boolean");
+  }
+  if (typeof value.allowToolAssistedMemory !== "boolean") {
+    throw new ApiError(400, "invalid_personalization", "allowToolAssistedMemory must be a boolean");
+  }
+  if (!isPersonality(value.personality)) {
+    throw new ApiError(400, "invalid_personalization", "personality is not supported");
+  }
+  return {
+    customInstructions: value.customInstructions,
+    localMemoriesEnabled: value.localMemoriesEnabled,
+    allowToolAssistedMemory: value.allowToolAssistedMemory,
+    personality: value.personality,
+  };
 }
 
 function recordRecordMap(value: unknown): Record<string, Record<string, unknown>> | null {
@@ -1578,6 +1614,32 @@ function createRoutes(
     const body = await readJsonBody(ctx.request);
     setAnalyticsConsent({ analyticsEnabled: body.analyticsEnabled });
     return jsonResponse({ ok: true, distinctId: launchAnalyticsId() });
+  });
+
+  addRoute(routes, "GET", "/personalization", "client", async () => {
+    return jsonResponse({ settings: await readGlobalPersonalizationSettings(config) });
+  });
+
+  addRoute(routes, "PUT", "/personalization", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const settings = parsePersonalizationPayload(await readJsonBody(ctx.request));
+    await writeRuntimeOpencodeConfig(config, GLOBAL_PERSONALIZATION_ID, (current) => ({
+      ...current,
+      personalization: settings,
+    }));
+    return jsonResponse({ settings, updatedAt: Date.now() });
+  });
+
+  addRoute(routes, "DELETE", "/personalization/memories", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const body = await readJsonBody(ctx.request);
+    if (body.confirm !== true) {
+      throw new ApiError(400, "confirmation_required", "confirm must be true");
+    }
+    const deletedDirectories = await deleteAllLocalMemories(config);
+    return jsonResponse({ ok: true, deletedDirectories });
   });
 
   addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) => {


### PR DESCRIPTION
## Summary

- add a host-wide Personalisation settings tab with real system-prompt additions and response personality controls
- integrate pinned `opencode-agent-memory@0.2.0`, including local-memory enablement and a privacy control for tool-assisted chats
- add confirmed deletion of global and workspace-local memory blocks
- persist settings in the LegalWork runtime database and refresh the active OpenCode config when they change

Agent Memory reference: https://www.opencode.asia/ecosystem/plugins/agent-memory/

## Verification

- `pnpm --filter legalwork-server typecheck`
- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter legalwork-server exec bun test src/personalization.test.ts src/legalwork-runtime-config.test.ts src/runtime-opencode-config-store.test.ts` (22 passing)
- `pnpm --filter legalwork-server build`
- `pnpm --filter @legalwork/app build`
- manually exercised save, memory switches, personality selection, and delete confirmation in a headed Playwright session