### PR TITLE
fix(copy): price the plan from €69 per seat per month, billed yearly

### DIFF
--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -578,7 +578,7 @@ const de: Record<string, string> = {
   // Premium-Upsell (Eigenwelt Plus Testphase)
   "premium_upsell.eyebrow": "Eigenwelt Plus",
   "premium_upsell.headline": "Teste Eigenwelt Plus 7 Tage kostenlos",
-  "premium_upsell.intro": "Nach der Testphase 69 € pro Sitzplatz/Monat. Für jeden Sitzplatz deiner Kanzlei enthalten:",
+  "premium_upsell.intro": "Nach der Testphase ab 69 € pro Sitzplatz/Monat (bei jährlicher Zahlung; 99 € bei monatlicher Zahlung). Für jeden Sitzplatz deiner Kanzlei enthalten:",
   "premium_upsell.audio_title": "Premium-Transkriptionsmodelle",
   "premium_upsell.audio_body": "Die genauesten On-Device-Modelle für Aufnahmen und Diktate, vollständig auf deinem Rechner.",
   "premium_upsell.eu_title": "KI-Nutzung in der EU ohne Datenspeicherung",
@@ -617,7 +617,7 @@ const de: Record<string, string> = {
   "onboarding_ai.subtitle":
     "Premium-Modelle, gehostet in der EU, startklar mit einer Anmeldung. Deine Dokumente werden nur mit deiner KI geteilt. Kein Server dazwischen.",
   "onboarding_ai.cta": "7 Tage kostenlos testen",
-  "onboarding_ai.cta_note": "EU-gehostet · Keine Datenspeicherung · 69 €/Sitzplatz nach der Testphase",
+  "onboarding_ai.cta_note": "EU-gehostet · Keine Datenspeicherung · Ab 69 €/Sitzplatz/Monat nach der Testphase",
   "onboarding_ai.login_prompt": "Du hast schon ein Konto?",
   "onboarding_ai.login_cta": "Anmelden",
   "onboarding_ai.waiting_title": "Im Browser abschließen",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1981,7 +1981,7 @@ export default {
   "recorder.tier_premium_unlock_hint": "This transcription model is part of the Plus plan. It will unlock automatically once your plan is active.",
   "premium_upsell.eyebrow": "Eigenwelt Plus",
   "premium_upsell.headline": "Try Eigenwelt Plus free for 7 days",
-  "premium_upsell.intro": "€69 per seat/month after the trial. Included for every seat in your firm:",
+  "premium_upsell.intro": "From €69 per seat/month after the trial (billed yearly; €99 billed monthly). Included for every seat in your firm:",
   "premium_upsell.audio_title": "Premium audio transcription models",
   "premium_upsell.audio_body": "The most accurate on-device models for recordings and dictation, running fully on your machine.",
   "premium_upsell.eu_title": "AI usage in the EU with zero data retention",
@@ -2085,7 +2085,7 @@ export default {
   "onboarding_ai.subtitle":
     "Premium models, hosted in the EU, ready in one sign-in. Your documents are only ever shared with your AI. No server in between.",
   "onboarding_ai.cta": "Start your 7-day free trial",
-  "onboarding_ai.cta_note": "EU-hosted · Zero retention · €69/seat after the trial",
+  "onboarding_ai.cta_note": "EU-hosted · Zero retention · From €69/seat/month after the trial",
   "onboarding_ai.login_prompt": "Already have an account?",
   "onboarding_ai.login_cta": "Log in",
   "onboarding_ai.waiting_title": "Finish in your browser",


### PR DESCRIPTION
## What

Pricing changed on the platform (eigenweltlabs/model-api#15): €69 per seat per month **billed yearly** (€828/year), or €99 per seat per month billed monthly. The app stated a flat "€69/seat after the trial" in two places:

- Onboarding AI step note: now "EU-hosted · Zero retention · From €69/seat/month after the trial".
- Recorder premium upsell intro: now "From €69 per seat/month after the trial (billed yearly; €99 billed monthly). Included for every seat in your firm:".

DE in du-form. Copy only, no logic; interval-neutral so the next price change does not need an app release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)