### PR TITLE
fix(hub): share dialog finds workflows from the global skill library

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/hub-share-dialog.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/hub-share-dialog.tsx
@@ -1,8 +1,10 @@
 /** @jsxImportSource react */
 /**
  * Multi-select "Share with your firm" dialog. Lists this workspace's local
- * skills, MCP servers and plugins with checkboxes (+ select-all) and pushes the
- * selected items to the team hub in one batch. MCP servers that carry a key get
+ * skills (plus the user's global skill library on local workspaces, where
+ * generated workflows live), MCP servers and plugins with checkboxes
+ * (+ select-all) and pushes the selected items to the team hub in one batch.
+ * MCP servers that carry a key get
  * an "Include key" switch — when on, the fully-configured entry is shared
  * (encrypted, any firm member may copy); otherwise a secret-free template is
  * shared and installers add their own key.
@@ -76,9 +78,16 @@ export function HubShareDialog(props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initialSelection?: { kind: Selectable["kind"]; ref: string } | null;
+  /**
+   * Also offer the user's global skill library (~/.config/opencode/skills).
+   * Must match what the Skills/Workflows pages list, or an item shown there
+   * comes up as "no longer available" here: generated workflows are imported
+   * into the global library, not into the workspace.
+   */
+  includeGlobalSkills?: boolean;
   onShared?: () => void;
 }) {
-  const { client, workspaceId } = props;
+  const { client, workspaceId, includeGlobalSkills = false } = props;
   const initialSelection = props.initialSelection;
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -113,7 +122,9 @@ export function HubShareDialog(props: {
         const loadMcps = !initialSelection || initialSelection.kind === "mcp";
         const loadPlugins = !initialSelection || initialSelection.kind === "plugin";
         const [s, m, p] = await Promise.all([
-          loadSkills ? client.listSkills(workspaceId) : Promise.resolve(null),
+          loadSkills
+            ? client.listSkills(workspaceId, { includeGlobal: includeGlobalSkills })
+            : Promise.resolve(null),
           loadMcps ? client.listMcp(workspaceId) : Promise.resolve(null),
           loadPlugins
             ? client.listPlugins(workspaceId, { includeGlobal: initialSelection?.kind === "plugin" })
@@ -146,7 +157,7 @@ export function HubShareDialog(props: {
     return () => {
       cancelled = true;
     };
-  }, [props.open, initialSelection, client, workspaceId]);
+  }, [props.open, initialSelection, client, workspaceId, includeGlobalSkills]);
 
   const all = useMemo(() => [...skills, ...mcps, ...plugins], [skills, mcps, plugins]);
   const key = (it: Selectable) => `${it.kind}:${it.ref}`;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2595,6 +2595,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         workspaceId={hubWorkspaceId}
         open={teamShareOpen}
         initialSelection={teamShareInitial}
+        includeGlobalSkills={(selectedWorkspace?.workspaceType ?? "local") !== "remote"}
         onOpenChange={(open) => {
           setTeamShareOpen(open);
           if (!open) setTeamShareInitial(null);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2619,7 +2619,9 @@ function createRoutes(
         }
         if (!ref) throw new ApiError(400, "invalid_ref", "Each item needs a local ref.");
         if (kind === "skill" || kind === "workflow") {
-          const localSkills = await listSkills(workspace.path, false);
+          // Generated workflows live in the global skill library, so resolve
+          // the kind against the same list the Workflows page shows.
+          const localSkills = await listSkills(workspace.path, true);
           const localSkill = localSkills.find((skill) => skill.name === ref);
           const publishedKind = resolveHubSkillKind(localSkill, kind, ref);
           const payload = await serializeWorkflowSkill(workspace.path, ref);


### PR DESCRIPTION
## Problem

Clicking Share on a workflow opened "Share with your firm" with **"This item is no longer available."**

Generated workflows are imported into the user's global skill library (`~/.config/opencode/skills/workflow-…`), and the Workflows page lists them from there (`listSkills` with `includeGlobal`). The share dialog only loaded the workspace's project skills, so it could not find the item it was asked to share.

## Fix

- `HubShareDialog` gets `includeGlobalSkills`; the settings route passes it for local workspaces, mirroring what the Skills/Workflows pages list. The single-item and multi-select flows both benefit.
- `POST /workspace/:id/hub/share/batch` resolves the published kind against the same list (the payload serializer already fell back to the global library, so publishing itself was not the blocker).

## Verification

Dev Electron against the local platform, with a copy of a global tabular workflow in the profile's global library: before, the dialog showed the "no longer available" text; after, it shows `workflow-tabular-qedffe` with the Workflow badge and the Share button enabled after acknowledging.

- `pnpm --filter @legalwork/app typecheck` and `pnpm --filter legalwork-server typecheck` clean.
- Server test suite: 492 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)