### PR TITLE
Add one-click experimental Apple PCC provider

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -58,6 +58,16 @@ declare global {
         relaunch?: () => Promise<void>;
       };
       system?: {
+        getAppleFoundationModelsStatus?: () => Promise<{
+          available: boolean;
+          enabled: boolean;
+          supported: boolean;
+          hasCli: boolean;
+          systemVersion: string;
+          baseURL: string;
+          startCommand: string;
+        }>;
+        connectAppleFoundationModels?: () => Promise<{ baseURL: string; model: string }>;
         getArchitectureInfo?: () => Promise<{
           appArch: string;
           appArchLabel: string;

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -120,6 +120,15 @@ type BrandedCustomProvider = {
   description: string;
 };
 
+const APPLE_FM_PROVIDER: BrandedCustomProvider = {
+  id: "apple-fm",
+  name: "Apple Intelligence (experimental)",
+  apiType: "chat",
+  baseUrlPlaceholder: "http://127.0.0.1:1976/v1",
+  baseUrlDefault: "http://127.0.0.1:1976/v1",
+  description: "Connect Apple’s on-device and Private Cloud Compute models through fm serve on this Mac.",
+};
+
 const BRANDED_CUSTOM_PROVIDERS: BrandedCustomProvider[] = [
   {
     id: "apertus",
@@ -251,10 +260,27 @@ export type ProviderAuthModalProps = {
 export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const workerType = props.workerType === "remote" ? "remote" : "local";
   const isRemoteWorker = workerType === "remote";
+  const appleConnectAttemptRef = useRef(0);
+  const [appleFmAvailable, setAppleFmAvailable] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    setAppleFmAvailable(false);
+    setAppleConnecting(false);
+    appleConnectAttemptRef.current += 1;
+    if (!props.open || isRemoteWorker) return;
+    void window.__LEGALWORK_ELECTRON__?.system?.getAppleFoundationModelsStatus?.()
+      .then((status) => { if (!cancelled) setAppleFmAvailable(status.available); })
+      .catch(() => { /* Older desktop builds do not expose this experiment. */ });
+    return () => { cancelled = true; appleConnectAttemptRef.current += 1; };
+  }, [props.open, isRemoteWorker]);
+  const brandedProviders = useMemo(() => appleFmAvailable && !isRemoteWorker
+    ? [...BRANDED_CUSTOM_PROVIDERS, APPLE_FM_PROVIDER]
+    : BRANDED_CUSTOM_PROVIDERS, [appleFmAvailable, isRemoteWorker]);
 
   const [view, setView] = useState<
-    "list" | "method" | "api" | "oauth-code" | "oauth-auto" | "custom"
+    "list" | "method" | "api" | "oauth-code" | "oauth-auto" | "custom" | "apple"
   >("list");
+  const [appleConnecting, setAppleConnecting] = useState(false);
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [oauthCodeInput, setOauthCodeInput] = useState("");
@@ -310,7 +336,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isEditingCustomProvider = customEditMode;
   const activeBrandedProvider =
     !customEditMode && customBrandName
-      ? BRANDED_CUSTOM_PROVIDERS.find((provider) => provider.id === customFixedProviderId) ?? null
+      ? brandedProviders.find((provider) => provider.id === customFixedProviderId) ?? null
       : null;
   const activeLocalTemplate = customShowLocalTemplates
     ? LOCAL_RUNTIME_TEMPLATES.find((template) => template.id === customTemplateId) ?? null
@@ -386,6 +412,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     const providersById = new Map(providers.map((provider) => [provider.id, provider]));
     const nextEntries = Object.keys(methods)
       .flatMap((id) => {
+        if (id === APPLE_FM_PROVIDER.id && (!appleFmAvailable || isRemoteWorker)) return [];
         const provider = providersById.get(id);
         const entryMethods = (methods[id] ?? []).filter((method) => {
           if (!isOpenAiProvider(id, provider?.name)) return true;
@@ -425,12 +452,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       // First-class branded providers (e.g. Apertus) that open the custom form.
       // Skip any already surfaced via auth methods to avoid duplicate ids.
       const existingIds = new Set(nextEntries.map((entry) => entry.id));
-      for (const branded of BRANDED_CUSTOM_PROVIDERS) {
+      for (const branded of brandedProviders) {
         if (existingIds.has(branded.id)) continue;
         nextEntries.push({
           id: branded.id,
           name: branded.name,
-          methods: [{ type: "api", label: "OpenAI-compatible" }],
+          methods: [{ type: "api", label: branded.id === APPLE_FM_PROVIDER.id ? "Private Cloud Compute" : "OpenAI-compatible" }],
           connected: connected.has(branded.id),
           env: [],
         });
@@ -463,6 +490,8 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     return nextEntries;
   }, [
     isRemoteWorker,
+    brandedProviders,
+    appleFmAvailable,
     props.authMethods,
     props.connectedProviderIds,
     props.providers,
@@ -595,6 +624,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     const edit = props.customEdit;
     if (!edit || customEditPrefilledRef.current === edit.providerId) return;
     customEditPrefilledRef.current = edit.providerId;
+    if (edit.providerId === APPLE_FM_PROVIDER.id) {
+      setSelectedProviderId(APPLE_FM_PROVIDER.id);
+      setView("apple");
+      return;
+    }
     setCustomEditMode(true);
     setCustomFixedProviderId(edit.providerId);
     setCustomBrandName(null);
@@ -905,6 +939,33 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setView("api");
   };
 
+  const connectApple = async () => {
+    const connect = window.__LEGALWORK_ELECTRON__?.system?.connectAppleFoundationModels;
+    if (appleConnecting || !appleFmAvailable || isRemoteWorker || !connect || !props.onSubmitCustomProvider) return;
+    const attempt = ++appleConnectAttemptRef.current;
+    setSelectedProviderId(APPLE_FM_PROVIDER.id);
+    setView("apple");
+    setAppleConnecting(true);
+    setLocalError(null);
+    try {
+      const result = await connect();
+      if (attempt !== appleConnectAttemptRef.current) return;
+      await props.onSubmitCustomProvider({
+        providerId: APPLE_FM_PROVIDER.id,
+        name: "Apple Intelligence",
+        baseURL: result.baseURL,
+        apiKey: "",
+        apiType: "chat",
+        models: [{ id: result.model, toolCall: true, reasoning: false, contextLimit: 32768 }],
+      });
+      props.onClose();
+    } catch (error) {
+      if (attempt === appleConnectAttemptRef.current) setLocalError(error instanceof Error ? error.message : "Could not connect to Apple Intelligence.");
+    } finally {
+      if (attempt === appleConnectAttemptRef.current) setAppleConnecting(false);
+    }
+  };
+
   const handleEntrySelect = (entry: ProviderAuthEntry) => {
     if (actionDisabled) return;
     setLocalError(null);
@@ -920,7 +981,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       return;
     }
 
-    const branded = BRANDED_CUSTOM_PROVIDERS.find((provider) => provider.id === entry.id);
+    if (entry.id === APPLE_FM_PROVIDER.id) {
+      void connectApple();
+      return;
+    }
+
+    const branded = brandedProviders.find((provider) => provider.id === entry.id);
     if (branded) {
       startCustomProvider(branded);
       return;
@@ -1601,6 +1667,21 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       This window will close once the provider is connected.
                     </div>
                   </div>
+                </div>
+              ) : null}
+
+              {resolvedView === "apple" ? (
+                <div className={`${surfaceCardClass} space-y-4`}>
+                  <div className="text-sm font-medium text-dls-text">Apple Intelligence</div>
+                  {appleConnecting ? (
+                    <div role="status" className="flex items-center gap-3 text-sm text-dls-secondary">
+                      <Loader2 size={18} className="animate-spin shrink-0" />
+                      <span>Connecting to Apple and checking tool support…</span>
+                    </div>
+                  ) : (
+                    <Button onClick={() => void connectApple()} disabled={actionDisabled || !appleFmAvailable || isRemoteWorker}>Connect</Button>
+                  )}
+                  <p className="text-xs text-dls-secondary">Uses Private Cloud Compute through your Mac. Apple’s Terminal opens for the local service; keep it running while using this provider.</p>
                 </div>
               ) : null}
 

--- a/apps/desktop/electron/apple-foundation-models.mjs
+++ b/apps/desktop/electron/apple-foundation-models.mjs
@@ -1,0 +1,178 @@
+import { randomBytes } from "node:crypto";
+import { accessSync, constants } from "node:fs";
+
+export const APPLE_FM_BASE_URL = "http://127.0.0.1:1976/v1";
+export const APPLE_FM_START_COMMAND = "/usr/bin/fm serve --host 127.0.0.1 --port 1976";
+
+/** Explicit opt-in. Use the macOS product version, never Darwin's kernel version. */
+export function appleFoundationModelsStatus({ platform, systemVersion, flag, hasCli }) {
+  const enabled = flag === "1";
+  const major = /^([0-9]+)(?:\.|$)/.exec(systemVersion)?.[1];
+  const supported = platform === "darwin" && Number(major) >= 27;
+  return {
+    available: enabled && supported && hasCli,
+    enabled,
+    supported,
+    hasCli,
+    systemVersion,
+    baseURL: APPLE_FM_BASE_URL,
+    startCommand: APPLE_FM_START_COMMAND,
+  };
+}
+
+export function hasAppleFoundationModelsCli() {
+  try {
+    accessSync("/usr/bin/fm", constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function appleFoundationModelsUrl(baseURL) {
+  const url = new URL(baseURL);
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname) ||
+      url.username || url.password || url.search || url.hash || !/^\/v1\/?$/.test(url.pathname)) {
+    throw new Error("Apple Foundation Models must use a local HTTP endpoint ending in /v1.");
+  }
+  url.pathname = "/v1/models";
+  return url;
+}
+
+/** Run in the main process: fm serve need not allow browser CORS requests. */
+export async function listAppleFoundationModels(status, baseURL, fetchImpl = fetch) {
+  if (!status.available) throw new Error("Apple Foundation Models requires the experimental flag, macOS 27 or later, and /usr/bin/fm.");
+  const url = appleFoundationModelsUrl(baseURL);
+  let response;
+  try {
+    response = await fetchImpl(url, { signal: AbortSignal.timeout(5000), redirect: "error" });
+  } catch {
+    throw new Error("Cannot reach fm serve. Start it in Terminal on this Mac and keep it running, then retry.");
+  }
+  if (!response.ok) throw new Error(`Apple model server returned HTTP ${response.status}. Check Terminal for availability, quota or setup errors.`);
+  const payload = await response.json();
+  const ids = Array.isArray(payload?.data)
+    ? payload.data.flatMap((model) => typeof model?.id === "string" && model.id.trim() ? [model.id] : [])
+    : [];
+  if (!ids.length) throw new Error("Apple model server returned no model IDs.");
+  return [...new Set(ids)];
+}
+
+/** Consume genuine Chat Completions SSE, including arguments split across events. */
+export async function readAppleToolTestStream(response) {
+  if (!response.ok) throw new Error(`Apple model server returned HTTP ${response.status}. Check Terminal for details.`);
+  if (!response.body) throw new Error("Apple model server returned an empty response.");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  let content = "";
+  const calls = new Map();
+  let finishReason;
+  let doneMarker = false;
+  const consume = (line) => {
+    if (!line.startsWith("data:")) return;
+    const data = line.slice(5).trim();
+    if (data === "[DONE]") { doneMarker = true; return; }
+    if (!data) return;
+    const event = JSON.parse(data);
+    if (event.error) throw new Error("Apple model server reported an error during the tool test. Check Terminal for details.");
+    const choice = event.choices?.[0];
+    if (!choice) return;
+    if (choice.finish_reason) finishReason = choice.finish_reason;
+    const delta = choice.delta;
+    if (typeof delta?.content === "string") content += delta.content;
+    for (const call of delta?.tool_calls ?? []) {
+      if (!Number.isInteger(call.index)) throw new Error("Apple returned a tool call without a stream index.");
+      const assembled = calls.get(call.index) ?? { id: "", type: "function", function: { name: "", arguments: "" } };
+      if (call.id) assembled.id = call.id;
+      if (call.function?.name) assembled.function.name += call.function.name;
+      if (call.function?.arguments) assembled.function.arguments += call.function.arguments;
+      calls.set(call.index, assembled);
+    }
+  };
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      pending += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      let newline;
+      while ((newline = pending.indexOf("\n")) !== -1) {
+        consume(pending.slice(0, newline).replace(/\r$/, ""));
+        pending = pending.slice(newline + 1);
+      }
+      if (doneMarker) break;
+      if (done) { if (pending) consume(pending); break; }
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+  if (!finishReason || !doneMarker) throw new Error("Apple returned an incomplete Chat Completions stream.");
+  return { content, toolCalls: [...calls.values()], finishReason };
+}
+
+/** A synthetic read-only tool: no user files, shell commands, or model claims accepted. */
+export async function testAppleFoundationModelsTools(status, baseURL, model, fetchImpl = fetch) {
+  if (!status.available) throw new Error("Apple provider is not available on this Mac.");
+  if (typeof model !== "string" || !model.trim() || model.length > 200) throw new Error("Select a model to test.");
+  const url = appleFoundationModelsUrl(baseURL);
+  url.pathname = "/v1/chat/completions";
+  const tools = [{ type: "function", function: {
+    name: "legalwork_connection_probe",
+    description: "Returns a newly generated connection verification code. Call it to obtain the code; do not invent one.",
+    parameters: { type: "object", properties: { request: { type: "string", description: "Use the value verify." } }, required: ["request"], additionalProperties: false },
+  } }];
+  const messages = [{ role: "user", content: "Call legalwork_connection_probe with request verify. Then return only the exact verification code returned by the tool. You cannot know the code until the tool executes." }];
+  const send = async (conversation) => {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, messages: conversation, tools, tool_choice: "auto", stream: true }),
+      signal: AbortSignal.timeout(60000),
+      redirect: "error",
+    });
+    return readAppleToolTestStream(response);
+  };
+  const first = await send(messages);
+  const call = first.toolCalls[0];
+  if (first.finishReason !== "tool_calls" || first.toolCalls.length !== 1 || !call?.id || call.function.name !== "legalwork_connection_probe") {
+    throw new Error("Tool test failed: the model did not return a structured tool call. A text claim that it called a tool does not count. This beta may have a broken fm serve tool parser.");
+  }
+  let args;
+  try { args = JSON.parse(call.function.arguments); } catch { throw new Error("Tool test failed: invalid JSON tool arguments."); }
+  if (args?.request !== "verify") throw new Error("Tool test failed: incorrect tool arguments.");
+  // Generate only after the tool call. The code cannot be guessed from the prompt.
+  const code = `LW-${randomBytes(12).toString("hex")}`;
+  const second = await send([
+    ...messages,
+    { role: "assistant", content: first.content || null, tool_calls: first.toolCalls },
+    { role: "tool", tool_call_id: call.id, content: code },
+  ]);
+  if (second.finishReason !== "stop" || second.toolCalls.length || second.content.trim() !== code) {
+    throw new Error("Tool test failed: the model did not return the actual tool result correctly.");
+  }
+  return { model, message: "Passed: streamed tool call, valid arguments, and exact tool result round-trip. Full OpenCode workflows still need testing." };
+}
+
+/** One action: reuse/start Apple's service, discover PCC, verify tools, return config. */
+export async function connectAppleFoundationModels(status, startServer, fetchImpl = fetch, pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms))) {
+  if (!status.available) throw new Error("Apple Intelligence requires macOS 27 or later with the experiment enabled and fm installed.");
+  let models;
+  try {
+    models = await listAppleFoundationModels(status, APPLE_FM_BASE_URL, fetchImpl);
+  } catch {
+    await startServer();
+    for (let attempt = 0; attempt < 8; attempt++) {
+      await pause(1000);
+      try {
+        models = await listAppleFoundationModels(status, APPLE_FM_BASE_URL, fetchImpl);
+        break;
+      } catch {
+        // The CLI may still be starting or waiting on Apple's first-use setup.
+      }
+    }
+  }
+  if (!models) throw new Error("Apple's local service could not start. Check the Terminal window for Apple's required first-use setup, then click Connect again.");
+  if (!models.includes("pcc")) throw new Error("Private Cloud Compute is not available from Apple's local service. Check Apple Intelligence availability on this Mac.");
+  await testAppleFoundationModelsTools(status, APPLE_FM_BASE_URL, "pcc", fetchImpl);
+  return { baseURL: APPLE_FM_BASE_URL, model: "pcc" };
+}

--- a/apps/desktop/electron/apple-foundation-models.test.mjs
+++ b/apps/desktop/electron/apple-foundation-models.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import {
+  appleFoundationModelsStatus,
+  connectAppleFoundationModels,
+  appleFoundationModelsUrl,
+  listAppleFoundationModels,
+  readAppleToolTestStream,
+  testAppleFoundationModelsTools,
+} from "./apple-foundation-models.mjs";
+
+const supported = { platform: "darwin", systemVersion: "27.0", flag: "1", hasCli: true };
+const status = appleFoundationModelsStatus(supported);
+
+test("experiment is explicit opt-in, product-version gated and requires the CLI", () => {
+  assert.equal(status.available, true);
+  for (const patch of [
+    { flag: undefined }, { flag: "0" }, { flag: "true" },
+    { platform: "linux" }, { platform: "win32" },
+    { systemVersion: "15.6.1" }, { systemVersion: "26.6" },
+    { systemVersion: "" }, { systemVersion: "Darwin 26" }, { hasCli: false },
+  ]) assert.equal(appleFoundationModelsStatus({ ...supported, ...patch }).available, false, JSON.stringify(patch));
+  assert.equal(appleFoundationModelsStatus({ ...supported, systemVersion: "27.1" }).available, true);
+  assert.equal(appleFoundationModelsStatus({ ...supported, systemVersion: "28.0" }).available, true);
+});
+
+test("native model discovery accepts only loopback HTTP /v1 URLs", () => {
+  for (const url of ["http://127.0.0.1:1976/v1", "http://localhost:1977/v1/", "http://[::1]:1976/v1"]) {
+    assert.equal(appleFoundationModelsUrl(url).pathname, "/v1/models");
+  }
+  for (const url of ["https://example.com/v1", "http://192.168.1.2/v1", "http://127.0.0.1.evil.test/v1", "file:///v1", "http://user:pass@localhost/v1", "http://localhost/v1?proxy=x", "http://localhost/v1#x", "http://localhost/admin"]) {
+    assert.throws(() => appleFoundationModelsUrl(url));
+  }
+});
+
+test("model discovery reports unsupported systems and stopped servers without making remote requests", async () => {
+  let requests = 0;
+  const unavailable = async () => { requests++; throw new Error("ECONNREFUSED"); };
+  await assert.rejects(listAppleFoundationModels({ ...status, available: false }, status.baseURL, unavailable), /requires/);
+  assert.equal(requests, 0);
+  await assert.rejects(listAppleFoundationModels(status, status.baseURL, unavailable), /Start it in Terminal/);
+  assert.equal(requests, 1);
+  await assert.rejects(listAppleFoundationModels(status, status.baseURL, async () => Response.json({ data: [] })), /no model IDs/);
+  await assert.rejects(listAppleFoundationModels(status, status.baseURL, async () => new Response("", { status: 503 })), /HTTP 503/);
+});
+
+function event(delta, finish_reason = null) {
+  return `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason }] })}\r\n\r\n`;
+}
+function toolEvents() {
+  return event({ tool_calls: [{ index: 0, id: "call_probe", type: "function", function: { name: "legalwork_connection_probe", arguments: '{"request":' } }] })
+    + event({ tool_calls: [{ index: 0, function: { arguments: '"verify"}' } }] })
+    + event({}, "tool_calls") + "data: [DONE]\r\n\r\n";
+}
+function textEvents(content) {
+  return event({ content }) + event({}, "stop") + "data: [DONE]\r\n\r\n";
+}
+
+test("SSE handles split byte chunks, partial JSON arguments, and UTF-8", async () => {
+  const bytes = new TextEncoder().encode(event({ content: "ä" }) + toolEvents());
+  const stream = new ReadableStream({ start(controller) {
+    for (let i = 0; i < bytes.length; i += 3) controller.enqueue(bytes.slice(i, i + 3));
+    controller.close();
+  } });
+  const result = await readAppleToolTestStream(new Response(stream));
+  assert.equal(result.content, "ä");
+  assert.equal(result.toolCalls[0].function.arguments, '{"request":"verify"}');
+  assert.equal(result.finishReason, "tool_calls");
+});
+
+test("tool probe rejects text-only claims, invalid arguments, incomplete streams and guessed results", async () => {
+  await assert.rejects(testAppleFoundationModelsTools(status, status.baseURL, "pcc", async () => new Response(textEvents("I ran your tool successfully."))), /structured tool call/);
+  await assert.rejects(testAppleFoundationModelsTools(status, status.baseURL, "pcc", async () => new Response(toolEvents().replace('verify', 'wrong'))), /incorrect tool arguments/);
+  await assert.rejects(readAppleToolTestStream(new Response(event({ content: "hello" }))), /incomplete/);
+  await assert.rejects(readAppleToolTestStream(new Response('data: {"error":{"message":"rate limit"}}\n\n')), /reported an error/);
+  let calls = 0;
+  await assert.rejects(testAppleFoundationModelsTools(status, status.baseURL, "pcc", async () => new Response(++calls === 1 ? toolEvents() : textEvents("invented-code"))), /actual tool result/);
+});
+
+test("HTTP discovery and streamed tool round-trip preserve the selected model and genuine tool result", async (t) => {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    if (req.url === "/v1/models") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ data: [{ id: "pcc" }, { id: "system" }, { id: "pcc" }, { id: null }] }));
+      return;
+    }
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    const body = JSON.parse(raw);
+    requests.push(body);
+    const result = body.messages.find((message) => message.role === "tool");
+    res.setHeader("Content-Type", "text/event-stream");
+    res.end(result ? textEvents(result.content) : toolEvents());
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(undefined)));
+  t.after(() => new Promise((resolve) => { server.close(resolve); server.closeAllConnections(); }));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Expected a TCP address");
+  const baseURL = `http://127.0.0.1:${address.port}/v1`;
+  assert.deepEqual(await listAppleFoundationModels(status, baseURL), ["pcc", "system"]);
+  const result = await testAppleFoundationModelsTools(status, baseURL, "pcc");
+  assert.match(result.message, /Passed/);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].model, "pcc");
+  assert.equal(requests[0].stream, true);
+  assert.equal(requests[0].tool_choice, "auto");
+  assert.equal(requests[1].messages[1].tool_calls[0].id, "call_probe");
+  assert.match(requests[1].messages[2].content, /^LW-[0-9a-f]{24}$/);
+  assert.equal(JSON.stringify(requests[0]).includes(requests[1].messages[2].content), false);
+});
+
+test("one-click connection starts a stopped server, retries readiness and checks tools before returning config", async () => {
+  let started = 0;
+  let discovery = 0;
+  let requests = 0;
+  const fakeFetch = async (url, options) => {
+    if (url.pathname === "/v1/models") {
+      if (++discovery <= 2) throw new Error("not ready");
+      return Response.json({ data: [{ id: "pcc" }, { id: "system" }] });
+    }
+    requests++;
+    const body = JSON.parse(options.body);
+    const result = body.messages.find((message) => message.role === "tool");
+    return new Response(result ? textEvents(result.content) : toolEvents());
+  };
+  const result = await connectAppleFoundationModels(status, async () => { started++; }, fakeFetch, async () => {});
+  assert.equal(started, 1);
+  assert.equal(discovery, 3);
+  assert.equal(requests, 2);
+  assert.deepEqual(result, { baseURL: status.baseURL, model: "pcc" });
+});
+
+test("one-click connection reuses a running server but does not connect if tool calling fails", async () => {
+  let started = 0;
+  const fakeFetch = async (url) => url.pathname === "/v1/models"
+    ? Response.json({ data: [{ id: "pcc" }] })
+    : new Response(textEvents("I called the tool."));
+  await assert.rejects(connectAppleFoundationModels(status, async () => { started++; }, fakeFetch), /structured tool call/);
+  assert.equal(started, 0);
+});
+
+test("one-click connection refuses unavailable platforms, missing PCC and startup failure", async () => {
+  let started = 0;
+  const start = async () => { started++; };
+  await assert.rejects(connectAppleFoundationModels({ ...status, available: false }, start), /requires macOS/);
+  assert.equal(started, 0);
+  await assert.rejects(connectAppleFoundationModels(status, start, async () => Response.json({ data: [{ id: "system" }] })), /Private Cloud Compute is not available/);
+  assert.equal(started, 0);
+  await assert.rejects(connectAppleFoundationModels(status, start, async () => { throw new Error("offline"); }, async () => {}), /could not start/);
+  assert.equal(started, 1);
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -20,6 +20,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { app, BrowserWindow, clipboard, desktopCapturer, dialog, globalShortcut, ipcMain, nativeImage, nativeTheme, powerMonitor, powerSaveBlocker, protocol, session, shell, systemPreferences } from "electron";
+import { appleFoundationModelsStatus, hasAppleFoundationModelsCli, connectAppleFoundationModels, APPLE_FM_START_COMMAND } from "./apple-foundation-models.mjs";
 import { configureFakeMediaForTests, installMediaPermissionHandlers } from "./media-permissions.mjs";
 import { appendLoopbackFeatureFlags, disableLoopbackAudio, enableLoopbackAudio, isLoopbackCaptureArmed } from "./audio/loopback.mjs";
 import { captureAuthStatus, openCapturePermissionSettings, requestCapturePermission } from "./audio/capture-permissions.mjs";
@@ -2783,6 +2784,35 @@ ipcMain.handle("legalwork:shell:relaunch", async () => {
   app.exit(0);
 });
 ipcMain.handle("legalwork:system:architecture", async () => resolveArchitectureInfo());
+function resolveAppleFoundationModelsStatus() {
+  return appleFoundationModelsStatus({
+    platform: process.platform,
+    systemVersion: process.getSystemVersion(),
+    flag: process.env.LEGALWORK_EXPERIMENTAL_APPLE_FM,
+    hasCli: process.platform === "darwin" && hasAppleFoundationModelsCli(),
+  });
+}
+ipcMain.handle("legalwork:system:appleFoundationModels", async () => resolveAppleFoundationModelsStatus());
+let appleFoundationModelsConnection = null;
+ipcMain.handle("legalwork:system:appleFoundationModelsConnect", async () => {
+  if (!appleFoundationModelsConnection) {
+    appleFoundationModelsConnection = connectAppleFoundationModels(resolveAppleFoundationModelsStatus(), async () => {
+      const directory = path.join(app.getPath("userData"), "apple-foundation-models");
+      await mkdir(directory, { recursive: true });
+      const launcher = path.join(directory, "Start Apple Intelligence.command");
+      // Run the documented CLI in Terminal, preserving Apple's foreground attribution.
+      // Never accept CLI terms or change Apple availability/quotas programmatically.
+      await writeFile(launcher, `#!/bin/sh\nexec ${APPLE_FM_START_COMMAND}\n`, { mode: 0o700 });
+      await chmod(launcher, 0o700);
+      await new Promise((resolve, reject) => {
+        const child = spawn("/usr/bin/open", ["-a", "Terminal", launcher], { stdio: "ignore" });
+        child.once("error", reject);
+        child.once("exit", (code) => code === 0 ? resolve(undefined) : reject(new Error("Could not open Apple's local service in Terminal.")));
+      });
+    }).finally(() => { appleFoundationModelsConnection = null; });
+  }
+  return appleFoundationModelsConnection;
+});
 ipcMain.handle("legalwork:system:microphoneStatus", async () => {
   if (process.platform !== "darwin") return { platform: process.platform, status: "not-mac" };
   return { platform: process.platform, status: systemPreferences.getMediaAccessStatus("microphone") };

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -70,6 +70,12 @@ contextBridge.exposeInMainWorld("__LEGALWORK_ELECTRON__", {
     },
   },
   system: {
+    getAppleFoundationModelsStatus() {
+      return ipcRenderer.invoke("legalwork:system:appleFoundationModels");
+    },
+    connectAppleFoundationModels() {
+      return ipcRenderer.invoke("legalwork:system:appleFoundationModelsConnect");
+    },
     getArchitectureInfo() {
       return ipcRenderer.invoke("legalwork:system:architecture");
     },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,7 @@
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
     "build:audiotap": "node ./scripts/build-audiotap.mjs",
     "build:key-monitor": "node ./scripts/build-key-monitor.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/opencode-state-dir.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs",
+    "test": "node --test electron/apple-foundation-models.test.mjs electron/runtime.test.mjs electron/opencode-state-dir.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs",
     "office:sideload": "node ./scripts/office-addin-sideload.mjs"
   },
   "dependencies": {

--- a/docs/apple-foundation-models.md
+++ b/docs/apple-foundation-models.md
@@ -1,0 +1,85 @@
+# Apple Foundation Models provider experiment
+
+LegalWork connects OpenCode directly to Apple's local `fm serve` HTTP endpoint.
+The experiment is disabled by default. OpenCode still owns the agent loop,
+permissions, tools and workspace configuration.
+
+## Try the PR on the beta Mac
+
+Requirements: macOS 27 or later, `/usr/bin/fm`, and Apple Intelligence available
+and enabled. PCC also depends on Apple's account, region and usage limits.
+
+Check out the PR, then run from the repository root:
+
+```sh
+pnpm install --frozen-lockfile
+LEGALWORK_EXPERIMENTAL_APPLE_FM=1 pnpm dev
+```
+
+In a **local** workspace, open the provider connection picker and click
+**Apple Intelligence (experimental)**. That one action:
+
+1. Reuses the local service or starts it in Apple's Terminal app.
+2. Waits for the service and checks for the PCC model.
+3. Verifies a streamed tool call and a real tool-result round-trip.
+4. Registers `apple-fm/pcc` through the existing OpenCode provider configuration.
+
+There are no endpoint fields, model settings, keys or separate test buttons.
+If checks fail, the provider is not registered and the screen offers **Connect**
+to retry. Keep the Terminal service running while using the provider. Closing
+it stops Apple's endpoint; reconnect to restart it.
+
+Apple may require its own first-use setup or CLI terms acceptance. LegalWork
+cannot accept those on the user's behalf. If the service cannot start, the
+connection error points to the Terminal window for that setup. The app starts
+only the documented command `/usr/bin/fm serve --host 127.0.0.1 --port 1976`;
+it does not bypass Apple's availability, quota or entitlement checks.
+
+The flag must equal `1`. The entry is hidden on older macOS, Windows, Linux,
+web-only clients, remote workers, and Macs without the CLI. Restart the dev app
+to change the flag. No release workflow is changed or dispatched by this PR.
+
+## Automatic tool verification
+
+The check makes two small streaming requests to `http://127.0.0.1:1976/v1`.
+First the model must emit a structured `tool_calls` event with valid JSON
+arguments. Only then does the test generate a random verification code and
+supply it as a real `role: tool` result. The second response must return the
+exact code. Text claiming that a tool ran is a failure. No user files, shell
+commands or external tools are exposed. Requests can consume Apple model quota.
+
+Passing this probe does not prove that every OpenCode tool schema or long
+conversation works. On the beta Mac, also try reading a fresh file with an
+unpredictable value and writing a second file. Confirm actual tool events and
+on-disk results. Record `sw_vers` and `fm serve --help` when reporting failures.
+
+## Beta status researched September 6, 2026
+
+- Apple's [macOS 27 beta 8 release notes](https://developer.apple.com/documentation/macos-release-notes/macos-27-release-notes)
+  list a fix for excessive on-device tool calls with guided generation. They do
+  not explicitly identify a fix for `fm serve` dropping structured tool calls.
+- The [fm-proxy maintainer's August 18 audit](https://github.com/gregbarbosa/fm-proxy/commit/6880b537e37773266b657fa79b601354cabab266)
+  reports missing tool calls in betas 5 and 6. This is a first-hand third-party
+  report, not proof of behavior on beta 8. No verified beta 8 fix was found.
+- The [CLI manual dated June 8, 2026](https://keith.github.io/xcode-man-pages/fm.1.html)
+  documents `serve`, binding options and the `pcc` model ID.
+
+This PR is for local development testing. It does not establish permission for
+commercial CLI distribution; Apple's [PCC requirements](https://developer.apple.com/private-cloud-compute/)
+and [staff response](https://developer.apple.com/forums/thread/842813) remain
+relevant before release.
+
+## Verification
+
+```sh
+node --test apps/desktop/electron/apple-foundation-models.test.mjs
+pnpm --filter @legalwork/app typecheck
+pnpm --filter @legalwork/desktop typecheck:electron
+node apps/desktop/scripts/check-electron-bridge.mjs
+```
+
+Tests cover flag/version gating, loopback URLs, startup/readiness, reusing a
+running server, discovery, fragmented SSE, rejection of prose and invented
+results, and a real local HTTP round-trip against a fake model server.
+The implementation machine runs macOS 15.6.1 without `fm`, so actual Apple
+inference and full OpenCode execution remain unverified until tested on the beta Mac.


### PR DESCRIPTION
## Summary
Add an experimental Apple Intelligence provider with a single connection action. Selecting it starts or reuses Apple's local `fm serve`, discovers PCC, verifies streamed tool calling and its result round-trip, then saves the provider using the existing OpenCode configuration.

## Why
Test Apple Private Cloud Compute from the desktop dev app without endpoint settings, API keys, model selection, or separate diagnostic buttons. Broken tool calling must fail connection instead of silently accepting a model's claim that it executed a tool.

## Issue
User-requested experiment; no linked issue.

## Scope
- Show the provider only with `LEGALWORK_EXPERIMENTAL_APPLE_FM=1`, macOS 27+, the installed `fm` CLI, and a local workspace.
- Start the documented CLI in Apple's Terminal app, where its foreground attribution is preserved. Reuse a running localhost service.
- Automatically verify a genuine streamed function call, JSON arguments, and an unpredictable tool result before registering `apple-fm/pcc`.
- Keep OpenCode's existing agent loop, tools, permissions, and provider persistence.
- Document beta status, first-use prerequisites, and testing.

## Out of scope
Alpha releases, distribution entitlement approval, native Foundation Models SDK integration, and remote workers.

## Testing
### Ran
- `pnpm --filter @legalwork/desktop test`
- `bun test apps/app/tests/provider-local-templates.test.ts`
- `pnpm --filter @legalwork/app typecheck`
- `pnpm --filter @legalwork/desktop typecheck:electron`
- `node apps/desktop/scripts/check-electron-bridge.mjs`
- Node syntax checks and `git diff --check`

### Result
All passed: desktop suite 96 passed / 1 platform-specific skip, including 9 new Apple tests; provider template tests 15 passed; bridge check 105 methods. New tests cover startup/reuse/failure, platform gating, fragmented SSE, and actual local HTTP requests against a fake model server.

## CI status
Local checks pass. GitHub checks pending at PR creation. Actual Apple inference is unverified: the implementation host runs macOS 15.6.1 and has no `fm`.

## Manual verification
1. Check out `feat/apple-fm-provider` on the beta Mac and run `pnpm install --frozen-lockfile`.
2. Start `LEGALWORK_EXPERIMENTAL_APPLE_FM=1 pnpm dev`.
3. In a local workspace, click **Apple Intelligence (experimental)** in the provider picker. Startup, discovery, tool checks, and provider registration run automatically. There are no settings fields.
4. Keep Apple's Terminal service running. If Apple requires first-use setup or terms acceptance, complete that in Terminal and retry Connect; the app does not accept terms automatically.
5. Once connected, ask OpenCode to read a fresh file containing an unpredictable value and write a second file; verify genuine tool events and disk contents. Record `sw_vers` and `fm serve --help` if reporting failures.
6. Without the flag, on older systems, or with a remote workspace, confirm the provider is hidden.

## Evidence
Playwright verified the real provider modal using a mocked native bridge: one click registers the expected PCC configuration, failure offers Connect again without saving, no settings inputs are shown, and unsupported/remote contexts hide the entry. Screenshots were captured locally; no real beta inference video is available because this host lacks macOS 27 and `fm`. The steps above reproduce the outstanding beta check.

## Risk
Beta 8 release notes do not explicitly confirm a fix for `fm serve` dropping tool calls; the first-hand beta 5/6 report remains relevant but does not establish beta 8 behavior. Connection therefore checks the actual installed beta. A successful synthetic probe is not proof that every OpenCode workflow works. Apple availability, quota, first-use setup, and eventual distribution eligibility still apply. Research links are in `docs/apple-foundation-models.md`.

## Rollback
Leave the environment flag unset to hide the experiment. Remove an already connected Apple provider through existing provider management; revert this commit to remove the integration entirely.
