### PR TITLE
feat(chat): hide model reasoning by default, also for existing installs

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
@@ -236,7 +236,7 @@ export function ShellCustomizationView() {
                 aria-label={t("settings.show_model_reasoning")}
                 checked={local.prefs.showThinking}
                 onCheckedChange={(value) =>
-                  local.setPrefs((previous) => ({ ...previous, showThinking: value }))
+                  local.setPrefs((previous) => ({ ...previous, showThinking: value, showThinkingChosen: true }))
                 }
               />
             </LayoutSectionItemHeaderActions>

--- a/apps/app/src/react-app/domains/settings/state/session-display-preferences.ts
+++ b/apps/app/src/react-app/domains/settings/state/session-display-preferences.ts
@@ -13,6 +13,7 @@ export function useSessionDisplayPreferences() {
         ...previous,
         showThinking:
           typeof value === "function" ? value(previous.showThinking) : value,
+        showThinkingChosen: true,
       }));
     },
     [setPrefs],
@@ -23,8 +24,13 @@ export function useSessionDisplayPreferences() {
   }, [setShowThinking]);
 
   const resetSessionDisplayPreferences = useCallback(() => {
-    setShowThinking(DEFAULT_SHOW_THINKING);
-  }, [setShowThinking]);
+    // Back to "never chose": future default changes apply again.
+    setPrefs((previous) => ({
+      ...previous,
+      showThinking: DEFAULT_SHOW_THINKING,
+      showThinkingChosen: false,
+    }));
+  }, [setPrefs]);
 
   return {
     showThinking: prefs.showThinking,

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -32,7 +32,20 @@ export type LocalUIState = {
 export type HideAppMode = "never" | "recording" | "always";
 
 export type LocalPreferences = {
+  /** Show the model's reasoning in the chat. Off unless the user turns it on. */
   showThinking: boolean;
+  /**
+   * True once the user flipped the reasoning toggle themselves. The stored
+   * value alone cannot tell a choice from a persisted default, so this is what
+   * lets a later change of the default reach everyone who never chose.
+   */
+  showThinkingChosen: boolean;
+  /**
+   * The DEFAULT_SHOW_THINKING generation this store was last aligned with
+   * (see applyShowThinkingDefault). Stores from before the field existed read
+   * as 0 and get the current default applied once.
+   */
+  showThinkingDefaultVersion: number;
   /** When to exclude the window from screen shares / recordings. */
   hideAppMode: HideAppMode;
   modelVariant: string | null;
@@ -94,11 +107,21 @@ const LocalContext = createContext<LocalContextValue | undefined>(undefined);
 
 const UI_STORAGE_KEY = "legalwork.ui";
 const PREFS_STORAGE_KEY = "legalwork.preferences";
-export const DEFAULT_SHOW_THINKING = true;
+export const DEFAULT_SHOW_THINKING = false;
+/**
+ * Bump whenever DEFAULT_SHOW_THINKING changes. Version 1 was the original
+ * "on" default; 2 turned it off. Every store below the current version gets
+ * the new default unless the user chose a value themselves.
+ */
+export const SHOW_THINKING_DEFAULT_VERSION = 2;
 
 const INITIAL_UI: LocalUIState = { view: "settings", tab: "general" };
 const INITIAL_PREFS: LocalPreferences = {
   showThinking: DEFAULT_SHOW_THINKING,
+  showThinkingChosen: false,
+  // 0, not the current version: readPersisted fills missing fields from here,
+  // so an older store must still look "behind" for applyShowThinkingDefault.
+  showThinkingDefaultVersion: 0,
   hideAppMode: "recording",
   modelVariant: null,
   defaultModel: null,
@@ -129,6 +152,20 @@ function readPersisted<T>(key: string, fallback: T): T {
   }
 }
 
+/**
+ * Align a loaded store with the current reasoning default: a store from an
+ * older default generation keeps the user's own choice, but a value that was
+ * only ever the old persisted default is replaced by the current default.
+ */
+export function applyShowThinkingDefault(prefs: LocalPreferences): LocalPreferences {
+  if (prefs.showThinkingDefaultVersion >= SHOW_THINKING_DEFAULT_VERSION) return prefs;
+  return {
+    ...prefs,
+    showThinking: prefs.showThinkingChosen ? prefs.showThinking : DEFAULT_SHOW_THINKING,
+    showThinkingDefaultVersion: SHOW_THINKING_DEFAULT_VERSION,
+  };
+}
+
 function writePersisted(key: string, value: unknown) {
   if (typeof window === "undefined") return;
   try {
@@ -147,7 +184,7 @@ export function LocalProvider({ children }: LocalProviderProps) {
     readPersisted(UI_STORAGE_KEY, INITIAL_UI),
   );
   const [prefs, setPrefsRaw] = useState<LocalPreferences>(() => {
-    const persisted = readPersisted(PREFS_STORAGE_KEY, INITIAL_PREFS);
+    const persisted = applyShowThinkingDefault(readPersisted(PREFS_STORAGE_KEY, INITIAL_PREFS));
     if (persisted.defaultModel) {
       return persisted;
     }
@@ -209,7 +246,8 @@ export function LocalProvider({ children }: LocalProviderProps) {
     try {
       const parsed = JSON.parse(raw);
       if (typeof parsed === "boolean") {
-        setPrefsRaw((previous) => ({ ...previous, showThinking: parsed }));
+        // The legacy key was only ever written by the toggle: a real choice.
+        setPrefsRaw((previous) => ({ ...previous, showThinking: parsed, showThinkingChosen: true }));
       }
     } catch {
       // ignore invalid legacy values

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2112,7 +2112,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             busy={busy}
             showThinking={local.prefs.showThinking}
             onToggleShowThinking={() => {
-              local.setPrefs((previous) => ({ ...previous, showThinking: !previous.showThinking }));
+              local.setPrefs((previous) => ({
+                ...previous,
+                showThinking: !previous.showThinking,
+                showThinkingChosen: true,
+              }));
             }}
             autoCompactContext={autoCompactContext}
             autoCompactContextBusy={autoCompactContextBusy}

--- a/apps/app/tests/reasoning-display.test.ts
+++ b/apps/app/tests/reasoning-display.test.ts
@@ -1,12 +1,60 @@
 import { describe, expect, test } from "bun:test";
 
-import { DEFAULT_SHOW_THINKING } from "../src/react-app/kernel/local-provider";
+import {
+  DEFAULT_SHOW_THINKING,
+  SHOW_THINKING_DEFAULT_VERSION,
+  applyShowThinkingDefault,
+  type LocalPreferences,
+} from "../src/react-app/kernel/local-provider";
 
 // The legacy SessionTranscript markup test was removed with the legacy
 // message list (#2016). Reasoning markup for the current transcript is
 // covered by the app e2e checks which drive the real app.
+
+function prefs(overrides: Partial<LocalPreferences>): LocalPreferences {
+  return {
+    showThinking: DEFAULT_SHOW_THINKING,
+    showThinkingChosen: false,
+    showThinkingDefaultVersion: 0,
+    hideAppMode: "recording",
+    modelVariant: null,
+    defaultModel: null,
+    selectedAgent: null,
+    releaseChannel: "stable",
+    featureFlags: { microsandboxCreateSandbox: true },
+    hasCompletedOnboarding: false,
+    onboardingStage: "done",
+    analyticsEnabled: null,
+    fusionModels: [],
+    ...overrides,
+  };
+}
+
 describe("reasoning display", () => {
-  test("defaults reasoning visibility on", () => {
-    expect(DEFAULT_SHOW_THINKING).toBe(true);
+  test("defaults reasoning visibility off", () => {
+    expect(DEFAULT_SHOW_THINKING).toBe(false);
+  });
+
+  test("a store that only carried the old 'on' default is turned off", () => {
+    // What every pre-existing install has persisted: the old default, never chosen.
+    const migrated = applyShowThinkingDefault(prefs({ showThinking: true }));
+    expect(migrated.showThinking).toBe(false);
+    expect(migrated.showThinkingChosen).toBe(false);
+    expect(migrated.showThinkingDefaultVersion).toBe(SHOW_THINKING_DEFAULT_VERSION);
+  });
+
+  test("a value the user chose survives a default change", () => {
+    const migrated = applyShowThinkingDefault(prefs({ showThinking: true, showThinkingChosen: true }));
+    expect(migrated.showThinking).toBe(true);
+    expect(migrated.showThinkingDefaultVersion).toBe(SHOW_THINKING_DEFAULT_VERSION);
+  });
+
+  test("a store already on the current default generation is left alone", () => {
+    const current = prefs({
+      showThinking: true,
+      showThinkingChosen: false,
+      showThinkingDefaultVersion: SHOW_THINKING_DEFAULT_VERSION,
+    });
+    expect(applyShowThinkingDefault(current)).toBe(current);
   });
 });


### PR DESCRIPTION
## What

"Show model reasoning" (Settings) is now **off by default**, and existing installs that never touched the toggle are switched off once on the next start.

## How

The whole preferences object is persisted on every change, so every existing install has `showThinking: true` stored whether or not the user ever chose it. The preference therefore gets two companions:

- `showThinkingChosen`: set by the toggles from now on (and by the legacy migration from the old standalone key, which only the toggle ever wrote).
- `showThinkingDefaultVersion`: the default generation the store was last aligned with. On load, `applyShowThinkingDefault` leaves a store on the current generation alone; an older store keeps the value if it was chosen and otherwise takes the current default, then is stamped with the current generation.

Consequence: installs that never chose go off; the only users who see a change they did not ask for are those who explicitly turned it on before this build (indistinguishable from the default in the old data), and they can turn it on again once. Future default changes respect explicit choices.

## Verification

- `bun test tests/`: 286 pass (4 new in `reasoning-display.test.ts`: default off, untouched old store goes off, chosen value survives, current-generation store untouched).
- `pnpm --filter @legalwork/app typecheck` clean.
- Live in the dev app: an old-style store (`showThinking: true`, no marker fields) reloads to `false / chosen false / version 2`; a store with `chosen: true` keeps `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)