### PR TITLE
feat(models): follow the firm's model list from the Eigenwelt platform

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -133,9 +133,16 @@ export type LegalworkPersonalizationSettings = {
 export type EigenweltManifestModel = {
   id: string;
   name?: string;
+  description?: string;
   contextLength?: number;
   toolCall?: boolean;
   reasoning?: boolean;
+  /** Where the deployment runs: "EU" or an ISO 3166 alpha-2 code ("US"). */
+  region?: string;
+  /** Plain-English hosting label, e.g. "Europe". */
+  hostedIn?: string;
+  /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
+  upstreamModel?: string;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */
@@ -190,6 +197,14 @@ export type EigenweltEntitlementsView = {
   platformURL: string | null;
   /** Signed in with an Eigenwelt account — independent of the served model list. */
   connected: boolean;
+  /**
+   * Fingerprint of the model list the server currently serves (admins turn
+   * models on and off on the platform); null when not connected. Only the
+   * entitlements read sends it; older servers omit it.
+   */
+  modelsRevision?: string | null;
+  /** The ids of the models the server's engine config serves right now. */
+  servedModelIds?: string[];
 };
 
 /** Payload delivered once "Sign in with Eigenwelt" completes in the browser. */

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -143,6 +143,8 @@ export type EigenweltManifestModel = {
   hostedIn?: string;
   /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
   upstreamModel?: string;
+  /** The provider keeps prompts and responses for a while to detect misuse. */
+  abuseMonitoring?: boolean;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */

--- a/apps/app/src/i18n/locales/de.ts
+++ b/apps/app/src/i18n/locales/de.ts
@@ -68,6 +68,8 @@ const de: Record<string, string> = {
   /* ---- App errors ---- */
   "app.error_eigenwelt_signin_expired":
     "Deine Eigenwelt-Anmeldung auf diesem Computer ist nicht mehr gültig. Öffne die Einstellungen, dann Konto, und melde dich erneut an.",
+  "app.error_eigenwelt_model_off":
+    "Deine Kanzlei hat dieses Modell auf der Eigenwelt-Plattform ausgeschaltet. Wähle im Modellwähler ein anderes Modell.",
 
   /* ---- Common actions ---- */
   "common.add": "Hinzufügen",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -68,6 +68,8 @@ export default {
   "app.error_connect_first": "Connect to this worker before applying runtime changes.",
   "app.error_eigenwelt_signin_expired":
     "Your Eigenwelt sign-in on this computer is no longer valid. Open Settings, then Account, and sign in again.",
+  "app.error_eigenwelt_model_off":
+    "Your firm turned this model off on the Eigenwelt platform. Choose another model in the model picker.",
   "app.error_not_connected": "Not connected to a server",
   "app.error_rate_limit": "Rate limit exceeded",
   "app.error_remote_access": "Failed to update remote access.",

--- a/apps/app/src/react-app/domains/connections/eigenwelt-entitlements.ts
+++ b/apps/app/src/react-app/domains/connections/eigenwelt-entitlements.ts
@@ -51,10 +51,12 @@ export function useEigenweltEntitlements(input: {
   return useQuery({
     queryKey: eigenweltEntitlementsQueryKey(input.workspaceId ?? ""),
     enabled: Boolean(input.enabled !== false && input.client && input.workspaceId),
-    staleTime: 60_000,
+    staleTime: 20_000,
     // Keep entitlements live: each read makes the server opportunistically
-    // refresh its access token (rotating) and pull the current plan/usage, so a
-    // plan change on the platform propagates without re-signing-in.
+    // refresh its access token (rotating) and pull the current plan/usage AND
+    // the firm's model list, so a plan change or a model an admin turned on or
+    // off on the platform propagates without re-signing-in. Short staleness so
+    // switching back to the app after a change on the platform picks it up.
     refetchOnWindowFocus: true,
     refetchInterval: 5 * 60_000,
     queryFn: async (): Promise<EigenweltEntitlementsView> => {

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -8,7 +8,12 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { t } from "../../../../i18n";
-import { eigenweltSignInExpiredMessage, isEigenweltSignInExpiredError } from "./eigenwelt-provider-error";
+import {
+  eigenweltModelDisabledMessage,
+  eigenweltSignInExpiredMessage,
+  isEigenweltModelDisabledError,
+  isEigenweltSignInExpiredError,
+} from "./eigenwelt-provider-error";
 import { unwrap } from "../../../../app/lib/opencode";
 import {
   abortSession as abortSessionTyped,
@@ -299,10 +304,16 @@ export function createSessionActionsStore(options: {
       (typeof error === "string" ? readString(error) : null);
 
     const generic = raw && /^unknown\s+error$/i.test(raw);
+    // A model the firm's admin turned off on the platform (403 from the
+    // gateway): checked first, since a 403 from the eigenwelt provider would
+    // otherwise read as an expired sign-in.
+    const modelOff = isEigenweltModelDisabledError({ texts: [raw, response] });
     // A dead Eigenwelt key (the sign-in on this device was replaced or
     // revoked): the raw 401 body is noise, the fix is signing in again.
-    const signInExpired = isEigenweltSignInExpiredError({ status, provider, texts: [raw, response] });
+    const signInExpired =
+      !modelOff && isEigenweltSignInExpiredError({ status, provider, texts: [raw, response] });
     const heading = (() => {
+      if (modelOff) return eigenweltModelDisabledMessage();
       if (signInExpired) return eigenweltSignInExpiredMessage();
       if (status === 401 || status === 403) return t("app.error_auth_failed");
       if (status === 429) return t("app.error_rate_limit");
@@ -311,7 +322,7 @@ export function createSessionActionsStore(options: {
     })();
 
     const lines = [heading];
-    if (raw && !generic && !signInExpired && raw !== heading) lines.push(raw);
+    if (raw && !generic && !signInExpired && !modelOff && raw !== heading) lines.push(raw);
     if (status && !heading.includes(String(status))) lines.push(`Status: ${status}`);
     if (provider && !heading.includes(provider)) lines.push(`Provider: ${provider}`);
     if (code) lines.push(`Code: ${code}`);

--- a/apps/app/src/react-app/domains/session/sync/eigenwelt-provider-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/eigenwelt-provider-error.ts
@@ -24,3 +24,27 @@ export function isEigenweltSignInExpiredError(input: {
 export function eigenweltSignInExpiredMessage(): string {
   return t("app.error_eigenwelt_signin_expired");
 }
+
+/**
+ * The gateway's answer when the firm's admin turned the requested model off
+ * on the Eigenwelt platform (LiteLLM's `team_model_access_denied`, a 403).
+ * Checked BEFORE the sign-in check: a 403 from the eigenwelt provider would
+ * otherwise read as an expired sign-in.
+ */
+const MODEL_OFF_MARKERS = [
+  "team_model_access_denied",
+  "team not allowed to access model",
+  "key not allowed to access model",
+];
+
+export function isEigenweltModelDisabledError(input: {
+  texts: Array<string | null | undefined>;
+}): boolean {
+  return input.texts.some(
+    (text) => Boolean(text) && MODEL_OFF_MARKERS.some((marker) => text!.includes(marker)),
+  );
+}
+
+export function eigenweltModelDisabledMessage(): string {
+  return t("app.error_eigenwelt_model_off");
+}

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -5,7 +5,12 @@ import type { FilePart, Part, ToolPart } from "@opencode-ai/sdk/v2/client";
 import type { LegalworkSessionSnapshot } from "../../../../app/lib/legalwork-server";
 import { safeStringify } from "../../../../app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
-import { eigenweltSignInExpiredMessage, isEigenweltSignInExpiredError } from "./eigenwelt-provider-error";
+import {
+  eigenweltModelDisabledMessage,
+  eigenweltSignInExpiredMessage,
+  isEigenweltModelDisabledError,
+  isEigenweltSignInExpiredError,
+} from "./eigenwelt-provider-error";
 import {
   parseDynamicToolUIPart,
   parseStructuredOutputUIPart,
@@ -56,6 +61,7 @@ function withAttachmentRecoveryHint(text: string) {
 }
 
 function describeErrorText(text: string) {
+  if (isEigenweltModelDisabledError({ texts: [text] })) return eigenweltModelDisabledMessage();
   if (isEigenweltSignInExpiredError({ status: null, provider: null, texts: [text] })) {
     return eigenweltSignInExpiredMessage();
   }
@@ -79,15 +85,25 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   const retries = firstNumberValue(records, ["retries", "retryCount"]);
   const responseBody = firstStringValue(records, ["responseBody", "body", "response"]);
 
+  // A model the firm's admin turned off (403 from the gateway): say so
+  // instead of echoing the allowlist. Checked first, since a 403 from the
+  // eigenwelt provider otherwise reads as an expired sign-in.
+  const modelOff = isEigenweltModelDisabledError({ texts: [message, responseBody] });
   // A dead Eigenwelt key (the sign-in on this device was replaced or
   // revoked): the raw 401 body is noise, the fix is signing in again.
-  const signInExpired = isEigenweltSignInExpiredError({
-    status,
-    provider,
-    texts: [message, responseBody],
-  });
+  const signInExpired =
+    !modelOff &&
+    isEigenweltSignInExpiredError({
+      status,
+      provider,
+      texts: [message, responseBody],
+    });
   const lines = [
-    signInExpired ? eigenweltSignInExpiredMessage() : (message ?? defaultErrorMessage(name, fallback)),
+    modelOff
+      ? eigenweltModelDisabledMessage()
+      : signInExpired
+        ? eigenweltSignInExpiredMessage()
+        : (message ?? defaultErrorMessage(name, fallback)),
   ];
   if (status && !lines[0]?.includes(String(status))) lines.push(`Status: ${status}`);
   if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -126,7 +126,11 @@ import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-works
 import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
 import { CommandPalette, type PaletteItem, type SessionGroupOption, type SessionOption as PaletteSessionOption } from "./command-palette";
 import { SessionSearchDialog } from "./session-search-dialog";
-import { invalidateEigenweltEntitlements } from "@/react-app/domains/connections/eigenwelt-entitlements";
+import {
+  hasEigenweltFeature,
+  invalidateEigenweltEntitlements,
+  useEigenweltEntitlements,
+} from "@/react-app/domains/connections/eigenwelt-entitlements";
 import { FreeRetiredDialog, markFreeRetiredNoticePending } from "./free-retired-dialog";
 import { WhatsNewDialog } from "./whats-new";
 import { TranscriptionIntroDialog } from "./transcription-intro";
@@ -771,6 +775,44 @@ export function SessionRoute() {
     client,
     selectedWorkspaceId,
     providerConnectedIds,
+    activeReloadBlockingSessions.length,
+    sessionProviderAuthStore,
+  ]);
+  // Live model list: on the Eigenwelt platform an admin turns models on and
+  // off for the whole firm. Every entitlements poll (every few minutes and
+  // when the window regains focus) makes the server re-pull the firm's list
+  // and rebuild the engine config; the response says which model ids that
+  // config now serves. When the engine's live provider list differs, reload
+  // it once per served list, so the picker gains or loses the model and a
+  // selection on a model that went off is moved by the auto-select above.
+  // Skipped while a task runs (a dispose would interrupt it); the next poll
+  // retries.
+  const eigenweltEntitlementsQuery = useEigenweltEntitlements({ client, workspaceId: selectedWorkspaceId });
+  const servedModelIds = eigenweltEntitlementsQuery.data?.servedModelIds;
+  const eigenweltModelsIncluded = hasEigenweltFeature(
+    eigenweltEntitlementsQuery.data?.entitlements,
+    "premium_models",
+  );
+  const engineEigenweltModelIds = useMemo(() => {
+    const list = providerListQuery.data;
+    if (!list) return null;
+    const eigenwelt = getConnectedProviderItems(list).find((provider) => provider.id === "eigenwelt");
+    return Object.keys(eigenwelt?.models ?? {});
+  }, [providerListQuery.data]);
+  const reloadedForServedModels = useRef<string | null>(null);
+  useEffect(() => {
+    if (!servedModelIds || !engineEigenweltModelIds || !eigenweltModelsIncluded) return;
+    const servedKey = [...servedModelIds].sort().join("\u0000");
+    const engineKey = [...engineEigenweltModelIds].sort().join("\u0000");
+    if (servedKey === engineKey) return;
+    if (reloadedForServedModels.current === servedKey) return; // one reload per change
+    if (activeReloadBlockingSessions.length > 0) return; // don't disrupt a running task
+    reloadedForServedModels.current = servedKey;
+    void sessionProviderAuthStore.refreshProviders({ dispose: true }).catch(() => undefined);
+  }, [
+    servedModelIds,
+    engineEigenweltModelIds,
+    eigenweltModelsIncluded,
     activeReloadBlockingSessions.length,
     sessionProviderAuthStore,
   ]);

--- a/apps/app/tests/eigenwelt-provider-error.test.ts
+++ b/apps/app/tests/eigenwelt-provider-error.test.ts
@@ -6,10 +6,38 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  eigenweltModelDisabledMessage,
   eigenweltSignInExpiredMessage,
+  isEigenweltModelDisabledError,
   isEigenweltSignInExpiredError,
 } from "../src/react-app/domains/session/sync/eigenwelt-provider-error";
 import { describeOpencodeSessionError } from "../src/react-app/domains/session/sync/usechat-adapter";
+
+const LITELLM_MODEL_OFF_BODY =
+  '{"error":{"message":"team not allowed to access model. This team can only access models=[\'Eigenwelt Europe\']. Tried to access Eigenwelt US","type":"team_model_access_denied","param":"model","code":"403"}}';
+
+describe("isEigenweltModelDisabledError", () => {
+  test("recognizes the gateway's team_model_access_denied body", () => {
+    expect(isEigenweltModelDisabledError({ texts: [LITELLM_MODEL_OFF_BODY] })).toBe(true);
+    expect(isEigenweltModelDisabledError({ texts: [null, "key not allowed to access model"] })).toBe(true);
+    expect(isEigenweltModelDisabledError({ texts: [LITELLM_DEAD_KEY_BODY, undefined] })).toBe(false);
+  });
+
+  test("a 403 for a model the firm turned off reads as such, not as an expired sign-in", () => {
+    const text = describeOpencodeSessionError({
+      name: "APIError",
+      message: LITELLM_MODEL_OFF_BODY,
+      statusCode: 403,
+      providerID: "eigenwelt",
+    });
+    expect(text.startsWith(eigenweltModelDisabledMessage())).toBe(true);
+    expect(text).not.toContain(eigenweltSignInExpiredMessage());
+    expect(text).not.toContain("team_model_access_denied");
+    expect(describeOpencodeSessionError(new Error(LITELLM_MODEL_OFF_BODY))).toBe(
+      eigenweltModelDisabledMessage(),
+    );
+  });
+});
 
 const LITELLM_DEAD_KEY_BODY =
   '{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...qrtQ, Key Hash (Token) =bfc5. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}';

--- a/apps/server/src/eigenwelt-auth.test.ts
+++ b/apps/server/src/eigenwelt-auth.test.ts
@@ -34,8 +34,16 @@ type FakePlatform = {
   url: string;
   exchangeCalls: Array<Record<string, unknown>>;
   modelsCalls: number;
+  /** Authorization headers seen on /api/desktop/models (the firm's list). */
+  desktopModelsAuth: Array<string | undefined>;
   close: () => Promise<void>;
   failModels: boolean;
+};
+
+/** The firm's own list: the admin turned "ewl-small" off on the platform. */
+const FIRM_MANIFEST_PAYLOAD = {
+  baseURL: MANIFEST_PAYLOAD.baseURL,
+  models: [{ ...MANIFEST_PAYLOAD.models[0], region: "EU", hostedIn: "Europe", upstreamModel: "DeepSeek V4 Flash" }],
 };
 
 /** Throwaway local HTTP server standing in for the Eigenwelt platform. */
@@ -45,6 +53,7 @@ async function startFakePlatform(): Promise<FakePlatform> {
     url: "",
     exchangeCalls,
     modelsCalls: 0,
+    desktopModelsAuth: [],
     close: async () => {},
     failModels: false,
   };
@@ -60,6 +69,17 @@ async function startFakePlatform(): Promise<FakePlatform> {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify(EXCHANGE_PAYLOAD));
       });
+      return;
+    }
+    if (req.method === "GET" && req.url === "/api/desktop/models") {
+      platform.desktopModelsAuth.push(req.headers.authorization);
+      if (req.headers.authorization !== "Bearer desktop-token") {
+        res.writeHead(401, { "Content-Type": "text/plain" });
+        res.end("unauthorized");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(FIRM_MANIFEST_PAYLOAD));
       return;
     }
     if (req.method === "GET" && req.url === "/api/public/models") {
@@ -229,6 +249,38 @@ describe("eigenwelt manifest", () => {
     const platform = await setupPlatform();
     await platform.close();
     await expect(fetchEigenweltManifest()).rejects.toThrow(/Could not reach the Eigenwelt platform/);
+  });
+
+  test("with the firm's access token it fetches the FIRM's list (admin on/off applied) and its facts", async () => {
+    const platform = await setupPlatform();
+    const manifest = await fetchEigenweltManifest({ platformToken: "desktop-token" });
+    expect(platform.desktopModelsAuth).toEqual(["Bearer desktop-token"]);
+    expect(platform.modelsCalls).toBe(0); // never the public catalog
+    expect(manifest.models).toEqual([
+      {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        contextLength: 200000,
+        region: "EU",
+        hostedIn: "Europe",
+        upstreamModel: "DeepSeek V4 Flash",
+      },
+    ]);
+  });
+
+  test("a rejected token says to sign in again instead of falling back to the public catalog", async () => {
+    const platform = await setupPlatform();
+    await expect(fetchEigenweltManifest({ platformToken: "stale-token" })).rejects.toThrow(
+      /sign in again/i,
+    );
+    expect(platform.modelsCalls).toBe(0);
+  });
+
+  test("an empty token means the public catalog (paste-a-key path)", async () => {
+    const platform = await setupPlatform();
+    const manifest = await fetchEigenweltManifest({ platformToken: null });
+    expect(platform.modelsCalls).toBe(1);
+    expect(manifest.models).toHaveLength(2);
   });
 });
 

--- a/apps/server/src/eigenwelt-auth.ts
+++ b/apps/server/src/eigenwelt-auth.ts
@@ -78,9 +78,16 @@ export function validateEigenweltPlatformUrl(value: string): string {
 export type EigenweltManifestModel = {
   id: string;
   name?: string;
+  description?: string;
   contextLength?: number;
   toolCall?: boolean;
   reasoning?: boolean;
+  /** Where the deployment runs: "EU" or an ISO 3166 alpha-2 code ("US"). */
+  region?: string;
+  /** Plain-English hosting label, e.g. "Europe". */
+  hostedIn?: string;
+  /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
+  upstreamModel?: string;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */
@@ -500,16 +507,34 @@ export async function waitForEigenweltSignIn(
 }
 
 /**
- * Fetch the platform's public model manifest (gateway baseURL + model list).
- * Backs the "Paste an API key" path, where no exchange delivers the models.
+ * Fetch the platform's model manifest (gateway baseURL + model list).
+ *
+ * With a desktop access token this is the FIRM's list from the authenticated
+ * endpoint: models an org admin turned off on the platform are left out, so
+ * a refresh never re-adds one. Without a token (the "Paste an API key" path,
+ * or a legacy sign-in without tokens) it is the whole public catalog.
  */
-export async function fetchEigenweltManifest(): Promise<EigenweltManifest> {
+export async function fetchEigenweltManifest(options?: {
+  platformToken?: string | null;
+}): Promise<EigenweltManifest> {
   const platform = eigenweltPlatformUrl();
+  const token = options?.platformToken?.trim() || null;
+  const url = token ? `${platform}/api/desktop/models` : `${platform}/api/public/models`;
   let response: Response;
   try {
-    response = await fetch(`${platform}/api/public/models`, { headers: { Accept: "application/json" } });
+    response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
   } catch {
     throw new Error("Could not reach the Eigenwelt platform.");
+  }
+  if (token && (response.status === 401 || response.status === 403)) {
+    throw new Error(
+      "Your Eigenwelt sign-in on this computer is no longer valid. Sign in again to refresh the models.",
+    );
   }
   if (!response.ok) {
     throw new Error(`Could not reach the Eigenwelt platform (HTTP ${response.status}).`);

--- a/apps/server/src/eigenwelt-auth.ts
+++ b/apps/server/src/eigenwelt-auth.ts
@@ -88,6 +88,8 @@ export type EigenweltManifestModel = {
   hostedIn?: string;
   /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
   upstreamModel?: string;
+  /** The provider keeps prompts and responses for a while to detect misuse. */
+  abuseMonitoring?: boolean;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */

--- a/apps/server/src/eigenwelt-paid-manifest.test.ts
+++ b/apps/server/src/eigenwelt-paid-manifest.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  applyEigenweltPaidManifestModels,
+  eigenweltPaidManifestRevision,
+  parseManifestModels,
+  readCachedEigenweltPaidManifest,
+  writeCachedEigenweltPaidManifest,
+} from "./eigenwelt-paid-manifest.js";
+import type { ServerConfig } from "./types.js";
+
+const previousRuntimeDb = process.env.LEGALWORK_RUNTIME_DB;
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  if (previousRuntimeDb === undefined) delete process.env.LEGALWORK_RUNTIME_DB;
+  else process.env.LEGALWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function setup(): Promise<ServerConfig> {
+  const root = await mkdtemp(join(tmpdir(), "legalwork-eigenwelt-manifest-"));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  process.env.LEGALWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return serverConfig(root);
+}
+
+const EUROPE = { id: "Eigenwelt Europe", name: "Eigenwelt Europe", region: "EU", hostedIn: "Europe" };
+const US = { id: "Eigenwelt US", name: "Eigenwelt US", region: "US", hostedIn: "United States" };
+
+describe("parseManifestModels", () => {
+  test("keeps the hosting facts and drops malformed entries", () => {
+    expect(
+      parseManifestModels([
+        { id: "Eigenwelt Europe", name: "Eigenwelt Europe", region: "EU", hostedIn: " Europe ", upstreamModel: "DeepSeek V4 Flash", description: "" },
+        { id: "", name: "nameless" },
+        "junk",
+        { id: "plain" },
+      ]),
+    ).toEqual([
+      { id: "Eigenwelt Europe", name: "Eigenwelt Europe", region: "EU", hostedIn: "Europe", upstreamModel: "DeepSeek V4 Flash" },
+      { id: "plain" },
+    ]);
+  });
+});
+
+describe("applyEigenweltPaidManifestModels", () => {
+  test("is a no-op without a cached manifest (not signed in)", async () => {
+    const config = await setup();
+    expect(await applyEigenweltPaidManifestModels(config, [EUROPE])).toBe(false);
+    expect(await readCachedEigenweltPaidManifest(config)).toBeNull();
+  });
+
+  test("replaces the cached list around the kept key only when it differs", async () => {
+    const config = await setup();
+    await writeCachedEigenweltPaidManifest(config, {
+      baseURL: "https://gateway.test/v1",
+      apiKey: "ewl_key",
+      models: [EUROPE, US],
+    });
+    // The admin turned the US model off on the platform.
+    expect(await applyEigenweltPaidManifestModels(config, [EUROPE])).toBe(true);
+    expect(await readCachedEigenweltPaidManifest(config)).toEqual({
+      baseURL: "https://gateway.test/v1",
+      apiKey: "ewl_key",
+      models: [EUROPE],
+    });
+    expect(await applyEigenweltPaidManifestModels(config, [EUROPE])).toBe(false);
+  });
+});
+
+describe("eigenweltPaidManifestRevision", () => {
+  test("is null when not connected, stable across order, and moves with the model set", () => {
+    expect(eigenweltPaidManifestRevision(null)).toBeNull();
+    const base = { baseURL: "https://gateway.test/v1", apiKey: "k" };
+    const both = eigenweltPaidManifestRevision({ ...base, models: [EUROPE, US] });
+    expect(eigenweltPaidManifestRevision({ ...base, models: [US, EUROPE] })).toBe(both);
+    expect(eigenweltPaidManifestRevision({ ...base, models: [EUROPE] })).not.toBe(both);
+    // The key is not part of the fingerprint: a rotated key is not a model change.
+    expect(eigenweltPaidManifestRevision({ ...base, apiKey: "other", models: [EUROPE, US] })).toBe(both);
+  });
+});

--- a/apps/server/src/eigenwelt-paid-manifest.ts
+++ b/apps/server/src/eigenwelt-paid-manifest.ts
@@ -14,7 +14,7 @@
  */
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import {
@@ -40,14 +40,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function optionalText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 function parseManifestModel(value: unknown): EigenweltManifestModel | null {
   if (!isRecord(value) || typeof value.id !== "string" || !value.id) return null;
+  const description = optionalText(value.description);
+  const region = optionalText(value.region);
+  const hostedIn = optionalText(value.hostedIn);
+  const upstreamModel = optionalText(value.upstreamModel);
   return {
     id: value.id,
     ...(typeof value.name === "string" ? { name: value.name } : {}),
+    ...(description ? { description } : {}),
     ...(typeof value.contextLength === "number" ? { contextLength: value.contextLength } : {}),
     ...(typeof value.toolCall === "boolean" ? { toolCall: value.toolCall } : {}),
     ...(typeof value.reasoning === "boolean" ? { reasoning: value.reasoning } : {}),
+    ...(region ? { region } : {}),
+    ...(hostedIn ? { hostedIn } : {}),
+    ...(upstreamModel ? { upstreamModel } : {}),
   };
 }
 
@@ -99,21 +111,51 @@ export async function clearCachedEigenweltPaidManifest(config: ServerConfig): Pr
 /**
  * Refresh the model list around the kept key (the manual "Refresh models"
  * button + background refresh). No-op when there is no cached manifest (not
- * connected — nothing to refresh). Returns the model count and whether the
- * cache changed; the caller rebuilds the engine config file when it changed.
- * The fetch failure (unreachable gateway) is surfaced to the caller.
+ * connected — nothing to refresh). With the firm's desktop access token the
+ * list is the firm's own (admin on/off applied); without one it is the
+ * public catalog. Returns the model count and whether the cache changed; the
+ * caller rebuilds the engine config file when it changed. The fetch failure
+ * (unreachable gateway, dead token) is surfaced to the caller.
  */
 export async function refreshEigenweltPaidManifest(
   config: ServerConfig,
+  options?: { platformToken?: string | null },
 ): Promise<{ modelCount: number; changed: boolean }> {
   const cached = await readCachedEigenweltPaidManifest(config);
   if (!cached) return { modelCount: 0, changed: false };
 
-  const { baseURL, models } = await fetchEigenweltManifest(); // throws on unreachable
+  const { baseURL, models } = await fetchEigenweltManifest(options); // throws on unreachable
   const next: EigenweltPaidManifest = { ...cached, baseURL, models };
   const changed = JSON.stringify(cached) !== JSON.stringify(next);
   if (changed) await writeCachedEigenweltPaidManifest(config, next);
   return { modelCount: next.models.length, changed };
+}
+
+/**
+ * Replace the cached model list with one the platform delivered on its own
+ * (the token refresh payload carries the firm's current list). No-op when
+ * not connected. Returns whether the cache changed.
+ */
+export async function applyEigenweltPaidManifestModels(
+  config: ServerConfig,
+  models: EigenweltManifestModel[],
+): Promise<boolean> {
+  const cached = await readCachedEigenweltPaidManifest(config);
+  if (!cached) return false;
+  if (JSON.stringify(cached.models) === JSON.stringify(models)) return false;
+  await writeCachedEigenweltPaidManifest(config, { ...cached, models });
+  return true;
+}
+
+/**
+ * Fingerprint of the served model list, so the app can tell a poll that
+ * changed the models (reload the engine's providers) from one that did not.
+ * Order-independent; null when not connected.
+ */
+export function eigenweltPaidManifestRevision(manifest: EigenweltPaidManifest | null): string | null {
+  if (!manifest) return null;
+  const models = [...manifest.models].sort((a, b) => a.id.localeCompare(b.id));
+  return createHash("sha1").update(JSON.stringify(models)).digest("hex").slice(0, 16);
 }
 
 /**

--- a/apps/server/src/eigenwelt-paid-manifest.ts
+++ b/apps/server/src/eigenwelt-paid-manifest.ts
@@ -60,6 +60,7 @@ function parseManifestModel(value: unknown): EigenweltManifestModel | null {
     ...(region ? { region } : {}),
     ...(hostedIn ? { hostedIn } : {}),
     ...(upstreamModel ? { upstreamModel } : {}),
+    ...(value.abuseMonitoring === true ? { abuseMonitoring: true } : {}),
   };
 }
 

--- a/apps/server/src/eigenwelt-refresh.ts
+++ b/apps/server/src/eigenwelt-refresh.ts
@@ -19,6 +19,7 @@ import {
   type EigenweltEntitlementsView,
 } from "./eigenwelt-connection-store.js";
 import { readEigenweltEntitlementsView } from "./eigenwelt-connection-store.js";
+import { applyEigenweltPaidManifestModels, parseManifestModels } from "./eigenwelt-paid-manifest.js";
 import type { ServerConfig } from "./types.js";
 
 /** Refresh once fewer than this many ms of access-token life remain. */
@@ -130,6 +131,15 @@ async function doRefresh(config: ServerConfig, workspaceId: string): Promise<str
     ...(account ? { account } : {}),
     ...(platformURL ? { platformURL } : {}),
   });
+  // The firm's current model list rides on the refresh (admins turn models on
+  // and off on the platform). Replace the cached list when it differs; the
+  // entitlements poll notices the new revision and rebuilds the engine config.
+  // A platform that omits it (older, or its gateway was down) keeps the cache.
+  if (Array.isArray(payload.models)) {
+    await applyEigenweltPaidManifestModels(config, parseManifestModels(payload.models)).catch(
+      () => undefined,
+    );
+  }
   return payload.platformToken;
 }
 

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -13,6 +13,7 @@ import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { keepLegalworkRuntimeConfigFileFresh, writeLegalworkRuntimeConfigFile } from "./legalwork-runtime-config.js";
 import { prepareManagedOpencodeEngineDb } from "./managed-opencode-db.js";
 import { refreshEigenweltPaidManifest } from "./eigenwelt-paid-manifest.js";
+import { ensureFreshPlatformToken } from "./eigenwelt-refresh.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
 
@@ -72,9 +73,12 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       const runtimeConfigPath = await writeLegalworkRuntimeConfigFile(config, workspace.id);
       keepLegalworkRuntimeConfigFileFresh(config, workspace.id);
       // Fire-and-forget: refresh the GLOBAL paid manifest's model list around
-      // the kept key (no-op when not signed in), then rewrite the engine config
-      // so newly-available models appear across every workspace.
-      void refreshEigenweltPaidManifest(config)
+      // the kept key (no-op when not signed in) with the firm's access token,
+      // so the list reflects the admin's on/off choices, then rewrite the
+      // engine config so the current models appear across every workspace.
+      void ensureFreshPlatformToken(config, workspace.id)
+        .catch(() => null)
+        .then((platformToken) => refreshEigenweltPaidManifest(config, { platformToken }))
         .then((r) => (r.changed ? writeLegalworkRuntimeConfigFile(config, workspace.id) : undefined))
         .catch(() => undefined);
       const cwd = options.opencodeCwd

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -119,7 +119,9 @@ import {
 } from "./eigenwelt-auth.js";
 import {
   clearCachedEigenweltPaidManifest,
+  eigenweltPaidManifestRevision,
   parseManifestModels,
+  readCachedEigenweltPaidManifest,
   refreshEigenweltPaidManifest,
   writeCachedEigenweltPaidManifest,
 } from "./eigenwelt-paid-manifest.js";
@@ -2142,6 +2144,28 @@ function createRoutes(
   // is added or dropped live — the same fallback the recorder does for audio.
   let lastPaidEntitled: boolean | undefined;
 
+  // The firm's model list follows the platform (admins turn models on and off
+  // there): every entitlements poll re-pulls it with the firm's access token,
+  // at most every 20 s unless forced. The engine config is rebuilt when the
+  // list's revision moves, and the revision is reported to the app so it
+  // reloads the engine's provider list only then.
+  const MODELS_SYNC_THROTTLE_MS = 20_000;
+  let lastModelsSyncAt = 0;
+  let lastModelsRevision: string | null | undefined;
+  const syncEigenweltModels = async (workspaceId: string, force: boolean) => {
+    const now = Date.now();
+    if (!force && now - lastModelsSyncAt < MODELS_SYNC_THROTTLE_MS) return;
+    lastModelsSyncAt = now;
+    try {
+      const platformToken = await ensureFreshPlatformToken(config, workspaceId);
+      await refreshEigenweltPaidManifest(config, { platformToken });
+    } catch (error) {
+      console.debug(
+        `eigenwelt model sync skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+
   addRoute(routes, "PUT", "/workspace/:id/eigenwelt/connection", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
@@ -2228,14 +2252,22 @@ function createRoutes(
     // pull now (the post-checkout "waiting for your subscription" poll).
     const force = ctx.url.searchParams.get("refresh") === "1";
     const view = await readFreshEntitlementsView(config, workspace.id, { force });
-    // A flip in active-sub state adds/drops the paid provider — rebuild the
-    // engine config once so premium API access follows the subscription live.
+    if (view.connected) await syncEigenweltModels(workspace.id, force);
+    const cachedManifest = await readCachedEigenweltPaidManifest(config);
+    const modelsRevision = eigenweltPaidManifestRevision(cachedManifest);
+    // What the engine config now serves; the app compares it with the engine's
+    // live provider list and reloads the engine when they differ.
+    const servedModelIds = cachedManifest?.models.map((model) => model.id) ?? [];
+    // A flip in active-sub state adds/drops the paid provider, and a changed
+    // model list adds/drops models — rebuild the engine config once so both
+    // follow the platform live.
     const paidEntitled = eigenweltHasPremiumModels(view.entitlements);
-    if (paidEntitled !== lastPaidEntitled) {
+    if (paidEntitled !== lastPaidEntitled || modelsRevision !== lastModelsRevision) {
       lastPaidEntitled = paidEntitled;
+      lastModelsRevision = modelsRevision;
       await rebuildEngineConfigFile();
     }
-    return jsonResponse(view);
+    return jsonResponse({ ...view, modelsRevision, servedModelIds });
   });
 
   // Manual "Refresh models": re-pull the gateway manifest into the GLOBAL
@@ -2244,9 +2276,15 @@ function createRoutes(
   addRoute(routes, "POST", "/workspace/:id/eigenwelt/refresh-models", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
-    await resolveWorkspace(config, ctx.params.id);
-    const result = await refreshEigenweltPaidManifest(config);
-    if (result.changed) await rebuildEngineConfigFile();
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    // With the firm's access token the pull is the firm's own list (admin
+    // on/off applied); a legacy sign-in without tokens gets the public catalog.
+    const platformToken = await ensureFreshPlatformToken(config, workspace.id);
+    const result = await refreshEigenweltPaidManifest(config, { platformToken });
+    if (result.changed) {
+      lastModelsRevision = eigenweltPaidManifestRevision(await readCachedEigenweltPaidManifest(config));
+      await rebuildEngineConfigFile();
+    }
     return jsonResponse(result);
   });
 


### PR DESCRIPTION
## Summary

Counterpart of eigenweltlabs/model-api#19: the platform's Models page lets an org admin turn Eigenwelt models on and off for the whole firm. This makes LegalWork follow that list.

- **Server**: `fetchEigenweltManifest({ platformToken })` reads the firm's own list from `GET /api/desktop/models` (admin on/off applied) instead of the public catalog; the public catalog stays the fallback for the paste-a-key path. The token refresh payload's `models` replace the cached list too. The entitlements route re-syncs the list on every poll (at most every 20 s unless forced), rebuilds the engine config when its revision moved, and returns `modelsRevision` + `servedModelIds`. Startup refresh and the manual "Refresh models" use the token as well.
- **App**: the session route compares `servedModelIds` with the engine's live eigenwelt models and reloads the engine's provider list once per change (skipped while a task runs), so the picker gains or loses the model; the existing auto-select moves a selection off a model that went away. Entitlements go stale after 20 s so switching back to the app after a change on the platform picks it up.
- **Errors**: LiteLLM's `team_model_access_denied` (403) now reads "Your firm turned this model off on the Eigenwelt platform. Choose another model in the model picker." (EN + DE), checked before the expired-sign-in rule so a 403 from the eigenwelt provider is not misread.
- Manifest models carry `region`, `hostedIn`, `upstreamModel` (and `description`) for later use.

Stacked on #102 (weekly allowance). Merge order: #101, #102, then this.

## Test plan

- [x] Server: typecheck, `bun test src` (502 pass); new tests for the token path (`/api/desktop/models`, 401 handling, public fallback), manifest apply/revision
- [x] App: typecheck, `bun test tests/` (290 pass); new tests for the disabled-model error mapping
- [x] Dev device A against the local platform: turned Eigenwelt US off on the platform, entitlements poll returned `servedModelIds: ["Eigenwelt Europe"]`, the engine's provider list dropped the model and the composer showed the single remaining model; the gateway rejected the model for the device key with 403; turned it back on, the engine regained both models

🤖 Generated with [Claude Code](https://claude.com/claude-code)
