### PR TITLE
fix(chat): explain a dead Eigenwelt key as "sign in again"

### DIFF
--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -65,6 +65,10 @@ const de: Record<string, string> = {
   "office_addins.install_hint":
     "Bei der Installation wird ein nur für localhost gültiges Zertifikat erzeugt und vom Betriebssystem als vertrauenswürdig eingestuft (eine einmalige Bestätigung); danach wird das Add-in zu deinen Office-Apps hinzugefügt.",
 
+  /* ---- App errors ---- */
+  "app.error_eigenwelt_signin_expired":
+    "Deine Eigenwelt-Anmeldung auf diesem Computer ist nicht mehr gültig. Öffne die Einstellungen, dann Konto, und melde dich erneut an.",
+
   /* ---- Common actions ---- */
   "common.add": "Hinzufügen",
   "common.back": "Zurück",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -66,6 +66,8 @@ export default {
   "app.error_compact_no_session": "Select a session with messages before running /compact.",
   "app.error_compact_no_session_id": "Select a session before compacting.",
   "app.error_connect_first": "Connect to this worker before applying runtime changes.",
+  "app.error_eigenwelt_signin_expired":
+    "Your Eigenwelt sign-in on this computer is no longer valid. Open Settings, then Account, and sign in again.",
   "app.error_not_connected": "Not connected to a server",
   "app.error_rate_limit": "Rate limit exceeded",
   "app.error_remote_access": "Failed to update remote access.",

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -8,6 +8,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { t } from "../../../../i18n";
+import { eigenweltSignInExpiredMessage, isEigenweltSignInExpiredError } from "./eigenwelt-provider-error";
 import { unwrap } from "../../../../app/lib/opencode";
 import {
   abortSession as abortSessionTyped,
@@ -298,7 +299,11 @@ export function createSessionActionsStore(options: {
       (typeof error === "string" ? readString(error) : null);
 
     const generic = raw && /^unknown\s+error$/i.test(raw);
+    // A dead Eigenwelt key (the sign-in on this device was replaced or
+    // revoked): the raw 401 body is noise, the fix is signing in again.
+    const signInExpired = isEigenweltSignInExpiredError({ status, provider, texts: [raw, response] });
     const heading = (() => {
+      if (signInExpired) return eigenweltSignInExpiredMessage();
       if (status === 401 || status === 403) return t("app.error_auth_failed");
       if (status === 429) return t("app.error_rate_limit");
       if (provider) return `Provider error (${provider})`;
@@ -306,11 +311,11 @@ export function createSessionActionsStore(options: {
     })();
 
     const lines = [heading];
-    if (raw && !generic && raw !== heading) lines.push(raw);
+    if (raw && !generic && !signInExpired && raw !== heading) lines.push(raw);
     if (status && !heading.includes(String(status))) lines.push(`Status: ${status}`);
     if (provider && !heading.includes(provider)) lines.push(`Provider: ${provider}`);
     if (code) lines.push(`Code: ${code}`);
-    if (response) lines.push(`Response: ${response}`);
+    if (response && !signInExpired) lines.push(`Response: ${response}`);
     if (lines.length > 1) return lines.join("\n");
 
     if (raw && !generic) return raw;

--- a/apps/app/src/react-app/domains/session/sync/eigenwelt-provider-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/eigenwelt-provider-error.ts
@@ -1,0 +1,26 @@
+import { EIGENWELT_PROVIDER_ID } from "../../../../app/lib/eigenwelt-budget";
+import { t } from "../../../../i18n";
+
+/**
+ * The gateway's answer when the key behind a request no longer exists
+ * (LiteLLM's `token_not_found_in_db`): the sign-in on this device was
+ * replaced or revoked. The only way out is signing in again, so the chat
+ * should say that instead of echoing the raw 401 body.
+ */
+const SIGN_IN_EXPIRED_MARKERS = ["token_not_found_in_db", "Invalid proxy server token"];
+
+export function isEigenweltSignInExpiredError(input: {
+  status: number | null;
+  provider: string | null;
+  texts: Array<string | null | undefined>;
+}): boolean {
+  const mentionsDeadKey = input.texts.some(
+    (text) => Boolean(text) && SIGN_IN_EXPIRED_MARKERS.some((marker) => text!.includes(marker)),
+  );
+  if (mentionsDeadKey) return true;
+  return (input.status === 401 || input.status === 403) && input.provider === EIGENWELT_PROVIDER_ID;
+}
+
+export function eigenweltSignInExpiredMessage(): string {
+  return t("app.error_eigenwelt_signin_expired");
+}

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -5,6 +5,7 @@ import type { FilePart, Part, ToolPart } from "@opencode-ai/sdk/v2/client";
 import type { LegalworkSessionSnapshot } from "../../../../app/lib/legalwork-server";
 import { safeStringify } from "../../../../app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
+import { eigenweltSignInExpiredMessage, isEigenweltSignInExpiredError } from "./eigenwelt-provider-error";
 import {
   parseDynamicToolUIPart,
   parseStructuredOutputUIPart,
@@ -54,9 +55,16 @@ function withAttachmentRecoveryHint(text: string) {
   return `${text}\nAn attached file in this conversation uses a format the model can't read. Revert the conversation to before the attachment was sent, or start a new session.`;
 }
 
+function describeErrorText(text: string) {
+  if (isEigenweltSignInExpiredError({ status: null, provider: null, texts: [text] })) {
+    return eigenweltSignInExpiredMessage();
+  }
+  return withAttachmentRecoveryHint(text);
+}
+
 export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  if (error instanceof Error) return withAttachmentRecoveryHint(error.message || fallback);
-  if (typeof error === "string") return withAttachmentRecoveryHint(error.trim() || fallback);
+  if (error instanceof Error) return describeErrorText(error.message || fallback);
+  if (typeof error === "string") return describeErrorText(error.trim() || fallback);
   if (!error || typeof error !== "object") return fallback;
 
   const data = recordValue(error, "data");
@@ -71,12 +79,21 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   const retries = firstNumberValue(records, ["retries", "retryCount"]);
   const responseBody = firstStringValue(records, ["responseBody", "body", "response"]);
 
-  const lines = [message ?? defaultErrorMessage(name, fallback)];
+  // A dead Eigenwelt key (the sign-in on this device was replaced or
+  // revoked): the raw 401 body is noise, the fix is signing in again.
+  const signInExpired = isEigenweltSignInExpiredError({
+    status,
+    provider,
+    texts: [message, responseBody],
+  });
+  const lines = [
+    signInExpired ? eigenweltSignInExpiredMessage() : (message ?? defaultErrorMessage(name, fallback)),
+  ];
   if (status && !lines[0]?.includes(String(status))) lines.push(`Status: ${status}`);
   if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);
   if (code) lines.push(`Code: ${code}`);
   if (retries !== null) lines.push(`Retries: ${retries}`);
-  if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
+  if (responseBody && responseBody !== message && !signInExpired) lines.push(`Response: ${responseBody}`);
   if (lines.some((line) => line !== fallback)) return withAttachmentRecoveryHint(lines.join("\n"));
 
   const serialized = safeStringify(error);

--- a/apps/app/tests/eigenwelt-provider-error.test.ts
+++ b/apps/app/tests/eigenwelt-provider-error.test.ts
@@ -1,0 +1,73 @@
+/**
+ * A dead Eigenwelt key (LiteLLM "token_not_found_in_db": the sign-in on this
+ * device was replaced or revoked) must surface as "sign in again", not as the
+ * raw 401 body, on both chat error paths (request errors and session errors).
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  eigenweltSignInExpiredMessage,
+  isEigenweltSignInExpiredError,
+} from "../src/react-app/domains/session/sync/eigenwelt-provider-error";
+import { describeOpencodeSessionError } from "../src/react-app/domains/session/sync/usechat-adapter";
+
+const LITELLM_DEAD_KEY_BODY =
+  '{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...qrtQ, Key Hash (Token) =bfc5. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}';
+
+describe("isEigenweltSignInExpiredError", () => {
+  test("recognizes LiteLLM's dead-key body wherever it appears", () => {
+    expect(
+      isEigenweltSignInExpiredError({ status: null, provider: null, texts: [LITELLM_DEAD_KEY_BODY] }),
+    ).toBe(true);
+    expect(
+      isEigenweltSignInExpiredError({
+        status: null,
+        provider: null,
+        texts: [null, "Invalid proxy server token passed"],
+      }),
+    ).toBe(true);
+  });
+
+  test("treats any 401/403 from the eigenwelt provider as an expired sign-in", () => {
+    expect(isEigenweltSignInExpiredError({ status: 401, provider: "eigenwelt", texts: [] })).toBe(true);
+    expect(isEigenweltSignInExpiredError({ status: 403, provider: "eigenwelt", texts: [] })).toBe(true);
+  });
+
+  test("leaves other providers and other failures alone", () => {
+    expect(isEigenweltSignInExpiredError({ status: 401, provider: "openai", texts: ["bad key"] })).toBe(false);
+    expect(isEigenweltSignInExpiredError({ status: 429, provider: "eigenwelt", texts: ["slow down"] })).toBe(false);
+    expect(isEigenweltSignInExpiredError({ status: null, provider: null, texts: [null, undefined] })).toBe(false);
+  });
+});
+
+describe("describeOpencodeSessionError", () => {
+  test("replaces the raw 401 body with the sign-in-again message", () => {
+    const text = describeOpencodeSessionError({
+      name: "ProviderAuthError",
+      data: {
+        providerID: "eigenwelt",
+        message: "Provider authentication failed",
+        statusCode: 401,
+        responseBody: LITELLM_DEAD_KEY_BODY,
+      },
+    });
+    expect(text.startsWith(eigenweltSignInExpiredMessage())).toBe(true);
+    expect(text).not.toContain("token_not_found_in_db");
+    expect(text).not.toContain("LiteLLM_VerificationTokenTable");
+    expect(text).toContain("Status: 401");
+  });
+
+  test("handles the body arriving as a plain Error message", () => {
+    const text = describeOpencodeSessionError(new Error(`Request failed - Response: ${LITELLM_DEAD_KEY_BODY}`));
+    expect(text).toBe(eigenweltSignInExpiredMessage());
+  });
+
+  test("keeps unrelated provider errors verbatim", () => {
+    const text = describeOpencodeSessionError({
+      name: "ProviderError",
+      data: { providerID: "openai", message: "Rate limit exceeded", statusCode: 429 },
+    });
+    expect(text).toContain("Rate limit exceeded");
+    expect(text).not.toContain(eigenweltSignInExpiredMessage());
+  });
+});


### PR DESCRIPTION
## Problem

When the gateway no longer knows the key behind a request (LiteLLM's `token_not_found_in_db`: the sign-in on this device was replaced or revoked), the chat showed the raw 401 JSON body:

```
Authentication failed
... Response: {"error":{"message":"Authentication Error, Invalid proxy server token passed. ...","type":"token_not_found_in_db","code":"401"}}
```

The platform side of this (a second sign-in killed the first device's key) is fixed in eigenweltlabs/model-api#14; this PR makes the remaining case (a key really revoked or replaced) actionable.

## Fix

- New `eigenwelt-provider-error.ts`: recognizes LiteLLM's dead-key body wherever it appears, and any 401/403 from the `eigenwelt` provider.
- Both chat error paths (`actions-store` request errors and `usechat-adapter` session errors) now lead with "Your Eigenwelt sign-in on this computer is no longer valid. Open Settings, then Account, and sign in again." and drop the LiteLLM body. Status and provider lines stay for support.
- Copy in EN and DE (du-form).

## Tests

- `bun test tests/`: 283 pass (new: `eigenwelt-provider-error.test.ts`, 6 tests across both error paths).
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)