### PR TITLE
docs(terms): state that the Gemini models are zero data retention

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -1,6 +1,6 @@
 # LegalWork — Terms & Conditions
 
-**Last updated: 8 September 2026**
+**Last updated: 11 September 2026**
 
 LegalWork is a local-first desktop application published by **Eigenwelt Labs**,
 operated by Poensgen Technology UG (haftungsbeschränkt), Berlin, Germany
@@ -99,13 +99,10 @@ content-free metering data — model, token counts, cost, status and timestamps.
 Our inference providers apply zero data retention by default and do not train on
 your content.
 
-**One exception.** On some models the provider runs automated abuse monitoring;
-this currently applies to the Gemini models served through Google Cloud (Vertex
-AI), in the EU region as well as the US one. Automated safety classifiers inspect
-every request, and a prompt flagged as possible misuse may be kept for up to 90
-days solely to investigate that suspicion — never for training. Affected models
-are labelled in the App and on the platform, and an administrator can switch them
-off for the firm.
+This includes the Gemini models served through Google Cloud (Vertex AI), in the
+EU region as well as the US one: Google has switched off abuse-monitoring logging
+for Eigenwelt, so prompts sent to these models are not logged or retained for
+abuse monitoring either.
 
 ### Free Eigenwelt models (closed to new users)
 

--- a/apps/app/src/app/lib/legalwork-server.ts
+++ b/apps/app/src/app/lib/legalwork-server.ts
@@ -144,8 +144,6 @@ export type EigenweltManifestModel = {
   hostedIn?: string;
   /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
   upstreamModel?: string;
-  /** The provider keeps prompts and responses for a while to detect misuse. */
-  abuseMonitoring?: boolean;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */

--- a/apps/server/src/eigenwelt-auth.ts
+++ b/apps/server/src/eigenwelt-auth.ts
@@ -88,8 +88,6 @@ export type EigenweltManifestModel = {
   hostedIn?: string;
   /** The model behind the Eigenwelt name, e.g. "DeepSeek V4 Flash". */
   upstreamModel?: string;
-  /** The provider keeps prompts and responses for a while to detect misuse. */
-  abuseMonitoring?: boolean;
 };
 
 /** The signed-in seat's included usage for the current window (cents, plus a percentage). */

--- a/apps/server/src/eigenwelt-paid-manifest.ts
+++ b/apps/server/src/eigenwelt-paid-manifest.ts
@@ -60,7 +60,6 @@ function parseManifestModel(value: unknown): EigenweltManifestModel | null {
     ...(region ? { region } : {}),
     ...(hostedIn ? { hostedIn } : {}),
     ...(upstreamModel ? { upstreamModel } : {}),
-    ...(value.abuseMonitoring === true ? { abuseMonitoring: true } : {}),
   };
 }
 


### PR DESCRIPTION
Google has switched off abuse-monitoring logging for our Vertex AI projects, so the "One exception" in section 4 of `TERMS.md` no longer holds. The section now says that zero data retention covers the Gemini models on Vertex AI too, in both regions, because Google turned the logging off for Eigenwelt. The wording matches the published LegalWork terms, and "Last updated" moves to 11 September 2026.

The platform stops sending `abuseMonitoring` in the model manifest, so `EigenweltManifestModel` in the app and the server, and the paid-manifest parser, drop the field. Nothing in the app rendered it.

## Verification

- `apps/server` and `apps/app` typecheck
- `bun test src/eigenwelt` in `apps/server`: 48 pass

Companion PRs: eigenweltlabs/eigenwelt-website#20 (the published terms); eigenweltlabs/model-api#30 (the platform note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
