### PR TITLE
Add DCO contributor sign-offs and automatic PR check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,3 +39,7 @@
 
 ## Rollback
 -
+
+## Contribution rights
+- Read [CONTRIBUTING.md](../CONTRIBUTING.md) and the DCO, then sign off your own commits with `git commit -s`.
+- List any third-party code, its source and licence here:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,21 @@
+name: DCO
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    steps:
+      # No PR checkout: inspect commit metadata without running contributor code.
+      - uses: christophebedard/dco-check@7b0205d25ead0f898e0b706b58227dd5fa7e3f55 # 0.5.0
+        with:
+          args: --verbose --check-merge-commits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to LegalWork
+
+Submit focused pull requests against `dev`. Explain the change and include the
+commands and results of relevant tests. See [AGENTS.md](AGENTS.md) for project
+conventions and the pull request template for verification details.
+
+## Contribution rights: Developer Certificate of Origin
+
+LegalWork is [MIT-licensed](LICENSE). Contributions are submitted under that
+licence; you retain your copyright. We use the
+[Developer Certificate of Origin, version 1.1](https://developercertificate.org/)
+(DCO) to record that you have the right to contribute the work. We do not require
+a separate CLA granting broader commercial licensing rights.
+
+Read the DCO before signing. Add your own sign-off to each commit:
+
+```sh
+git commit -s
+```
+
+This adds `Signed-off-by: Your Name <your-email@example.com>` using your Git
+identity. The sign-off is a certification, not a cryptographic signature. Use
+an email you are comfortable publishing, and obtain employer permission when
+needed. Never sign for another person. Include source, licence and required
+notices for third-party material, and do not submit confidential material.
+
+The automatic **DCO** check reports commits missing a matching sign-off. If you
+can make the certification for your most recent commit, amend it with:
+
+```sh
+git commit --amend --no-edit --signoff
+```
+
+For multiple commits, sign each of your own commits using an interactive rebase;
+do not rewrite other contributors' commits without coordinating with them.
+After rewriting a branch already on GitHub, update your PR branch with
+`git push --force-with-lease`. GitHub's web editor also supports a sign-off when
+that repository setting is enabled; otherwise use Git locally.
+
+## Maintainer rollout
+
+After merging the workflow, test unsigned and signed commits from a fork and
+require the **DCO** check in branch rules for `dev`, preserving the existing `prod` ruleset and its other protections.
+The workflow executes only trusted action code and reads PR commit metadata;
+it has no write permissions and no contributor exemptions. These sign-offs
+apply prospectively, not as proof of rights in existing contributions.


### PR DESCRIPTION
LegalWork uses MIT, which already permits commercial use and sublicensing. A broad CLA is unnecessary for that model; a DCO provides an explicit record that contributors may submit their work.

Adds CONTRIBUTING.md, a PR-template reminder and a commit-pinned DCO check against every PR commit, including merges. The workflow reads commit metadata from the trusted base context, runs no contributor code and has read-only permissions.

Validation: git diff origin/dev --check passed; Ruby YAML parsing passed; the pinned DCO implementation passed four local cases: matching sign-off accepted, missing sign-off rejected, wrong signer rejected, unsigned merge rejected. No application behavior changed, so product tests and UI capture are not applicable. Live fork testing remains pending because pull_request_target requires the workflow on dev. No sign-off was made on anyone’s behalf.

Rollout: merge, test a fork with unsigned and correctly signed commits, then add DCO to the existing prod ruleset for dev without replacing other rules. Draft pending rollout. This is a recommended provenance policy, not a legal requirement imposed by MIT.
