### PR TITLE
fix(analytics): make the onboarding funnel measurable — one launch, one id

### DIFF
--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -1323,9 +1323,9 @@ export function createLegalworkServerClient(options: { baseUrl: string; token?: 
     runtimeVersions: () =>
       requestJson<LegalworkRuntimeSnapshot>(baseUrl, "/runtime/versions", { token, hostToken, timeoutMs: timeouts.status }),
     status: () => requestJson<LegalworkServerDiagnostics>(baseUrl, "/status", { token, hostToken, timeoutMs: timeouts.status }),
-    // Sync analytics consent; the server answers with the per-launch
-    // distinct id (in-memory) for the caller to adopt.
-    setAnalyticsIdentity: (payload: { analyticsEnabled: boolean }) =>
+    // Sync analytics consent and our per-launch distinct id; the server
+    // answers with the id now in force (in-memory) for the caller to adopt.
+    setAnalyticsIdentity: (payload: { analyticsEnabled: boolean; distinctId: string }) =>
       requestJson<{ ok: boolean; distinctId?: string }>(baseUrl, "/analytics/identity", {
         token,
         hostToken,

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 
 import { THINKING_PREF_KEY } from "../../app/constants";
-import { setAnalyticsDistinctId } from "../../app/lib/analytics";
+import { getAnalyticsDistinctId, setAnalyticsDistinctId } from "../../app/lib/analytics";
 import { createLegalworkServerClient } from "../../app/lib/legalwork-server";
 import { coerceReleaseChannel } from "../../app/lib/release-channels";
 import { isDesktopRuntime } from "../../app/lib/runtime-env";
@@ -204,10 +204,15 @@ export function LocalProvider({ children }: LocalProviderProps) {
     writePersisted(PREFS_STORAGE_KEY, prefs);
   }, [prefs]);
 
-  // Sync analytics consent with the local server and adopt its per-launch
-  // distinct id in return. In-memory on both sides; retried briefly because
-  // the server may still be booting. Desktop only. Until the round-trip
-  // succeeds, analytics falls back to a locally minted id.
+  // Sync analytics consent and our per-launch distinct id to the local
+  // server, so the renderer, the server's gateway header and the Office pane
+  // all report one launch. We offer the id rather than asking for one:
+  // events fire (app open, welcome screen) before this round-trip can
+  // answer, and asking would strand those first events on a second id.
+  // In-memory on both sides; retried briefly because the server may still be
+  // booting. Desktop only. The answer is normally our own id echoed back —
+  // it differs only against a server that already had one (a shared or
+  // longer-lived server), where matching it keeps desktop and pane together.
   useEffect(() => {
     if (!isDesktopRuntime()) return;
     let cancelled = false;
@@ -220,7 +225,10 @@ export function LocalProvider({ children }: LocalProviderProps) {
               baseUrl: normalizedBaseUrl,
               token: resolvedToken || undefined,
               hostToken: resolvedHostToken || undefined,
-            }).setAnalyticsIdentity({ analyticsEnabled: prefs.analyticsEnabled === true });
+            }).setAnalyticsIdentity({
+              analyticsEnabled: prefs.analyticsEnabled === true,
+              distinctId: getAnalyticsDistinctId(),
+            });
             if (typeof result?.distinctId === "string") setAnalyticsDistinctId(result.distinctId);
             return;
           }

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -140,6 +140,14 @@ export function WelcomeRoute() {
     async (_preset: string, folder: string | null) => {
       if (!folder) return;
       dispatch({ type: "create:start" });
+      // Funnel intent: the user committed to creating a workspace. Fired here
+      // rather than after creation succeeds, so a failed create (reported as
+      // app_error{source:"workspace_create"}) stays distinguishable from a
+      // user who simply never started. Flushed eagerly for the same reason
+      // onboarding_welcome_viewed is: the consent choice commits below, and
+      // an opt-out there purges whatever is still queued.
+      captureAnalyticsEvent("onboarding_started", { surface: analyticsSurface() });
+      void flushAnalytics();
       setCreatePhase("workspace");
       try {
         const workspaceName = folderNameFromPath(folder);
@@ -218,7 +226,7 @@ export function WelcomeRoute() {
           hasCompletedOnboarding: true,
           onboardingStage: "ai",
         }));
-        captureAnalyticsEvent("onboarding_started", { surface: analyticsSurface() });
+        captureAnalyticsEvent("workspace_created", { source: "onboarding", surface: analyticsSurface() });
         // The consent choice just persisted: an opt-out sends its single
         // anonymous marker (and purges everything queued, including the
         // events captured above); staying opted in leaves the queue to flush.

--- a/apps/app/tests/onboarding-funnel-events.test.ts
+++ b/apps/app/tests/onboarding-funnel-events.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Onboarding funnel events on the welcome screen.
+ *
+ * `onboarding_started` marks INTENT (the user committed to creating a
+ * workspace), not success — success is `workspace_created`. Intent is flushed
+ * eagerly, like `onboarding_welcome_viewed`, because the consent choice
+ * commits at the end of workspace creation and an opt-out there purges
+ * whatever is still queued. Without the eager flush an opted-out user reports
+ * as a welcome view with no start, which reads as a drop-off that never
+ * happened.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// The module gates every capture on a configured key — inject one before import.
+process.env.VITE_LEGALWORK_POSTHOG_KEY = "phc_test_dummy_key";
+
+const { captureAnalyticsEvent, captureAnalyticsOptOut, flushAnalytics } = await import(
+  "../src/app/lib/analytics"
+);
+
+const PREFS_STORAGE_KEY = "legalwork.preferences";
+const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function setConsent(value: boolean | null) {
+  if (value === null) window.localStorage.removeItem(PREFS_STORAGE_KEY);
+  else window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify({ analyticsEnabled: value }));
+}
+
+const sentBatches: Array<{ event: string }[]> = [];
+function sentEvents(): string[] {
+  return sentBatches.flat().map((entry) => entry.event);
+}
+
+/** The welcome screen up to the moment the consent choice commits. */
+async function runWelcomeUpToConsentCommit() {
+  captureAnalyticsEvent("onboarding_welcome_viewed", { surface: "desktop" });
+  await flushAnalytics();
+  captureAnalyticsEvent("onboarding_started", { surface: "desktop" });
+  await flushAnalytics();
+  // ...workspace creation happens here...
+  captureAnalyticsEvent("workspace_created", { source: "onboarding", surface: "desktop" });
+}
+
+describe("onboarding funnel events", () => {
+  beforeEach(() => {
+    sentBatches.length = 0;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage: memoryStorage() },
+    });
+    globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+      const body = init?.body
+        ? (JSON.parse(init.body) as { batch: { event: string }[] })
+        : { batch: [] };
+      sentBatches.push(body.batch);
+      return { ok: true } as Response;
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    // Drain any queued events so state never leaks into the next test.
+    setConsent(false);
+    await flushAnalytics();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    globalThis.fetch = originalFetch;
+  });
+
+  test("opting out at the end still reports the start, so the funnel is measurable", async () => {
+    setConsent(null);
+    await runWelcomeUpToConsentCommit();
+    setConsent(false);
+    captureAnalyticsOptOut("onboarding");
+
+    expect(sentEvents()).toContain("onboarding_welcome_viewed");
+    // The regression this pins: queued-only, `onboarding_started` was purged
+    // by the opt-out and the user looked like a welcome-screen drop-off.
+    expect(sentEvents()).toContain("onboarding_started");
+    expect(sentEvents()).toContain("analytics_opted_out");
+  });
+
+  test("the opt-out still purges anything not yet flushed", async () => {
+    setConsent(null);
+    await runWelcomeUpToConsentCommit();
+    setConsent(false);
+    captureAnalyticsOptOut("onboarding");
+
+    expect(sentEvents()).not.toContain("workspace_created");
+  });
+
+  test("staying opted in reports intent and success separately", async () => {
+    setConsent(null);
+    await runWelcomeUpToConsentCommit();
+    setConsent(true);
+    await flushAnalytics();
+
+    expect(sentEvents()).toContain("onboarding_started");
+    expect(sentEvents()).toContain("workspace_created");
+    expect(sentEvents()).not.toContain("analytics_opted_out");
+  });
+});

--- a/apps/server/src/launch-analytics-id.test.ts
+++ b/apps/server/src/launch-analytics-id.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  adoptLaunchAnalyticsId,
+  isAdoptableLaunchAnalyticsId,
+  launchAnalyticsId,
+} from "./launch-analytics-id.js";
+
+// The id is process-global by design, so adoption is asserted once, against
+// that single lifetime. The shape rules are a pure predicate and get the
+// exhaustive treatment.
+describe("launch analytics id", () => {
+  test("adopts the first client-offered id, then never renames the launch", () => {
+    const offered = "11111111-2222-4333-8444-555555555555";
+    expect(adoptLaunchAnalyticsId(offered)).toBe(offered);
+    expect(launchAnalyticsId()).toBe(offered);
+    // First writer wins: a later window or reconnect must not rename it.
+    expect(adoptLaunchAnalyticsId("99999999-8888-4777-8666-555555555555")).toBe(offered);
+    expect(adoptLaunchAnalyticsId("")).toBe(offered);
+  });
+});
+
+describe("adoptable launch id shapes", () => {
+  test("accepts what clients actually mint", () => {
+    // crypto.randomUUID() in the renderer, and its non-crypto fallback.
+    expect(isAdoptableLaunchAnalyticsId("11111111-2222-4333-8444-555555555555")).toBe(true);
+    expect(isAdoptableLaunchAnalyticsId("lw.k3j4h5g6f7d8s9a0q1w2e3")).toBe(true);
+  });
+
+  // The value lands in an outbound header, so header-breaking input must not
+  // stick. Empty and short offers are refused so a stray "" cannot claim the
+  // launch and collide across installs.
+  for (const bad of [
+    "",
+    "short",
+    "has space",
+    "crlf\r\nX-Injected: 1",
+    "newline\nX-Injected: 1",
+    "tab\tsep",
+    "semi;colon",
+    "unicode-é",
+    "x".repeat(65),
+  ]) {
+    test(`refuses ${JSON.stringify(bad)}`, () => {
+      expect(isAdoptableLaunchAnalyticsId(bad)).toBe(false);
+    });
+  }
+});

--- a/apps/server/src/launch-analytics-id.test.ts
+++ b/apps/server/src/launch-analytics-id.test.ts
@@ -4,26 +4,46 @@ import {
   adoptLaunchAnalyticsId,
   isAdoptableLaunchAnalyticsId,
   launchAnalyticsId,
+  resolveLaunchAnalyticsId,
 } from "./launch-analytics-id.js";
 
-// The id is process-global by design, so adoption is asserted once, against
-// that single lifetime. The shape rules are a pure predicate and get the
-// exhaustive treatment.
+const OFFER = "11111111-2222-4333-8444-555555555555";
+
+// The id is process-global by design and `bun test src` shares one module
+// registry, so any other file in the run may already hold it. The precedence
+// rules are therefore asserted through the pure resolver; the stateful pair
+// only gets invariants that hold whoever claimed the launch first.
+describe("resolveLaunchAnalyticsId", () => {
+  test("takes a client offer when nothing is in force", () => {
+    expect(resolveLaunchAnalyticsId("", OFFER)).toBe(OFFER);
+  });
+
+  test("mints instead of taking an unusable offer", () => {
+    const minted = resolveLaunchAnalyticsId("", "crlf\r\nX-Injected: 1");
+    expect(minted).not.toBe("crlf\r\nX-Injected: 1");
+    expect(isAdoptableLaunchAnalyticsId(minted)).toBe(true);
+  });
+
+  test("first writer wins: an id in force is never replaced", () => {
+    expect(resolveLaunchAnalyticsId("already-in-force-id", OFFER)).toBe("already-in-force-id");
+    expect(resolveLaunchAnalyticsId("already-in-force-id", "")).toBe("already-in-force-id");
+  });
+});
+
 describe("launch analytics id", () => {
-  test("adopts the first client-offered id, then never renames the launch", () => {
-    const offered = "11111111-2222-4333-8444-555555555555";
-    expect(adoptLaunchAnalyticsId(offered)).toBe(offered);
-    expect(launchAnalyticsId()).toBe(offered);
-    // First writer wins: a later window or reconnect must not rename it.
-    expect(adoptLaunchAnalyticsId("99999999-8888-4777-8666-555555555555")).toBe(offered);
-    expect(adoptLaunchAnalyticsId("")).toBe(offered);
+  test("adopting is idempotent and never renames the launch", () => {
+    const inForce = adoptLaunchAnalyticsId(OFFER);
+    expect(inForce.length).toBeGreaterThan(0);
+    expect(adoptLaunchAnalyticsId("99999999-8888-4777-8666-555555555555")).toBe(inForce);
+    expect(adoptLaunchAnalyticsId("")).toBe(inForce);
+    expect(launchAnalyticsId()).toBe(inForce);
   });
 });
 
 describe("adoptable launch id shapes", () => {
   test("accepts what clients actually mint", () => {
     // crypto.randomUUID() in the renderer, and its non-crypto fallback.
-    expect(isAdoptableLaunchAnalyticsId("11111111-2222-4333-8444-555555555555")).toBe(true);
+    expect(isAdoptableLaunchAnalyticsId(OFFER)).toBe(true);
     expect(isAdoptableLaunchAnalyticsId("lw.k3j4h5g6f7d8s9a0q1w2e3")).toBe(true);
   });
 

--- a/apps/server/src/launch-analytics-id.ts
+++ b/apps/server/src/launch-analytics-id.ts
@@ -1,17 +1,48 @@
 /**
- * Anonymous per-launch id: minted once per server process and held in
- * memory only — a restart rotates it, nothing is persisted. Sent as a
- * header on Eigenwelt gateway requests and adopted by the desktop renderer
- * and Office pane as their analytics distinct id, so one launch shares
+ * Anonymous per-launch id: held in memory only — a restart rotates it,
+ * nothing is persisted. Sent as a header on Eigenwelt gateway requests and
+ * shared with the desktop renderer and Office pane, so one launch shares
  * one id everywhere.
+ *
+ * The desktop mints it and offers it via PUT /analytics/identity, rather
+ * than asking for one: the renderer captures events (app open, welcome
+ * screen) before any round-trip could answer, and those would otherwise
+ * land on a second id. This module mints one only when asked before a
+ * client has offered anything — headless runs, the CLI, tests.
  */
 import { randomUUID } from "node:crypto";
 
 export const EIGENWELT_ANALYTICS_ID_HEADER = "X-Eigenwelt-Analytics-Id";
+
+/** Opaque, header-safe, and long enough to not collide: what clients mint. */
+const OFFERED_ID = /^[A-Za-z0-9._-]{8,64}$/;
 
 let launchId = "";
 
 export function launchAnalyticsId(): string {
   if (!launchId) launchId = randomUUID();
   return launchId;
+}
+
+/**
+ * Adopt a client-minted launch id, returning the id now in force.
+ *
+ * First writer wins: once an id is in use — offered or minted here — it
+ * stays for the process lifetime, so a second window or a reconnect never
+ * renames a launch mid-flight. Offered ids are shape-checked because this
+ * value is interpolated into an outbound request header; anything else is
+ * ignored in favour of a locally minted id.
+ */
+export function adoptLaunchAnalyticsId(offered: string): string {
+  if (!launchId && isAdoptableLaunchAnalyticsId(offered)) launchId = offered;
+  return launchAnalyticsId();
+}
+
+/**
+ * Whether a client-offered id is safe to adopt. The value is interpolated
+ * into an outbound request header, so anything that could break or inject a
+ * header line is refused and a locally minted id is used instead.
+ */
+export function isAdoptableLaunchAnalyticsId(offered: string): boolean {
+  return OFFERED_ID.test(offered);
 }

--- a/apps/server/src/launch-analytics-id.ts
+++ b/apps/server/src/launch-analytics-id.ts
@@ -34,8 +34,19 @@ export function launchAnalyticsId(): string {
  * ignored in favour of a locally minted id.
  */
 export function adoptLaunchAnalyticsId(offered: string): string {
-  if (!launchId && isAdoptableLaunchAnalyticsId(offered)) launchId = offered;
-  return launchAnalyticsId();
+  launchId = resolveLaunchAnalyticsId(launchId, offered);
+  return launchId;
+}
+
+/**
+ * The id a launch should use, given what is already in force and what a
+ * client offered. Pure, so the precedence rules can be exercised without the
+ * process-global id — which anything else sharing the process may already
+ * have claimed.
+ */
+export function resolveLaunchAnalyticsId(inForce: string, offered: string): string {
+  if (inForce) return inForce;
+  return isAdoptableLaunchAnalyticsId(offered) ? offered : randomUUID();
 }
 
 /**

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -72,7 +72,7 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import { serve, type ServeResult } from "./serve-node.js";
-import { launchAnalyticsId } from "./launch-analytics-id.js";
+import { adoptLaunchAnalyticsId } from "./launch-analytics-id.js";
 import { handleWordAddinRequest, loadWordAddinTls, setAnalyticsConsent, WORD_ADDIN_PATH_PREFIX } from "./word-addin.js";
 import { OfficeToolRelay } from "./office-tools.js";
 import { registerOfficeToolRoutes } from "./routes/office-tools.js";
@@ -1512,13 +1512,14 @@ function createRoutes(
   });
 
   addRoute(routes, "PUT", "/analytics/identity", "client", async (ctx) => {
-    // Desktop pushes its analytics consent here and gets the per-launch
-    // distinct id back; the Office pane adopts it via the word-addin
-    // bootstrap. Held in memory only.
+    // Desktop pushes its analytics consent and its own per-launch distinct
+    // id here; the answer is the id now in force, which the Office pane also
+    // adopts via the word-addin bootstrap. Held in memory only.
     requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
     setAnalyticsConsent({ analyticsEnabled: body.analyticsEnabled });
-    return jsonResponse({ ok: true, distinctId: launchAnalyticsId() });
+    const offered = typeof body.distinctId === "string" ? body.distinctId : "";
+    return jsonResponse({ ok: true, distinctId: adoptLaunchAnalyticsId(offered) });
   });
 
   addRoute(routes, "GET", "/personalization", "client", async () => {


### PR DESCRIPTION
Three commits, all analytics-only. The first two are the change; neither is much use without the other.

## Summary
**1. Report intent separately from success** (`090a274`)
- Fire `onboarding_started` when the user commits to creating a workspace, instead of after creation has fully succeeded.
- Flush it eagerly, the same treatment `onboarding_welcome_viewed` already gets on the same screen.
- Report success separately as `workspace_created{source:"onboarding"}`.

**2. One launch, one distinct id** (`798eb0f`)
- The renderer mints the per-launch id and offers it via `PUT /analytics/identity`; the server adopts it, instead of the renderer asking the server for one.

**3. Make the launch-id test order-independent** (`e67e77b`)
- The precedence rule moves into a pure resolver so it can be asserted without the process-global id. See Testing.

## Why
The onboarding funnel is not measurable as instrumented today. Three separate causes:

**`onboarding_started` meant "workspace created", not "user started".** It fired near the end of `handleCreateWorkspace`, after `resolveLegalworkConnection()`, `createLocalWorkspace`, engine start and session create. If the server is unreachable the function throws and the event never fires — so a server failure and a user walking away are indistinguishable.

**The consent commit purges it.** `captureAnalyticsOptOut("onboarding")` runs immediately after and sets `queue = []`. `onboarding_started` is only queued, never flushed, so a user who leaves the analytics toggle off has their start event destroyed — while `onboarding_welcome_viewed`, flushed eagerly at mount, survives. Those users report as welcome-screen drop-offs despite completing the step.

**No single id spans the funnel.** The renderer captures `app_opened` and `onboarding_welcome_viewed` at startup, then asks the server for a launch id. The round-trip cannot answer that fast, so those first events go out under a locally minted id and everything after adoption under the server's. The result is two disjoint identity populations — ids holding only the welcome step, and ids holding everything from `onboarding_started` onward — so a funnel over those steps reports 0% however the events are named. The exception proves the mechanism: when the round-trip never completes, nothing replaces the local id and one id holds the whole flow. The same split affects any event emitted before adoption, such as `update_check` and `download_started`.

## Issue
- N/A — found while auditing the onboarding funnel.

## Scope
- `onboarding_started` moves to intent time and is flushed eagerly.
- New `workspace_created{source:"onboarding"}` marks success on the welcome path (the event name already exists in `session-route.tsx`).
- `setAnalyticsIdentity` gains a `distinctId`; `adoptLaunchAnalyticsId` on the server takes it, first-writer-wins.
- Tests for both.

## Out of scope
- No change to consent semantics, storage, or what an opted-out user sends after opting out. Nothing is persisted and no machine-level identifier is introduced — the id still lives in memory for one launch.

## Decide these two
1. **The eager flush** sends one more event before the consent choice persists. That is the same pending-choice, default-on model `onboarding_welcome_viewed` already runs under, on the same screen — but it is a deliberate call, and dropping the `void flushAnalytics()` line is a clean way to decline it. Without it the opted-out blind spot remains.
2. **The gateway header's value can now originate from the client.** The header itself is still built server-side in `buildEigenweltPaidProviderBlock`, unchanged; only `launchAnalyticsId()` — the single variable that also serves analytics — may now hold a client-offered value. It travels next to `Authorization: Bearer ${apiKey}`, so auth is unaffected and the id is a correlation tag. Offers are shape-checked (`/^[A-Za-z0-9._-]{8,64}$/`) before being interpolated into the header, and the route already requires a collaborator scope. If the gateway treats that id as server-authoritative, decouple instead: keep `launchAnalyticsId()` minting for the header and store the client id separately for analytics.

## Testing
### Ran
Against the rebased head, base `f1e334c`:
- `pnpm install --prefer-offline`
- `pnpm typecheck`
- `pnpm --filter legalwork-server typecheck`
- `pnpm --filter @legalwork/app test`
- `pnpm --filter legalwork-server test`
- `bun test src/word-addin.e2e.test.ts src/launch-analytics-id.test.ts` (and the reverse order)

### Result
- pass/fail: **pass**
- `pnpm typecheck` — clean, no output.
- `pnpm --filter legalwork-server typecheck` — clean, no output.
- `pnpm --filter @legalwork/app test` — 344 pass, 0 fail, 803 expect() calls across 57 files.
- `pnpm --filter legalwork-server test` — 528 pass, 6 skip, 0 fail, 1857 expect() calls across 71 files.
- Both explicit orderings — 23 pass, 0 fail.

The first push of commit 2 failed `legalwork-tests (macos-14)` while passing ubuntu. The cause was my test, not the code: the launch id is process-global and `bun test src` shares one module registry, so `word-addin.e2e.test.ts` and the server e2e tests can claim the id first, and file enumeration order differs per platform. Commit 3 moves the precedence rule into a pure `resolveLaunchAnalyticsId(inForce, offered)` and asserts it there; the stateful pair keeps only invariants that hold whoever claimed the launch first. The two explicit orderings above pin it.

## CI status
- pass: `legalwork-tests (ubuntu-latest)`, `legalwork-tests (macos-14)`, `i18n-audit` — all green.
- code-related failures: none.
- external/env/auth blockers: none.

## Manual verification
1. Fresh profile, launch the desktop app so the welcome screen shows — `app_opened` and `onboarding_welcome_viewed` are sent.
2. Click **Get started**, pick a folder — `onboarding_started` is sent immediately, before the workspace call returns.
3. Let creation finish with the analytics toggle **off** — `workspace_created` is purged, `analytics_opted_out` is sent, `onboarding_started` is still present from step 2.
4. Repeat with the toggle **on** — `onboarding_started` and `workspace_created` both arrive.
5. Confirm every event from step 1 through `onboarding_completed` carries **one** `distinct_id`.
6. Failure path: stop the LegalWork server before step 2 — `onboarding_started` is still sent and the failure reports as `app_error{source:"workspace_create"}`.

## Evidence
- **No video or screenshots.** Developed in a headless remote container with no display, and the flow needs the Electron app plus a running LegalWork server, so I could not drive it end to end. The automated tests model the event sequence (`runWelcomeUpToConsentCommit`) and the id precedence rules directly; steps 1–6 are the reproduction for a reviewer with a desktop checkout. Step 5 is the one that most needs a human — nothing in CI exercises the real round-trip.

## Risk
- Confined to analytics. No user-visible behaviour and no control-flow change.
- **Definitional break:** `onboarding_started` changes meaning from "workspace created" to "creation attempted", so counts after this lands are not comparable with counts before, and will read higher. `workspace_created{source:"onboarding"}` is the continuation of the old series.
- **Server semantics:** the launch id is no longer always server-minted. Against a shared or longer-lived server the first client to connect claims the launch; the renderer then adopts whatever the server returns, which keeps desktop and Office pane together.

## Rollback
- Revert commits 1 and 2 independently — they touch different call sites. Nothing is persisted, migrated, or written to storage, and no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)