### PR TITLE
Fix alpha build: remove deleted eigenwelt-free.js from the packaging patch loop

### DIFF
--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -58,8 +58,8 @@ const serverDistDir = resolve(repoRoot, "apps", "server", "dist");
 const constantsSrc = resolve(repoRoot, "constants.json");
 copyFileSync(constantsSrc, resolve(serverDistDir, "constants.json"));
 // Every compiled module importing the repo-root constants.json needs the
-// same rewrite (server.js: opencodeVersion; eigenwelt-free.js: mint key).
-for (const jsFile of ["server.js", "eigenwelt-free.js"]) {
+// same rewrite (server.js: opencodeVersion).
+for (const jsFile of ["server.js"]) {
   const jsPath = resolve(serverDistDir, jsFile);
   const jsSrc = readFileSync(jsPath, "utf8");
   const patched = jsSrc.replace(


### PR DESCRIPTION
The alpha run failed at 'Build Electron alpha app' with ENOENT on apps/server/dist/eigenwelt-free.js: the free tier's module was deleted in #92, but electron-build.mjs still tried to rewrite its constants.json import. Only server.js imports the repo-root constants now (verified by grep), so the loop shrinks to that one file.

Re-dispatch the alpha workflow after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)