### PR TITLE
fix(release): resolve the release tag past the alpha tag in ship

### DIFF
--- a/scripts/release/ship.mjs
+++ b/scripts/release/ship.mjs
@@ -49,7 +49,11 @@ const run = (cmd, opts = {}) => {
 // ── Step 1: Resolve tag from HEAD ───────────────────────────────────
 heading("Resolving tag");
 
-const tag = run("git describe --tags --exact-match HEAD", {
+// Alpha builds tag every dev commit (alpha-macos-v0.1.16-alpha.61-992269c),
+// and a release tags a commit that already carries one. Without --match,
+// describe can return the alpha tag and ship bails out with "does not look
+// like a release tag" — prepare.mjs already filters the same way.
+const tag = run('git describe --tags --exact-match --match "v[0-9]*" HEAD', {
   readOnly: true,
   allowFail: true,
 });


### PR DESCRIPTION
## The bug

Shipping v0.1.16 aborted at the first step:

```
▸ Resolving tag
  ✗ Tag 'alpha-macos-v0.1.16-alpha.61-992269c' does not look like a release tag (expected vX.Y.Z)
```

Alpha builds tag every dev commit, so the commit a release tags always carries an alpha tag as well:

```
$ git tag --points-at HEAD
alpha-macos-v0.1.16-alpha.61-992269c
v0.1.16
```

`ship.mjs` resolved the tag with an unfiltered `git describe --tags --exact-match HEAD`, which returned the alpha tag, and the `vX.Y.Z` guard right below it then rejected the run. The v0.1.16 tag push had to be done by hand.

`prepare.mjs` already filters (`--match "v*"`); `ship.mjs` was the one place that didn't.

## The fix

Filter to v-prefixed tags. Verified against the exact failing state — both tags still on HEAD:

```
▸ Resolving tag
  ✓ Found tag: v0.1.16

▸ Verifying tag against origin/dev
  ✓ v0.1.16 is on origin/dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)