### PR TITLE
fix(chat): show the connect bar with a login when signed out of Eigenwelt

### DIFF
--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -593,7 +593,11 @@ const de: Record<string, string> = {
   "chat.no_model_title": "Keine KI verbunden.",
   "chat.no_model_body": "Starte deine 7-tägige kostenlose Testphase bei Eigenwelt oder verbinde dein eigenes Modell.",
   "chat.no_model_trial": "Kostenlos testen",
+  "chat.no_model_login": "Anmelden",
   "chat.no_model_byo": "Modell verbinden",
+  // Composer: von Eigenwelt abgemeldet (oder Zugang entzogen), sonst nichts verbunden
+  "chat.signed_out_title": "Von Eigenwelt abgemeldet.",
+  "chat.signed_out_body": "Melde dich an, um die Eigenwelt-Modelle weiter zu nutzen, starte deine 7-tägige kostenlose Testphase oder verbinde dein eigenes Modell.",
   // Einmaliger Migrationsdialog nach dem Ende des kostenlosen Zugangs.
   "free_retired.eyebrow": "Eigenwelt-Modelle",
   "free_retired.headline": "Kostenlose Modelle wurden eingestellt.",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -2061,7 +2061,11 @@ export default {
   "chat.no_model_title": "No AI connected.",
   "chat.no_model_body": "Start your 7-day free trial with Eigenwelt, or connect your own model.",
   "chat.no_model_trial": "Start free trial",
+  "chat.no_model_login": "Log in",
   "chat.no_model_byo": "Connect a model",
+  // Composer: signed out of Eigenwelt (or access revoked) with nothing else connected
+  "chat.signed_out_title": "Signed out of Eigenwelt.",
+  "chat.signed_out_body": "Log in to keep using Eigenwelt models, start your 7-day free trial, or connect your own model.",
   // One-time migration dialog after the free tier was retired.
   "free_retired.eyebrow": "Eigenwelt models",
   "free_retired.headline": "Free models have been retired.",

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -61,6 +61,8 @@ type ComposerProps = {
   queuedCount: number;
   disabled: boolean;
   modelUnavailable?: boolean;
+  /** The notice above the composer already explains the dead selection. */
+  modelUnavailableLabelHidden?: boolean;
   statusLabel: string;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
@@ -1511,7 +1513,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                   disabled={props.busy}
                   locked={props.modelLocked}
                 />
-                {props.modelUnavailable ? (
+                {props.modelUnavailable && !props.modelUnavailableLabelHidden ? (
                   <span className="text-xs font-medium text-red-10">Model no longer available</span>
                 ) : null}
 

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -141,9 +141,8 @@ export type SessionSurfaceProps = {
   /** Single provider serving a single model: plain model label, no Fusion. */
   modelSelectorLocked?: boolean;
   selectedModel: ModelRef;
-  /** True when the active model is a free-tier model (no-key fallback). */
-  /** Open the connect-AI flow (true = preselect Eigenwelt / start trial). */
-  onConnectAi?: (preferEigenwelt: boolean) => void;
+  /** Open the connect-AI flow from the notice above the composer. */
+  onConnectAi?: (action: ConnectAiAction) => void;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
   onSendDraft: (draft: ComposerDraft, sessionId: string) => void;
@@ -322,31 +321,43 @@ function TodoPanel(props: { todos: TodoItem[] }) {
   );
 }
 
+/** The ways out of "no usable model": trial sign-up, sign-in, or bring your own. */
+export type ConnectAiAction = "trial" | "login" | "byo";
+
 /**
- * Banner shown above the composer when NO model is connected (there is no
- * free fallback tier). Offers the two real paths: the Eigenwelt trial, or
- * bringing your own model/key.
+ * Banner shown above the composer when there is no usable model (there is no
+ * free fallback tier): nothing selected yet, or the selection points at a
+ * provider that is no longer connected (signed out of Eigenwelt, access
+ * revoked) with nothing else to switch to. Offers the three real paths: the
+ * Eigenwelt trial, signing in to an existing account, or bringing your own
+ * model/key.
  */
-function NoModelNotice(props: { onConnect?: (preferEigenwelt: boolean) => void }) {
+function NoModelNotice(props: {
+  variant: "none" | "signed-out";
+  onConnect?: (action: ConnectAiAction) => void;
+}) {
+  const secondaryButtonClass =
+    "rounded-md border border-dls-border px-2.5 py-1 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover";
   return (
     <div className="flex flex-wrap items-center gap-2.5 border-b border-dls-border bg-dls-surface px-4 py-3">
       <p className="min-w-0 flex-1 text-xs leading-relaxed text-dls-secondary">
-        <span className="font-medium text-dls-text">{t("chat.no_model_title")}</span>{" "}
-        {t("chat.no_model_body")}
+        <span className="font-medium text-dls-text">
+          {props.variant === "signed-out" ? t("chat.signed_out_title") : t("chat.no_model_title")}
+        </span>{" "}
+        {props.variant === "signed-out" ? t("chat.signed_out_body") : t("chat.no_model_body")}
       </p>
       <div className="flex shrink-0 items-center gap-2">
         <button
           type="button"
           className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-fg transition-opacity hover:opacity-90"
-          onClick={() => props.onConnect?.(true)}
+          onClick={() => props.onConnect?.("trial")}
         >
           {t("chat.no_model_trial")}
         </button>
-        <button
-          type="button"
-          className="rounded-md border border-dls-border px-2.5 py-1 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover"
-          onClick={() => props.onConnect?.(false)}
-        >
+        <button type="button" className={secondaryButtonClass} onClick={() => props.onConnect?.("login")}>
+          {t("chat.no_model_login")}
+        </button>
+        <button type="button" className={secondaryButtonClass} onClick={() => props.onConnect?.("byo")}>
           {t("chat.no_model_byo")}
         </button>
       </div>
@@ -515,6 +526,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const trialBillingUrl = eigenweltBillingUrl(eigenweltEntitlementsQuery.data?.platformURL ?? null);
   // No model connected at all (free tier retired): offer trial / BYO inline.
   const noModelNoticeVisible = !props.selectedModel.providerID;
+  // Locked out: the selection points at a provider that is no longer
+  // connected (signed out of Eigenwelt, access revoked, provider removed) and
+  // nothing else is connected, so there is no model to switch to. Same ways
+  // out as "no model"; a lapsed trial keeps its own subscribe notice.
+  const lockedOutNoticeVisible =
+    !noModelNoticeVisible &&
+    !trialEndedNoticeVisible &&
+    Boolean(props.modelUnavailable) &&
+    (props.providerConnectedCount ?? 0) === 0;
+  const connectNoticeVisible = noModelNoticeVisible || lockedOutNoticeVisible;
+  const connectNoticeVariant =
+    lockedOutNoticeVisible && props.selectedModel.providerID === "eigenwelt" ? "signed-out" : "none";
   const showThinking = local.prefs.showThinking;
   const sessionActivityStatus = useSessionActivityStore(
     (state) => state.statusesByWorkspaceId[props.workspaceId]?.[props.sessionId] ?? "idle",
@@ -1756,6 +1779,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         queuedCount={queuedMessages.length}
         disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
         modelUnavailable={Boolean(props.modelUnavailable)}
+        modelUnavailableLabelHidden={lockedOutNoticeVisible}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
         modelPickerOpen={props.modelPickerOpen}
         selectedModel={props.selectedModel}
@@ -1804,12 +1828,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
           onToggleLiveTranscript={recorderActive ? handleToggleLiveTranscript : undefined}
           liveTranscriptActive={liveTranscriptActive}
           onUploadInboxFiles={props.onUploadInboxFiles ?? handleUploadInboxFiles}
-          compactTopSpacing={Boolean(trialEndedNoticeVisible || noModelNoticeVisible || props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0)}
+          compactTopSpacing={Boolean(trialEndedNoticeVisible || connectNoticeVisible || props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0)}
           topAccessory={
-            trialEndedNoticeVisible || noModelNoticeVisible || props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0 ? (
+            trialEndedNoticeVisible || connectNoticeVisible || props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0 ? (
               <div>
                 {trialEndedNoticeVisible ? <TrialEndedNotice billingUrl={trialBillingUrl} /> : null}
-                {noModelNoticeVisible ? <NoModelNotice onConnect={props.onConnectAi} /> : null}
+                {connectNoticeVisible ? (
+                  <NoModelNotice variant={connectNoticeVariant} onConnect={props.onConnectAi} />
+                ) : null}
                 {queuedMessages.length > 0 ? (
                   <QueuedMessagesPanel messages={queuedMessages} onRemove={removeQueuedDraft} />
                 ) : null}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -97,6 +97,7 @@ import {
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
+import type { ConnectAiAction } from "@/react-app/domains/session/surface/session-surface";
 import { ReactSessionRuntime } from "@/react-app/domains/session/sync/runtime-sync";
 import { useSessionActivityStore } from "@/react-app/domains/session/status/session-activity-store";
 import { buildLegalworkEnvSystemContext } from "@/react-app/domains/session/sync/env-context";
@@ -720,6 +721,18 @@ export function SessionRoute() {
       // Canceled or failed — the connect-AI bar keeps offering the path.
     }
   }, [sessionProviderAuthStore]);
+  // "Log in" from the connect-AI bar: the same browser flow, but the platform
+  // lands on sign-in instead of sign-up (an existing account, e.g. after a
+  // sign-out or a revoked key).
+  const startEigenweltLogin = useCallback(async () => {
+    try {
+      const { authorizeUrl, sessionId } = await sessionProviderAuthStore.startEigenweltSignIn({ intent: "sign-in" });
+      await openDesktopUrl(authorizeUrl);
+      await sessionProviderAuthStore.completeEigenweltSignIn(sessionId);
+    } catch {
+      // Canceled or failed — the connect-AI bar keeps offering the path.
+    }
+  }, [sessionProviderAuthStore]);
   // On subscription activation (from the premium upsell challenge): re-pull the
   // paid Eigenwelt manifest and dispose+reload the engine/provider list so the
   // newly-entitled EU/ZDR models appear in the picker, not just the audio gate.
@@ -936,12 +949,16 @@ export function SessionRoute() {
       modelUnavailable: selectedModelUnavailable,
       modelSelectorLocked: soloEigenweltModel,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
-      // The connect-AI empty state above the composer (no model selected).
-      // "Start free trial" goes straight to the Eigenwelt sign-in; only the
-      // BYO path opens the provider picker.
-      onConnectAi: (preferEigenwelt: boolean) => {
-        if (preferEigenwelt) {
+      // The connect-AI notice above the composer (no model selected, or signed
+      // out with nothing else connected). Trial and login go straight to the
+      // Eigenwelt sign-in in the browser; only the BYO path opens the picker.
+      onConnectAi: (action: ConnectAiAction) => {
+        if (action === "trial") {
           void startEigenweltTrial();
+          return;
+        }
+        if (action === "login") {
+          void startEigenweltLogin();
           return;
         }
         void sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" });


### PR DESCRIPTION
## Problem

After signing out of Eigenwelt (or any other loss of access) the composer kept the dead "Eigenwelt Europe" selection and showed only a red **"Model no longer available"** label. No way forward from there. The "No AI connected" bar above the composer only appeared when nothing was selected at all.

## Fix

- The bar above the composer now also appears when the selected model's provider is no longer connected **and** nothing else is connected (so there is no model to switch to). A lapsed trial keeps its own subscribe notice; both never show together.
- In that case it reads **"Signed out of Eigenwelt."** with three actions: **Start free trial**, **Log in**, **Connect a model**. The fresh-install "No AI connected." variant gets the same Log in button.
- **Log in** runs the Eigenwelt sign-in with `intent: "sign-in"`, so the platform lands on sign-in rather than sign-up (the same flag the onboarding "Already have an account?" link uses).
- The red label is hidden while the bar explains the state; sending stays disabled until a model is usable again. After login the engine reloads and the existing selection becomes valid again, so the bar disappears on its own.
- Copy in EN and DE (du-form).

## Verification

Dev Electron against the local platform, signed out of Eigenwelt: bar shows "Signed out of Eigenwelt. Log in to keep using Eigenwelt models, start your 7-day free trial, or connect your own model." with the three buttons, composer shows "Eigenwelt Europe" without the red label, Run task disabled.

- `pnpm --filter @legalwork/app typecheck` clean; `bun test tests/` passes (283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)