### PR TITLE
feat(eigenwelt): Knowledge Hub plan without AI

### DIFF
--- a/apps/app/src/app/lib/eigenwelt-budget.ts
+++ b/apps/app/src/app/lib/eigenwelt-budget.ts
@@ -36,8 +36,8 @@ export const EIGENWELT_BUDGET_EXCEEDED_BODY =
   "It resets tomorrow. Your firm's billing shows today's usage in detail.";
 export const EIGENWELT_BUDGET_UPGRADE_LABEL = "Open Billing";
 
-/** Kept for wire compatibility with older payloads; only "plus" ships. */
-export type EigenweltBudgetPlan = "plus" | "pro" | null;
+/** Kept for wire compatibility with older payloads; "hub" has no gateway budget at all. */
+export type EigenweltBudgetPlan = "plus" | "pro" | "hub" | null;
 
 /** Terminal-card copy for the single Plus plan (plan param retained for
  *  compatibility; every plan sees the same copy now that Pro is retired). */

--- a/apps/app/src/app/lib/eigenwelt-trial.ts
+++ b/apps/app/src/app/lib/eigenwelt-trial.ts
@@ -27,6 +27,23 @@ export function isEigenweltEntitledStatus(status: string | null | undefined): bo
   return status != null && ENTITLED_STATUSES.has(status);
 }
 
+/**
+ * The firm is subscribed, but on a plan without the Eigenwelt models (the
+ * Knowledge Hub): the platform grants the hub features and omits
+ * `premium_models`. Such a firm never sees the trial or sign-in prompts; it
+ * needs "upgrade or bring your own model".
+ */
+export function eigenweltPlanWithoutModels(
+  entitlements:
+    | { subscriptionStatus: string | null; features?: string[] | null }
+    | null
+    | undefined,
+): boolean {
+  if (!entitlements) return false;
+  if (!isEigenweltEntitledStatus(entitlements.subscriptionStatus)) return false;
+  return !(entitlements.features ?? []).includes("premium_models");
+}
+
 export type EigenweltTrialState =
   | { kind: "none" }
   | { kind: "active"; endsAt: Date; daysLeft: number }

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -150,7 +150,8 @@ export type EigenweltUsage = {
 
 /** Subscription entitlements. OPTIONAL — absent means the free/legacy tier. */
 export type EigenweltEntitlements = {
-  plan: "plus" | "pro" | null;
+  /** "hub" = the Knowledge Hub plan without AI (no `premium_models` feature). */
+  plan: "plus" | "pro" | "hub" | null;
   subscriptionStatus: string | null;
   /**
    * ISO timestamp when the 7-day trial ends (or ended — compare against now);

--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -586,6 +586,9 @@ const de: Record<string, string> = {
   "premium_upsell.share_title": "Workflows & Integrationen im Team teilen",
   "premium_upsell.share_body": "Veröffentliche Workflows und Integrationen für die ganze Kanzlei im gemeinsamen Hub.",
   "premium_upsell.cta": "7 Tage kostenlos testen",
+  "premium_upsell.headline_upgrade": "Wechsle zu Eigenwelt Plus",
+  "premium_upsell.intro_upgrade": "69 € pro Sitzplatz/Monat bei jährlicher Zahlung, 99 € monatlich. Für jeden Sitzplatz deiner Kanzlei enthalten:",
+  "premium_upsell.cta_upgrade": "Zu Plus wechseln",
   "premium_upsell.sign_in": "Mit Eigenwelt anmelden",
   "premium_upsell.signing_in": "Anmeldung läuft…",
 
@@ -596,6 +599,9 @@ const de: Record<string, string> = {
   "chat.no_model_login": "Anmelden",
   "chat.no_model_byo": "Modell verbinden",
   // Composer: von Eigenwelt abgemeldet (oder Zugang entzogen), sonst nichts verbunden
+  "chat.no_ai_plan_title": "Dein Plan enthält keine KI-Modelle.",
+  "chat.no_ai_plan_body": "Der Knowledge Hub deckt das Teilen in deiner Kanzlei ab. Wechsle zu Plus für die Eigenwelt-Modelle oder verbinde dein eigenes Modell.",
+  "chat.no_ai_plan_upgrade": "Zu Plus wechseln",
   "chat.signed_out_title": "Von Eigenwelt abgemeldet.",
   "chat.signed_out_body": "Melde dich an, um die Eigenwelt-Modelle weiter zu nutzen, starte deine 7-tägige kostenlose Testphase oder verbinde dein eigenes Modell.",
   // Einmaliger Migrationsdialog nach dem Ende des kostenlosen Zugangs.
@@ -673,6 +679,8 @@ const de: Record<string, string> = {
   // Eigenwelt-Konto: 7-tägige kostenlose Testphase
   "account.plan_inactive": "Inaktiv",
   "account.plan_label": "Plan",
+  "account.plan_hub": "Knowledge Hub",
+  "account.models_not_in_plan": "Nicht im Knowledge-Hub-Plan enthalten. Mit Plus bekommst du die Eigenwelt-Modelle.",
   "account.models_label": "Modelle",
   "account.trial_ends_today": "Kostenlose Testphase: endet heute",
   "account.trial_ends_in_one": "Kostenlose Testphase: noch 1 Tag",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1515,6 +1515,8 @@ export default {
   // A connected account with a lapsed subscription (there is no free tier).
   "account.plan_inactive": "Inactive",
   "account.plan_label": "Plan",
+  "account.plan_hub": "Knowledge Hub",
+  "account.models_not_in_plan": "Not included in the Knowledge Hub plan. Upgrade to Plus for the Eigenwelt models.",
   "account.models_label": "Models",
   // 7-day free trial (card-upfront; converts automatically at trial end)
   "account.trial_ends_today": "Free trial: ends today",
@@ -1989,6 +1991,9 @@ export default {
   "premium_upsell.share_title": "Share workflows & integrations with your team",
   "premium_upsell.share_body": "Publish workflows and integrations to your whole firm from the shared hub.",
   "premium_upsell.cta": "Start 7-day free trial",
+  "premium_upsell.headline_upgrade": "Upgrade to Eigenwelt Plus",
+  "premium_upsell.intro_upgrade": "€69 per seat/month billed yearly, €99 monthly. Included for every seat in your firm:",
+  "premium_upsell.cta_upgrade": "Upgrade to Plus",
   "premium_upsell.sign_in": "Sign in with Eigenwelt",
   "premium_upsell.signing_in": "Signing in…",
   "premium_upsell.intro_signin": "Sign in with Eigenwelt to connect your firm, then upgrade to Plus:",
@@ -2064,6 +2069,9 @@ export default {
   "chat.no_model_login": "Log in",
   "chat.no_model_byo": "Connect a model",
   // Composer: signed out of Eigenwelt (or access revoked) with nothing else connected
+  "chat.no_ai_plan_title": "Your plan does not include AI models.",
+  "chat.no_ai_plan_body": "The Knowledge Hub covers sharing across your firm. Upgrade to Plus for the Eigenwelt models, or connect your own model.",
+  "chat.no_ai_plan_upgrade": "Upgrade to Plus",
   "chat.signed_out_title": "Signed out of Eigenwelt.",
   "chat.signed_out_body": "Log in to keep using Eigenwelt models, start your 7-day free trial, or connect your own model.",
   // One-time migration dialog after the free tier was retired.

--- a/apps/app/src/react-app/domains/recorder/premium-upsell-context.tsx
+++ b/apps/app/src/react-app/domains/recorder/premium-upsell-context.tsx
@@ -21,6 +21,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { create } from "zustand";
 
+import { eigenweltPlanWithoutModels } from "@/app/lib/eigenwelt-trial";
 import type { LegalworkServerClient } from "@/app/lib/legalwork-server";
 import {
   hasEigenweltFeature,
@@ -103,6 +104,8 @@ export function PremiumUpsellHost(props: {
   // Whether the desktop is signed in with an Eigenwelt firm — a subscription is
   // per-firm, so without a connection there is nothing to poll.
   const connected = view?.connected ?? false;
+  // A Knowledge Hub firm upgrades instead of starting a trial.
+  const planWithoutModels = connected && eigenweltPlanWithoutModels(view?.entitlements ?? null);
   const [signingIn, setSigningIn] = useState(false);
   const handleSignIn = useCallback(async () => {
     if (!onSignIn) return;
@@ -160,6 +163,7 @@ export function PremiumUpsellHost(props: {
       phase={phase}
       canPoll={Boolean(client && workspaceId)}
       connected={connected}
+      planWithoutModels={planWithoutModels}
       canSignIn={Boolean(onSignIn)}
       signingIn={signingIn}
       onSignIn={handleSignIn}

--- a/apps/app/src/react-app/domains/recorder/premium-upsell-modal.tsx
+++ b/apps/app/src/react-app/domains/recorder/premium-upsell-modal.tsx
@@ -63,6 +63,11 @@ export function PremiumUpsellModal(props: {
   onSignIn: () => void;
   onUpgrade: () => void;
   onClose: () => void;
+  /**
+   * The firm is subscribed to the Knowledge Hub (no models in the plan): the
+   * pitch is an upgrade, not a trial, and the billing page does the switch.
+   */
+  planWithoutModels?: boolean;
 }) {
   const platformURL = eigenweltPremiumPlatformUrl();
   const checkoutUrl = eigenweltBillingUrl(platformURL);
@@ -92,7 +97,7 @@ export function PremiumUpsellModal(props: {
           },
         }
       : {
-          label: t("premium_upsell.cta"),
+          label: props.planWithoutModels ? t("premium_upsell.cta_upgrade") : t("premium_upsell.cta"),
           onClick: () => {
             // Open Stripe checkout in the browser, then hand off to the provider's
             // poll loop (unless we can't poll, in which case just close).
@@ -105,8 +110,16 @@ export function PremiumUpsellModal(props: {
       <FeatureAnnouncementModal
         open={props.open}
         eyebrow={t("premium_upsell.eyebrow")}
-        headline={t("premium_upsell.headline")}
-        intro={needsSignIn ? t("premium_upsell.intro_signin") : t("premium_upsell.intro")}
+        headline={
+          props.planWithoutModels ? t("premium_upsell.headline_upgrade") : t("premium_upsell.headline")
+        }
+        intro={
+          needsSignIn
+            ? t("premium_upsell.intro_signin")
+            : props.planWithoutModels
+              ? t("premium_upsell.intro_upgrade")
+              : t("premium_upsell.intro")
+        }
         heroOverlay={<PremiumHero />}
         entries={[
           { title: t("premium_upsell.audio_title"), body: t("premium_upsell.audio_body") },

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -21,7 +21,7 @@ import {
   eigenweltBillingUrl,
   useEigenweltEntitlements,
 } from "@/react-app/domains/connections/eigenwelt-entitlements";
-import { eigenweltTrialState } from "@/app/lib/eigenwelt-trial";
+import { eigenweltPlanWithoutModels, eigenweltTrialState } from "@/app/lib/eigenwelt-trial";
 import { openDesktopUrl } from "@/app/lib/desktop";
 import { eigenweltPremiumPlatformUrl } from "@/react-app/domains/recorder/model-tiers";
 import { createClient, unwrap } from "@/app/lib/opencode";
@@ -321,8 +321,11 @@ function TodoPanel(props: { todos: TodoItem[] }) {
   );
 }
 
-/** The ways out of "no usable model": trial sign-up, sign-in, or bring your own. */
-export type ConnectAiAction = "trial" | "login" | "byo";
+/**
+ * The ways out of "no usable model": trial sign-up, sign-in, bring your own,
+ * or (a firm on the Knowledge Hub plan) upgrading to Plus.
+ */
+export type ConnectAiAction = "trial" | "login" | "byo" | "upgrade";
 
 /**
  * Banner shown above the composer when there is no usable model (there is no
@@ -330,33 +333,49 @@ export type ConnectAiAction = "trial" | "login" | "byo";
  * provider that is no longer connected (signed out of Eigenwelt, access
  * revoked) with nothing else to switch to. Offers the three real paths: the
  * Eigenwelt trial, signing in to an existing account, or bringing your own
- * model/key.
+ * model/key. A firm subscribed to the Knowledge Hub (no AI in the plan) gets
+ * "upgrade or bring your own" instead: it is signed in and paying already.
  */
 function NoModelNotice(props: {
-  variant: "none" | "signed-out";
+  variant: "none" | "signed-out" | "no-ai-plan";
   onConnect?: (action: ConnectAiAction) => void;
 }) {
+  const primaryButtonClass =
+    "rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-fg transition-opacity hover:opacity-90";
   const secondaryButtonClass =
     "rounded-md border border-dls-border px-2.5 py-1 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover";
+  const title =
+    props.variant === "no-ai-plan"
+      ? t("chat.no_ai_plan_title")
+      : props.variant === "signed-out"
+        ? t("chat.signed_out_title")
+        : t("chat.no_model_title");
+  const body =
+    props.variant === "no-ai-plan"
+      ? t("chat.no_ai_plan_body")
+      : props.variant === "signed-out"
+        ? t("chat.signed_out_body")
+        : t("chat.no_model_body");
   return (
     <div className="flex flex-wrap items-center gap-2.5 border-b border-dls-border bg-dls-surface px-4 py-3">
       <p className="min-w-0 flex-1 text-xs leading-relaxed text-dls-secondary">
-        <span className="font-medium text-dls-text">
-          {props.variant === "signed-out" ? t("chat.signed_out_title") : t("chat.no_model_title")}
-        </span>{" "}
-        {props.variant === "signed-out" ? t("chat.signed_out_body") : t("chat.no_model_body")}
+        <span className="font-medium text-dls-text">{title}</span> {body}
       </p>
       <div className="flex shrink-0 items-center gap-2">
-        <button
-          type="button"
-          className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-fg transition-opacity hover:opacity-90"
-          onClick={() => props.onConnect?.("trial")}
-        >
-          {t("chat.no_model_trial")}
-        </button>
-        <button type="button" className={secondaryButtonClass} onClick={() => props.onConnect?.("login")}>
-          {t("chat.no_model_login")}
-        </button>
+        {props.variant === "no-ai-plan" ? (
+          <button type="button" className={primaryButtonClass} onClick={() => props.onConnect?.("upgrade")}>
+            {t("chat.no_ai_plan_upgrade")}
+          </button>
+        ) : (
+          <>
+            <button type="button" className={primaryButtonClass} onClick={() => props.onConnect?.("trial")}>
+              {t("chat.no_model_trial")}
+            </button>
+            <button type="button" className={secondaryButtonClass} onClick={() => props.onConnect?.("login")}>
+              {t("chat.no_model_login")}
+            </button>
+          </>
+        )}
         <button type="button" className={secondaryButtonClass} onClick={() => props.onConnect?.("byo")}>
           {t("chat.no_model_byo")}
         </button>
@@ -511,10 +530,21 @@ function mergeDrafts(drafts: ComposerDraft[]): ComposerDraft | null {
 export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
   const { config: shellConfig } = useShellConfig();
+  // No model connected at all (free tier retired): offer trial / BYO inline.
+  const noModelNoticeVisible = !props.selectedModel.providerID;
+  // The selection points at a provider that is no longer connected and
+  // nothing else is; refined below once the trial state is known.
+  const lockedOutCandidate =
+    !noModelNoticeVisible &&
+    Boolean(props.modelUnavailable) &&
+    (props.providerConnectedCount ?? 0) === 0;
   const eigenweltEntitlementsQuery = useEigenweltEntitlements({
     client: props.client,
     workspaceId: props.workspaceId,
-    enabled: props.selectedModel.providerID === "eigenwelt",
+    // Also needed while a connect notice may show: a firm on the Knowledge
+    // Hub plan is signed in with no model and gets its own wording.
+    enabled:
+      props.selectedModel.providerID === "eigenwelt" || noModelNoticeVisible || lockedOutCandidate,
   });
   const eigenweltPlan = eigenweltEntitlementsQuery.data?.entitlements?.plan ?? null;
   // Trial lapsed while the selection still points at the Eigenwelt provider:
@@ -524,20 +554,31 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const trialEndedNoticeVisible =
     props.selectedModel.providerID === "eigenwelt" && eigenweltTrial.kind === "ended";
   const trialBillingUrl = eigenweltBillingUrl(eigenweltEntitlementsQuery.data?.platformURL ?? null);
-  // No model connected at all (free tier retired): offer trial / BYO inline.
-  const noModelNoticeVisible = !props.selectedModel.providerID;
   // Locked out: the selection points at a provider that is no longer
   // connected (signed out of Eigenwelt, access revoked, provider removed) and
   // nothing else is connected, so there is no model to switch to. Same ways
   // out as "no model"; a lapsed trial keeps its own subscribe notice.
-  const lockedOutNoticeVisible =
-    !noModelNoticeVisible &&
-    !trialEndedNoticeVisible &&
-    Boolean(props.modelUnavailable) &&
-    (props.providerConnectedCount ?? 0) === 0;
+  const lockedOutNoticeVisible = lockedOutCandidate && !trialEndedNoticeVisible;
   const connectNoticeVisible = noModelNoticeVisible || lockedOutNoticeVisible;
-  const connectNoticeVariant =
-    lockedOutNoticeVisible && props.selectedModel.providerID === "eigenwelt" ? "signed-out" : "none";
+  // Signed in to a firm on the Knowledge Hub plan: subscribed, but the plan
+  // has no Eigenwelt models, so neither "start a trial" nor "log in" applies.
+  const planWithoutModels =
+    (eigenweltEntitlementsQuery.data?.connected ?? false) &&
+    eigenweltPlanWithoutModels(eigenweltEntitlementsQuery.data?.entitlements ?? null);
+  const connectNoticeVariant = planWithoutModels
+    ? "no-ai-plan"
+    : lockedOutNoticeVisible && props.selectedModel.providerID === "eigenwelt"
+      ? "signed-out"
+      : "none";
+  // "Upgrade to Plus" opens the firm's billing page; everything else is the
+  // route's business (sign-in flows, the provider picker).
+  const onConnectAi = (action: ConnectAiAction) => {
+    if (action === "upgrade") {
+      void openDesktopUrl(trialBillingUrl);
+      return;
+    }
+    props.onConnectAi?.(action);
+  };
   const showThinking = local.prefs.showThinking;
   const sessionActivityStatus = useSessionActivityStore(
     (state) => state.statusesByWorkspaceId[props.workspaceId]?.[props.sessionId] ?? "idle",
@@ -1834,7 +1875,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               <div>
                 {trialEndedNoticeVisible ? <TrialEndedNotice billingUrl={trialBillingUrl} /> : null}
                 {connectNoticeVisible ? (
-                  <NoModelNotice variant={connectNoticeVariant} onConnect={props.onConnectAi} />
+                  <NoModelNotice variant={connectNoticeVariant} onConnect={onConnectAi} />
                 ) : null}
                 {queuedMessages.length > 0 ? (
                   <QueuedMessagesPanel messages={queuedMessages} onRemove={removeQueuedDraft} />

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -559,13 +559,21 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // nothing else is connected, so there is no model to switch to. Same ways
   // out as "no model"; a lapsed trial keeps its own subscribe notice.
   const lockedOutNoticeVisible = lockedOutCandidate && !trialEndedNoticeVisible;
-  const connectNoticeVisible = noModelNoticeVisible || lockedOutNoticeVisible;
   // Signed in to a firm on the Knowledge Hub plan: subscribed, but the plan
   // has no Eigenwelt models, so neither "start a trial" nor "log in" applies.
+  // Also shown while the selection still points at the Eigenwelt provider
+  // (a firm moved down from Plus keeps the model in the picker until the
+  // engine config is rebuilt; the gateway already rejects it).
   const planWithoutModels =
     (eigenweltEntitlementsQuery.data?.connected ?? false) &&
     eigenweltPlanWithoutModels(eigenweltEntitlementsQuery.data?.entitlements ?? null);
-  const connectNoticeVariant = planWithoutModels
+  const noAiPlanNoticeVisible =
+    planWithoutModels &&
+    !trialEndedNoticeVisible &&
+    (noModelNoticeVisible || lockedOutCandidate || props.selectedModel.providerID === "eigenwelt");
+  const connectNoticeVisible =
+    noModelNoticeVisible || lockedOutNoticeVisible || noAiPlanNoticeVisible;
+  const connectNoticeVariant = noAiPlanNoticeVisible
     ? "no-ai-plan"
     : lockedOutNoticeVisible && props.selectedModel.providerID === "eigenwelt"
       ? "signed-out"

--- a/apps/app/src/react-app/domains/settings/pages/eigenwelt-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/eigenwelt-account-view.tsx
@@ -16,7 +16,11 @@ import { Button, Card } from "@legalwork/ui/react";
 import { toast } from "@/components/ui/sonner";
 import { t } from "@/i18n";
 import { openDesktopUrl } from "@/app/lib/desktop";
-import { eigenweltTrialState, isEigenweltEntitledStatus } from "@/app/lib/eigenwelt-trial";
+import {
+  eigenweltPlanWithoutModels,
+  eigenweltTrialState,
+  isEigenweltEntitledStatus,
+} from "@/app/lib/eigenwelt-trial";
 import type { LegalworkServerClient } from "@/app/lib/legalwork-server";
 import { ProviderIcon } from "@/react-app/design-system/provider-icon";
 import {
@@ -232,8 +236,14 @@ export function EigenweltAccountView({
   );
   const planValue =
     planActive && entitlements?.plan
-      ? entitlements.plan.charAt(0).toUpperCase() + entitlements.plan.slice(1)
+      ? entitlements.plan === "hub"
+        ? t("account.plan_hub")
+        : entitlements.plan.charAt(0).toUpperCase() + entitlements.plan.slice(1)
       : t("account.plan_inactive");
+  // The Knowledge Hub plan has no Eigenwelt models: no usage to show, and the
+  // models row explains the upgrade instead of "no models yet".
+  const modelsIncluded = hasEigenweltFeature(entitlements, "premium_models");
+  const planWithoutModels = eigenweltPlanWithoutModels(entitlements);
   const trial = eigenweltTrialState(entitlements);
   const trialText =
     trial.kind === "active"
@@ -309,7 +319,7 @@ export function EigenweltAccountView({
           </LayoutSectionItemHeader>
         </LayoutSectionItem>
 
-        {entitlements ? (
+        {entitlements && modelsIncluded ? (
           <LayoutSectionItem>
             <LayoutSectionItemHeader>
               <LayoutSectionItemTitle>{t("firm_hub.usage_label")}</LayoutSectionItemTitle>
@@ -327,7 +337,9 @@ export function EigenweltAccountView({
         <LayoutSectionItem>
           <LayoutSectionItemHeader>
             <LayoutSectionItemTitle>{t("account.models_label")}</LayoutSectionItemTitle>
-            {!hasModels ? (
+            {planWithoutModels ? (
+              <LayoutSectionItemDescription>{t("account.models_not_in_plan")}</LayoutSectionItemDescription>
+            ) : !hasModels ? (
               <LayoutSectionItemDescription>{t("account.no_models")}</LayoutSectionItemDescription>
             ) : null}
             <LayoutSectionItemHeaderActions>

--- a/apps/app/tests/eigenwelt-trial.test.ts
+++ b/apps/app/tests/eigenwelt-trial.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { eigenweltTrialState, isEigenweltEntitledStatus } from "../src/app/lib/eigenwelt-trial";
+import {
+  eigenweltPlanWithoutModels,
+  eigenweltTrialState,
+  isEigenweltEntitledStatus,
+} from "../src/app/lib/eigenwelt-trial";
 
 const NOW = Date.parse("2026-08-31T12:00:00.000Z");
 const inDays = (days: number) => new Date(NOW + days * 86_400_000).toISOString();
@@ -69,5 +73,29 @@ describe("eigenweltTrialState", () => {
     expect(
       eigenweltTrialState({ subscriptionStatus: null, trialEndsAt: inDays(-3) }, NOW).kind,
     ).toBe("ended");
+  });
+});
+
+describe("eigenweltPlanWithoutModels", () => {
+  test("a subscribed firm whose plan lacks premium_models (Knowledge Hub)", () => {
+    expect(
+      eigenweltPlanWithoutModels({
+        subscriptionStatus: "active",
+        features: ["admin_hub", "settings_presets", "org_management"],
+      }),
+    ).toBe(true);
+  });
+
+  test("Plus firms (premium_models present) and unentitled firms are not", () => {
+    expect(
+      eigenweltPlanWithoutModels({
+        subscriptionStatus: "trialing",
+        features: ["admin_hub", "premium_models"],
+      }),
+    ).toBe(false);
+    expect(eigenweltPlanWithoutModels({ subscriptionStatus: "canceled", features: [] })).toBe(false);
+    expect(eigenweltPlanWithoutModels({ subscriptionStatus: null })).toBe(false);
+    expect(eigenweltPlanWithoutModels(null)).toBe(false);
+    expect(eigenweltPlanWithoutModels(undefined)).toBe(false);
   });
 });

--- a/apps/server/src/eigenwelt-auth.ts
+++ b/apps/server/src/eigenwelt-auth.ts
@@ -99,7 +99,8 @@ export type EigenweltUsage = {
  * treat "no entitlements" as the free/legacy tier and not break.
  */
 export type EigenweltEntitlements = {
-  plan: "plus" | "pro" | null;
+  /** "hub" = the Knowledge Hub plan without AI (no `premium_models`). */
+  plan: "plus" | "pro" | "hub" | null;
   subscriptionStatus: string | null;
   /**
    * ISO timestamp when the 7-day trial ends (or ended — compare against now);
@@ -121,10 +122,11 @@ export type EigenweltAccountIdentity = {
 };
 
 /**
- * Active-subscription check. The platform emits the `premium_models` feature
- * ONLY when the org isEntitled (plan plus/pro with an active/trialing/past_due
- * status), so this is the authoritative "has an active sub" signal — stricter
- * than merely being signed in. Used to gate the paid Eigenwelt provider.
+ * Paid-models check. The platform emits the `premium_models` feature ONLY when
+ * the org isEntitled (an active/trialing/past_due status) on a plan that
+ * includes the Eigenwelt models (Plus; the Knowledge Hub plan does not), so
+ * this is the authoritative signal — stricter than merely being signed in or
+ * subscribed. Used to gate the paid Eigenwelt provider.
  */
 export function eigenweltHasPremiumModels(
   entitlements: EigenweltEntitlements | null | undefined,
@@ -206,7 +208,8 @@ function toFiniteNumber(value: unknown, fallback = 0): number {
  */
 export function parseEigenweltEntitlements(value: unknown): EigenweltEntitlements | undefined {
   if (!isRecord(value)) return undefined;
-  const plan = value.plan === "plus" || value.plan === "pro" ? value.plan : null;
+  const plan =
+    value.plan === "plus" || value.plan === "pro" || value.plan === "hub" ? value.plan : null;
   const subscriptionStatus = typeof value.subscriptionStatus === "string" ? value.subscriptionStatus : null;
   const trialEndsAt =
     typeof value.trialEndsAt === "string" && Number.isFinite(Date.parse(value.trialEndsAt))


### PR DESCRIPTION
App side of eigenweltlabs/model-api#17: the platform now sells a Knowledge Hub plan without AI (plan `hub`, hub features, no `premium_models`, no trial). The server already keeps the paid Eigenwelt provider out of the engine config when `premium_models` is absent; this teaches the UI what that state means.

## What

- entitlements accept plan `hub` (server parser and app types; older app versions parse it as `plan: null` with the hub features, nothing breaks)
- composer connect bar: a signed-in firm on a plan without models sees **"Your plan does not include AI models."** with *Upgrade to Plus* (opens the firm's billing page, where the upgrade lives) and *Connect a model*, instead of trial and log-in. Also shown while the Eigenwelt model is still selected after a sales-side downgrade, like the trial-ended notice
- account view: plan reads "Knowledge Hub", the daily usage row is hidden, the models row says "Not included in the Knowledge Hub plan. Upgrade to Plus for the Eigenwelt models."
- recorder premium upsell pitches the upgrade (no trial) for such firms
- `eigenweltPlanWithoutModels()` helper with tests; EN/DE copy

## Tested

- app typecheck, server typecheck, 288 app tests
- dev instance against the local platform: firm moved onto the Hub price shows the notice above the composer and the new account rows; moved back to Plus, the notice disappears and the models return

🤖 Generated with [Claude Code](https://claude.com/claude-code)
