### PR TITLE
fix(desktop): ship the app icons so the packaged dock icon follows dark mode

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -23,6 +23,16 @@ extraResources:
     to: opencode-plugins
     filter:
       - "*.js"
+  # The runtime dock/window icon, which the .icns baked in below cannot supply:
+  # resolveAppIconPath() reads these out of `process.resourcesPath/icons` so the
+  # dock can swap to the ink plate when macOS is in dark mode. Without them a
+  # packaged build finds no icon at all (`files:` does not pack resources/), so
+  # app.dock.setIcon() is never called and the icon never follows the system.
+  - from: resources/icons
+    to: icons
+    filter:
+      - icon.png
+      - icon-dark.png
 asar: true
 asarUnpack:
   - node_modules/.pnpm/@lydell+node-pty*/**

--- a/apps/desktop/electron/packaged-icons.test.mjs
+++ b/apps/desktop/electron/packaged-icons.test.mjs
@@ -1,0 +1,59 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const desktopDir = path.resolve(__dirname, "..");
+
+// resolveAppIconPath() in main.mjs falls back to `process.resourcesPath/icons`
+// once the repo-relative paths miss, which is every packaged build -- `files:`
+// packs only electron/, server/ and package.json, so resources/ never lands in
+// the asar. Nothing copied the icons there, so both the light and the dark
+// plate resolved to null and app.dock.setIcon() was never called: the dock kept
+// the static .icns and could not follow the system appearance. Only `dev` swapped.
+const REQUIRED_ICONS = ["icon.png", "icon-dark.png"];
+
+function readBuilderConfig() {
+  return readFileSync(path.join(desktopDir, "electron-builder.yml"), "utf8");
+}
+
+// The yml is not parsed: js-yaml is only present here transitively via
+// electron-builder, and a dependency added for one assertion buys less than
+// matching the block we actually care about.
+function iconsExtraResourceBlock(config) {
+  const lines = config.split("\n");
+  const start = lines.findIndex((line) => /^\s*-\s*from:\s*resources\/icons\s*$/.test(line));
+  if (start === -1) return null;
+  const block = [lines[start]];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*-\s*from:/.test(line) || /^\S/.test(line)) break;
+    block.push(line);
+  }
+  return block.join("\n");
+}
+
+test("electron-builder copies the runtime app icons into Resources/icons", () => {
+  const block = iconsExtraResourceBlock(readBuilderConfig());
+  assert.ok(
+    block,
+    "electron-builder.yml has no extraResources entry for resources/icons; a packaged build resolves no app icon and the dock cannot follow dark mode",
+  );
+  assert.match(
+    block,
+    /^\s*to:\s*icons\s*$/m,
+    `resources/icons must be copied to "icons" -- resolveAppIconPath() reads process.resourcesPath/icons. Got:\n${block}`,
+  );
+  for (const icon of REQUIRED_ICONS) {
+    assert.match(block, new RegExp(`^\\s*-\\s*${icon.replace(".", "\\.")}\\s*$`, "m"),
+      `${icon} is filtered out of the packaged icons. Got:\n${block}`);
+  }
+});
+
+test("the icons the packaged app resolves exist in the repo", () => {
+  for (const icon of REQUIRED_ICONS) {
+    const iconPath = path.join(desktopDir, "resources", "icons", icon);
+    assert.ok(existsSync(iconPath), `missing packaged app icon: ${iconPath}`);
+  }
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,7 @@
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
     "build:audiotap": "node ./scripts/build-audiotap.mjs",
     "build:key-monitor": "node ./scripts/build-key-monitor.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/opencode-state-dir.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs electron/packaged-server-deps.test.mjs",
+    "test": "node --test electron/runtime.test.mjs electron/opencode-state-dir.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/office-addin-cert.test.mjs electron/office-addin-cert-web.test.mjs electron/office-addin-platform.test.mjs electron/audio-recorder.test.mjs electron/system-dictation.test.mjs electron/power-lifecycle.test.mjs electron/system-key-monitor.test.mjs electron/packaged-server-deps.test.mjs electron/packaged-icons.test.mjs",
     "office:sideload": "node ./scripts/office-addin-sideload.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
The dark-plate dock icon from #116 works in `dev:electron` and does nothing in a packaged build. The code shipped; the asset did not.

## What was wrong

`resolveAppIconPath()` (`apps/desktop/electron/main.mjs:397`) tries three paths for `icon-dark.png`:

| # | Path | Dev | Packaged |
|---|---|---|---|
| 1 | `../resources/icons/dev/icon-dark.png` | hit | skipped, not `isDevMode` |
| 2 | `../resources/icons/icon-dark.png` | hit | resolves inside `app.asar`, and `files:` packs only `electron/**`, `server/**`, `package.json` |
| 3 | `$resourcesPath/icons/icon-dark.png` | n/a | nothing ever copied `resources/icons` there |

So a packaged build resolves `APP_ICON_DARK_PATH` to `null` — and `APP_ICON_IMAGE` too, since `icon.png` was equally unpacked. `applyDockIcon()` then falls back from a null dark image to a null light one and never calls `app.dock.setIcon()` at all. What the dock shows is the static `icon.icns` electron-builder bakes into the bundle, which cannot follow the system appearance.

Verified against the installed 0.1.17 build: `app.asar` contains `applyDockIcon`, the `AppleInterfaceThemeChangedNotification` subscription and the `icon-dark` reference, but `asar list | grep icon` is empty and `Contents/Resources/icons/` does not exist. Not a stale build — rebuilding would not have fixed it.

## The fix

One `extraResources` entry copying the two PNGs to `Resources/icons`, which is the path candidate #3 was already written to expect. Placed at the top level rather than under `mac:` because `APP_ICON_IMAGE` is also the `BrowserWindow` icon on Linux; electron-builder merges the top-level and platform lists rather than overriding, which the installed bundle confirms (it carries `app-dist` from the top level and `sidecars` from `mac:`).

Filtered to `icon.png` and `icon-dark.png` so the `.icns`/`.ico` masters and the `dev/` set stay out of the bundle. Adds ~1.2 MB.

## Verification

**The copy happens.** `pnpm --filter @legalwork/desktop package:electron:dir` produces `LegalWork.app/Contents/Resources/icons/` holding both `icon.png` and `icon-dark.png`. That directory does not exist in the installed build.

**The dock follows the system.** Ran the packaged bundle on macOS in dark mode alongside the installed 0.1.17 app as a control:

- installed 0.1.17, pinned and not running: **white plate** in dark mode — the reported bug
- this build, running: **ink plate** in dark mode

Confirmed the ink tile was this build and not the neighbouring dev instance by quitting it — that tile is the one that disappeared. Toggling appearance repaints without a restart, via the existing `AppleInterfaceThemeChangedNotification` subscription.

**Regression guard.** `electron/packaged-icons.test.mjs` asserts the `extraResources` entry is declared with both filenames and that the two PNGs exist. Verified to fail when the entry is removed, with the message naming the consequence. Desktop suite: 90 pass, 0 fail, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)